### PR TITLE
Add brainstorming session state documentation and enhance storytelling modes with challenge portion lifecycle

### DIFF
--- a/.bootstrap/.cache/brainstorm/kit-2-0-brainstorm.md
+++ b/.bootstrap/.cache/brainstorm/kit-2-0-brainstorm.md
@@ -1,0 +1,178 @@
+# Kit 2.0 Brainstorm — Session State
+
+**Topic:** Kit 2.0 (sub-agents, marketplace, skills, cfs script integration)
+**Org:** Constructor Fabric
+**Saved at:** Round 6, Q1/8 (session paused for save)
+
+---
+
+## Current Session State
+
+- `round_count`: 5 complete, round 6 in progress
+- `BRAINSTORM_MAX_ROUNDS`: 10
+- `pending_round_kind`: topic
+- `topic_current`: T5 — ScriptInterface / ScriptContext independent versioning
+- `round_6_position`: Q1/8 (unanswered — resume here)
+
+---
+
+## Open Questions
+
+| decision_key | description | reason |
+|---|---|---|
+| `subagent_discovery_host_tools_caching` | Caching walk-up agent scan (TTL + invalidation on kit ops) | user_skipped (round 2) |
+
+---
+
+## Decisions Log
+
+### Rounds 1 + 2 (challenge) — Marketplace & Ecosystem
+
+| decision_key | decision | source |
+|---|---|---|
+| `marketplace_model_choice` | Hybrid: GitHub owner/repo as primary install mechanism + optional community registry index. Registry must implement a standardized metadata schema (`kit.json`) and maintain index freshness SLA (max 7 days stale). GitHub Release/tag = version authority. | accepted + R2 delta |
+| `kit_dependency_resolution` | Declarative kit dependencies in `manifest.toml` with semver constraints. Single-version-per-kit rule. Conflict → fail with full dependency chain visualization in the error message. | accepted + R2 delta |
+| `kit_namespace_collision` | MANDATORY `cf-{kit-slug}-{name}` naming everywhere. On slug conflict → interactive rename prompt with suggested `{kit-slug}-{random-short-word}` default. | custom |
+| `community_kit_trust_model` | Official marketplace (Constructor Fabric, highest trust) + unofficial marketplaces with delegated trust. Mandatory CLI disclaimer for unofficial kits: "This kit is from an unofficial marketplace; Constructor Fabric does not vet or endorse it." Liability waiver required for unofficial marketplace operators. | custom + R2 delta |
+| `kit_script_sandboxing` | Scripts are Python packages satisfying an interface contract. cfs imports the package, validates the interface/protocol, runs if compliant, returns error if not. No subprocess/shell. Security enforced via marketplace vetting at publish time. | custom |
+| `kit_revocation_model` | Primary: GitHub. Secondary: Constructor Fabric maintains a **canonical** blocklist for the official marketplace. Community blocklists are advisory only. `--force` to bypass. | accepted + R2 delta |
+| `kit_search_discovery_ux` | `cfs kit search <query>` across all configured marketplaces. Results include marketplace source label. `--marketplace <name>` filter. Default search order: official marketplace first, then community registries. `cfs marketplace add/remove/list`. `cfs kit list [--marketplace <name>]`. | accepted + R2 delta |
+| `kit_script_invocation_surface` | `cfs script run <name>`, `cfs script list [--kit <slug>]`, `cfs script help <name>` — scripts as first-class CLI citizens. `cfs script help` shows kit owner, marketplace source, package dependencies. | accepted + R2 delta |
+| `kit_update_notification_ux` | `cfs kit list --outdated`, version pinning, opt-in auto-update (`--auto`), interactive diff preserved. | accepted |
+| `kit_author_incentive_model` | Phase 1: featured placement in official marketplace + monthly newsletter featuring top kits + advisory council access for top contributors. Phase 2: author profiles with metrics, monetization. | custom |
+| `first_party_vs_community_kit_strategy` | Core bundles nothing. Constructor Fabric publishes SDLC, testing, docs kits as reference implementations to the official marketplace. Explicit commitment: 2–3 additional first-party kits within 12 months of Kit 2.0 release. | accepted + R2 delta |
+| `community_governance_model` | Hybrid: Constructor Fabric owns infrastructure and code of conduct. Elected review board (kit authors + CF rep). Transparent decision log published in registry repo. | accepted |
+| `kit_bundled_subagent_support` | Extend `[[agents]]` manifest section for kit-bundled subagents: `name`, `description`, `tools`, `disallowedTools`, `worktree_isolation`. Generate host-tool definitions on `kit install`. Backward compatible. Add `manifest_version` field to signal feature support; v1 clients warn on unknown sections. | accepted + R2 delta |
+| `subagent_discovery_host_tools` | Automatic walk-up scan of agent directories (`.claude/agents/`, etc.) on host-tool startup. `kit install` generates host-tool-native files. Consistent with ADR-0019. | accepted |
+| `kit_subagent_lifecycle` | Persistent definitions: generated on `install/update`, stored on disk, loaded on IDE startup, removed on `uninstall`, regenerated on next `kit update` when manifest changes. | accepted |
+| `kit_semver_enforcement` | Mandatory semver for official marketplace (`v1.0.0` / `1.0.0`). `--dev` flag required for non-semver installs (SHA/branch) to signal non-production use. | accepted + R2 delta |
+| `kit_version_constraint_syntax` | npm-style: `^` (>=X <X+1), `~` (>=X.Y <X.Y+1), `=` (exact). Constraints applied at dependency graph resolution time. Clear error on unsatisfiable constraint. `cfs kit validate-constraints <manifest>` tool + comprehensive docs with examples. | accepted + R2 delta |
+| `kit_breaking_change_policy` | Major bump required for breaking changes. Checklist (5 categories): (1) resource removal from manifest, (2) agent/skill/workflow contract changes, (3) script signature changes, (4) manifest schema changes, (5) workflow input/output schema changes. Migration guide template for kit authors. | accepted + R2 delta |
+
+---
+
+### Round 3 — Python Script Interface Contract
+
+| decision_key | decision | source |
+|---|---|---|
+| `script_discovery_mechanism` | `[[scripts]]` section in `manifest.toml` v2.0 with fields: `id`, `source_package`, `entry_point`, `description`, `version_constraint`. Mirrors `[[agents]]`/`[[skills]]` pattern from ADR-0019. | accepted |
+| `script_namespace_enforcement` | `cf-{kit-slug}-{name}` convention applies to the **Python package name** (in `pyproject.toml`). Internal module name uses Python notation (`cf_kitslug_name`). Prevents PyPI collisions. | accepted |
+| `script_installation_mechanism` | Scripts are Python packages listed as dependencies in the kit's `pyproject.toml`. Installed via pip on `cfs kit install`. Scripts may declare their own dependencies. | accepted |
+| `script_interface_contract_definition` | `typing.Protocol` — `ScriptInterface` with required methods: `run(context: ScriptContext) -> ScriptResult` and `help() -> str`. No forced inheritance. Python 3.8+. | accepted |
+| `script_interface_validation_strategy` | `inspect.signature()` at import time. Checks: (1) package imports without error, (2) `run()` and `help()` exist as callables, (3) `run()` signature matches contract. `InterfaceError` with clear message on mismatch. Fail fast — no suppression. | accepted |
+| `script_capability_boundary` | Scripts may import any packages from cfs and use cfs as a library/SDK. No runtime restrictions. Security is enforced at the marketplace level (vetting at publish time). | custom |
+| `script_help_text_source` | Primary: `help()` method return value (part of `ScriptInterface` Protocol). Fallback: `__doc__` of `run()`. Optional supplementary `.md` files. Dynamic `help()` allowed. | accepted |
+| `script_authoring_workflow` | `cfs script scaffold <name>` — generates Python package template in kit's `scripts/`: `__init__.py`, `run.py`, `help.py`, `pyproject.toml` with `cf-{kit-slug}-{name}` naming. Validates structure on generation. | accepted |
+| `script_error_messages` | Validation error: formatted message with suggestion (e.g., "Expected signature: ..."). Runtime error: user-friendly message + `--verbose` for full traceback. JSON mode always includes full error details. | accepted |
+| `script_quality_assessment` | Both required for official marketplace: automated (interface validation via `inspect.signature`, mypy type hints check, docstring presence) + manual security review (what does the script do with cfs SDK?). | accepted |
+| `script_marketplace_listing` | Listing includes: script name, description (from `help()`), kit owner, kit GitHub URL, script version, interface version (`ScriptInterface v1`), dependencies, last updated, download count. Searchable by kit, owner, tags. | accepted |
+| `script_community_incentive` | Phase 1: featured listing for quality scripts + download stats visible to author + recognition in kit `SKILL.md`. Phase 2: revenue sharing. Mirrors kit incentive model. | accepted |
+| `script_manifest_contract` | `[[scripts]]` in `manifest.toml` v2.0: `id`, `source_package`, `entry_point`, `description`, `version_constraint`. `pyproject.toml` declares script packages as pip dependencies. `entry_points` optional for ecosystem interop. | accepted |
+| `script_lifecycle_management` | Lazy-loaded on first `cfs script run <name>`. Module cached within process. Cache invalidated on package version change. Keeps cfs startup fast. | accepted |
+| `script_invocation_surface` | Arguments passed via a **typed class** (dataclass or pydantic model), not a plain dict. Script declares its args schema; cfs parses CLI flags and instantiates the class. | custom |
+| `script_interface_versioning` | Two independent tracks: (1) package semver (increments on any change), (2) interface version (`ScriptInterface v{N}`) — increments only on breaking changes to `run()` or `help()`. Both declared in manifest and shown in marketplace. | accepted |
+| `script_breaking_change_policy` | Major bump required for: (1) `run()` signature change (params or return type), (2) `help()` signature change, (3) args class schema change (field removal/rename), (4) `ScriptInterface` version change. Minor: new optional params with defaults. Patch: bugfix, docs. | accepted |
+| `script_backward_compatibility_guarantee` | cfs supports the **current + 5 previous** `ScriptInterface` versions. Scripts targeting older versions (>5 back) must be updated or deprecated. | custom |
+
+---
+
+### Round 4 — ScriptContext & ScriptResult Contract
+
+**ScriptContext (final structure):**
+```python
+@dataclass
+class ScriptContext:
+    project_root: Path
+    studio_path: Path
+    logger: logging.Logger
+    args: T                       # typed args class instance
+    version: int                  # current=1
+    invoked_by: str
+    invocation_time: datetime
+    script_version: str
+    kit_metadata: dict[str, semver.Version]  # direct deps only, pinned versions
+```
+_ScriptContext contains only what `cfs info` shows. Everything else is a direct import from the cfs SDK._
+
+**ScriptResult (final structure):**
+```python
+@dataclass
+class ScriptResult:
+    success: bool                           # True iff exit_code == 0
+    exit_code: int                          # 0–255; conventions: 0=ok, 1=err, 2=warn, 3+=custom
+    output: Union[str, dict, list, None]    # plain mode: indented JSON for dict/list
+                                            # dict may contain _redact_keys: list[str]
+```
+_Buffered output only. Streaming via logger._
+
+| decision_key | decision | source |
+|---|---|---|
+| `ctx_kit_metadata_structure` | Direct dependencies only, resolved pinned versions as `semver.Version` objects. | accepted |
+| `ctx_artifact_registry_interface` | No special artifact API in ScriptContext — scripts import existing cfs classes directly (cfs as SDK). | custom |
+| `ctx_capability_boundary_sdk_access` | ScriptContext contains only what `cfs info` shows. Everything else — direct import from cfs SDK. | custom |
+| `result_sensitive_data_handling` | `ScriptResult.output` dict may include `_redact_keys: list[str]`. cfs redacts those values in logs and JSON output. | accepted |
+| `ctx_logger_interface` | Standard `logging.Logger` with cfs-configured handlers (console + file). JSON structured logging controlled at cfs level, not per-script. | accepted |
+| `result_output_format_flexibility` | `Union[str, dict, list, None]`. Plain mode: pretty-print dict/list as indented JSON. JSON mode: passed as-is in `output` field. | accepted |
+| `ctx_execution_metadata` | `invoked_by: str`, `invocation_time: datetime`, `script_version: str` in ScriptContext. `request_id` deferred. | accepted |
+| `result_success_semantics` | Boolean `success` + `exit_code: int`. `success=True` ↔ `exit_code=0`. Unix-compatible. Scripts use `exit_code` for nuance. | accepted |
+| `ctx_version_and_interface_compat` | `ScriptContext.version: int` (current=1). cfs fails with clear error if script requires `version > cfs.ctx_version`. Supports current + 5 previous. | accepted |
+| `result_streaming_output` | Buffered output only (`str/dict/list`). For streaming, scripts write to `logger`; cfs captures and buffers. Revisit if streaming becomes critical. | accepted |
+| `ctx_backward_compat_guarantees` | ScriptContext fields are **never removed** — only added. New fields must have sensible defaults (`None`, empty dict, etc.). Scripts safely ignore unknown fields. | accepted |
+| `ctx_exit_code_range` | 0–255 (Unix standard). Documented conventions: 0=success, 1=error, 2=warning, 3+=custom. Not enforced. | accepted |
+
+---
+
+### Round 5 — Kit Author Scaffolding & DX
+
+**Full kit author workflow:**
+```
+cfs kit new <name> [--template minimal|full]
+  → edit manifest.toml, SKILL.md, artifacts/
+cfs kit version bump [major|minor|patch]
+cfs kit validate               # syntax, namespaces, interface, deps, circular deps, SKILL.md
+cfs kit install --path .       # local test (v1); cfs kit dev (file watch) → p2
+cfs kit checklist              # pre-publish readiness (PASS/WARN/FAIL per item with hints)
+cfs kit publish --repo <org/repo>  # validate → GitHub Release → marketplace registration
+```
+
+| decision_key | decision | source |
+|---|---|---|
+| `kit_new_scaffold_contents` | Generates: `manifest.toml`, `SKILL.md`, `README.md`, one stub artifact, empty stubs for `scripts/`, `agents/`, `workflows/`. | accepted |
+| `kit_slug_reservation_early_check` | Local check against installed kits (mandatory) + optional online check against marketplace. Interactive rename on conflict. `--force` to bypass. | accepted |
+| `kit_local_dev_workflow` | `cfs kit install --path ./my-kit` in v1 (symlink or local install). `cfs kit dev` (watch mode) → p2. | accepted |
+| `kit_publish_mechanism` | `cfs kit publish --repo <owner/repo>`: validate kit → create GitHub Release with semver tag (via `GITHUB_TOKEN`) → register in marketplace. Fallback: manual PR to registry for p1. | accepted |
+| `kit_validate_scope` | Full validation: manifest.toml syntax, semver format, namespace conventions, required files (SKILL.md, README), script interface (`inspect.signature`), agent definitions, version constraint syntax, SKILL.md syntax, workflow references to valid artifact kinds, circular dependency detection. JSON output with per-file errors and warnings. | accepted |
+| `kit_semver_enforcement_timing` | `cfs kit new` generates `version = "0.0.1"`. First publish to official marketplace requires explicit bump to `1.0.0` (or `--pre-release` flag for `0.x`). Helper: `cfs kit version bump [major\|minor\|patch]`. | accepted |
+| `kit_template_variants` | `cfs kit new <name> --template [minimal\|full]`. `minimal` = manifest + README. `full` = minimal + `scripts/`, `agents/`, `workflows/`, `SKILL.md`, one complete artifact example. Default (no flag): `minimal`. | accepted |
+| `kit_author_workflow_checklist` | `cfs kit checklist` — PASS/WARN/FAIL per item: README with usage examples, SKILL.md with agent commands, at least one artifact example, manifest `version` matches git tag (if in repo), semver ≥ 1.0.0. Remediation hints per failing item. | accepted |
+
+---
+
+## Round 6 (in progress) — T5: ScriptInterface / ScriptContext Independent Versioning
+
+**Current position:** Q1/8 — unanswered. Resume from here.
+
+**Question queue with proposed defaults:**
+
+| Q | persona | decision_key | proposed_default |
+|---|---|---|---|
+| 1 | E1 | `iface_ctx_decoupling_coexistence_model` | Full independence: script declares `interface_version` + `context_version_min/max` separately. Allows adopting new `run()` signature without a context version bump, and vice versa. |
+| 2 | E2 | `iface_ctx_decoupling_validation_gates` | cfs rejects if actual `context_version < min` or `> max`. Script must handle optional new context fields gracefully. |
+| 3 | E3 | `iface_ctx_decoupling_developer_clarity` | Publish migration guide with examples: v1→v2 interface upgrade without context bump, and v1→v2 context upgrade without interface bump. |
+| 4 | E4 | `iface_ctx_decoupling_ecosystem_adoption` | cfs warns if a script declares a range narrower than the platform support window. Encourage wide ranges. |
+| 5 | E5 | `iface_ctx_decoupling_subagent_integration` | `cfs.script_metadata(id)` → `{interface_version, context_version_min, context_version_max}`. Subagent checks against its own `context_version` before invoking. |
+| 6 | E6 | `iface_ctx_decoupling_backward_compat_matrix` | Both tracks maintain a **5-version window** for symmetry. Symmetric windows simplify reasoning; avoids edge cases. |
+| 7 | E1 | `iface_ctx_decoupling_manifest_syntax` | Separate fields in `[[scripts]]`: `interface_version`, `context_version_min`, `context_version_max`. Explicit fields reduce parsing errors and make manifest diffs reviewable. |
+| 8 | E2 | `iface_ctx_decoupling_security_implications` | cfs validates version combinations at load time; rejects impossible ranges (e.g., `context_version_max > current + 10`). Signed manifests required for official marketplace. |
+
+**Panel note on conflicts:** Current decision `ctx_version_and_interface_compat` assumes 1:1 coupling ("fail if `version > cfs.ctx_version`"). Decoupling replaces the single required version with a `min/max` range declaration. This needs to be captured as an update to that decision once Q1 is answered.
+
+---
+
+## Topics Not Yet Covered
+
+| label | topic | why it matters |
+|---|---|---|
+| A | Hook contract in manifest (validation/generation hooks) — v1 or p2? | Kit authors can't plan without a contract |
+| B | Kit certification ("Verified Kit") and Constructor Fabric liability boundaries | Official marketplace needs a trust policy |
+| C | `kit.lock` — reproducible builds with transitive dependencies | CI/CD and deterministic installs |

--- a/requirements/storytelling-modes.md
+++ b/requirements/storytelling-modes.md
@@ -144,7 +144,7 @@ Review is **storytelling + Q&A interleaved as separate portions**, not "presenta
 
 1. **Presentation portion** — Body presents the chunk (source-grounded, audience-adapted, ≤ resolved page-size, with diagram per Phase E4). Identical shape to a presentation-mode portion. Progress marker: `📍 {idx}/{N} • phase: presentation • topic: "{plan-item}"`. The Next topics menu includes **"Challenge: panel reactions for {plan-item}"** as the suggested continue candidate (intra-item, not next plan item).
 
-2. **Challenge portion** — emitted only after user advances. Body: a 1-2 sentence recap of what was just presented + numbered panel reactions `Q1` / `Q2` / … from each panellist (1-2 critical questions / concerns per panellist, anchored to lines/sections where possible). Diagram per Phase E4 if relevant (panel-topology, gap diagram). Progress marker: `📍 {idx}/{N} • phase: challenge • topic: "{plan-item}"`. The Next topics menu includes **"Presentation: {next-plan-item}"** as the suggested continue candidate (or Wrap if last). **Comment slot** is most useful here — picking it asks `Which panel question to draft as a review comment? [Q1 / Q2 / Q3 / your own wording]`.
+2. **Challenge portion** — emitted only after user advances. Instead of a flat panel Q-list, the challenge portion **delegates to a single `cf-brainstorm` topic round**: the agent synthesizes reviewer roles from the topic and artifact content, invokes the skill, and walks questions one by one using the standard brainstorm per-question mechanics. Progress marker: `── Challenge Round ──` then `📍 {idx}/{N} • phase: challenge • topic: "{plan-item}"`. After the round, storytelling reclaims navigation and offers: `[Post comment | Save | Next: {next-plan-item} | Wrap]`. See `UNIT ChallengePortion` below for the full lifecycle spec.
 
 ```pdsl
 UNIT ReviewModeRhythm
@@ -174,6 +174,176 @@ RULES:
   - ALWAYS emit ChallengePortion only after user advances from PresentationPortion
   - NEVER increment plan-item index between presentation and challenge for the same item
   - ALWAYS allow sub-portion decomposition to compose: oversized item may split into sub-portions (3a, 3b) for presentation, then one challenge for the whole item
+```
+
+```pdsl
+UNIT ChallengePortion
+
+PURPOSE:
+  Run an interactive per-question challenge round. Synthesize a reviewer panel,
+  dispatch cf-brainstorm-panel to collect questions, then walk each question
+  one at a time via ChallengeQuestionLoop. NEVER emit a flat Q-list.
+
+STATE:
+  - SET challenge_label: string
+    default: "challenge:round-{idx}:{plan-item-slug}"
+  - SET question_queue: list
+    default: []
+  - SET drafted_comments: list
+    default: []
+  - SET scorer_triggered: bool
+    default: false
+
+WHEN:
+  - REQUIRE current_mode == review
+  - AND user selects "Challenge" from post-PresentationPortion menu
+
+DO:
+  # Context Collection
+  - RUN ContextSliceExtraction
+    NOTES: Collect from current presentation portion:
+           heading, opening (1-2 sentences), bullets (2-3 key points),
+           source_refs, artifact_kind, topic (plan-item label).
+  - RUN Scorer
+    NOTES: IF context.sub_items > 5 OR context.word_count > 500:
+             SET scorer_triggered = true;
+             DISPATCH cf-explorer to enrich context (at most once);
+             IF cf-explorer empty: proceed with available context.
+
+  # Panel Synthesis
+  - RUN PanelSynthesis
+    NOTES: Derive reviewer roles from topic + artifact content. No static KIND table.
+  - REQUIRE panel.roles.count >= 2
+    NOTES: Violation -> HALT.
+
+  # Entry
+  - EMIT ── Challenge Round ──
+  - EMIT 📍 {idx}/{N} • phase: challenge • topic: "{plan-item}"
+
+  # Panel dispatch — build question_queue
+  - LOAD {cf-studio-path}/.core/skills/studio/agents/cf-brainstorm-panel.md
+    NOTES: Open, load, and strictly follow the agent contract from that file.
+           Payload: panel=synthesized_roles, topic="{plan-item}: challenge",
+                    resource_context=context_slice, mode="topic",
+                    protocol="independent-then-critique".
+           From the result: flatten contributions into question_queue
+             ordered by panel order then question order within each contribution.
+           Each item: { queue_index, persona, text, rationale, status="pending" }.
+           ON empty question_queue:
+             EMIT "No questions generated for this topic.";
+             EMIT_MENU ChallengePostRoundMenu; WAIT user.reply; STOP_TURN.
+
+  # Question loop — one question per turn
+  - CONTINUE ChallengeQuestionLoop
+
+RULES:
+  - ALWAYS load cf-brainstorm-panel.md explicitly; NEVER synthesize questions inline without it
+  - NEVER emit more than one question before STOP_TURN
+  - NEVER show a storytelling navigation menu (Next/Deeper/Lateral) during the question loop
+  - ALWAYS use ChallengeQuestionLoop for every question; NEVER walk questions inline in DO
+  - ALWAYS return to ReviewModeRhythm after ChallengePostRoundMenu resolves
+  - NEVER increment plan-item index during ChallengePortion
+```
+
+```pdsl
+UNIT ChallengeQuestionLoop
+
+PURPOSE:
+  Ask exactly one pending question per turn. After user reacts, loop back.
+  When queue is empty, continue to post-round menu.
+
+DO:
+  - SET q = first question_queue item with status == "pending"
+
+  - REQUIRE q is null:
+    - EMIT "Challenge complete. Returning to {plan-item}..."
+    - EMIT_MENU ChallengePostRoundMenu
+    - WAIT user.reply
+    - STOP_TURN
+
+  - EMIT Q{q.queue_index}/{total} — {q.persona}
+  - EMIT "{q.text}"
+  - EMIT "Why it matters: {q.rationale}"
+  - EMIT_MENU ChallengeReactionMenu
+  - WAIT user.reply
+  - STOP_TURN
+
+RULES:
+  - ALWAYS emit exactly ONE question per turn
+  - ALWAYS STOP_TURN immediately after ChallengeReactionMenu
+  - NEVER continue to the next question in the same turn
+  - NEVER emit a storytelling navigation menu here
+
+MENU ChallengeReactionMenu:
+  TITLE: Reply with a number, or write a counter-argument.
+  OPTIONS:
+    1 agree         -> SET q.status = "agreed"
+                       CONTINUE ChallengeQuestionLoop
+    2 push back     -> IF no free text: EMIT "Write your counter-argument.", WAIT user.reply, STOP_TURN
+                       SET q.status = "pushed_back"; SET q.counter = user_text
+                       CONTINUE ChallengeQuestionLoop
+    3 draft comment -> SET q.status = "queued_as_comment"
+                       APPEND q to drafted_comments
+                       CONTINUE ChallengeQuestionLoop
+    4 defer         -> SET q.status = "deferred"
+                       CONTINUE ChallengeQuestionLoop
+    5 skip          -> SET q.status = "skipped"
+                       CONTINUE ChallengeQuestionLoop
+    6 wrap          -> EMIT "Challenge complete. Returning to {plan-item}..."
+                       EMIT_MENU ChallengePostRoundMenu
+                       WAIT user.reply
+                       STOP_TURN
+  INVALID:
+    IF reply is non-empty free text: treat as option 2 push-back
+    ELSE:
+      EMIT "Reply with 1 agree, 2 push back, 3 draft comment, 4 defer, 5 skip, 6 wrap."
+      WAIT user.reply
+      STOP_TURN
+
+MENU ChallengePostRoundMenu:
+  TITLE: Challenge round complete for "{plan-item}". What next?
+  OPTIONS:
+    1 Post comment  -> RUN CommentClassification
+    2 Save          -> RUN PersistRoundOutput
+    3 Next          -> SET review_phase = presentation
+                       CONTINUE ReviewModeRhythm
+    4 Wrap          -> CONTINUE WrapPhase
+  INVALID:
+    EMIT "Reply with 1–4."
+    WAIT user.reply
+    STOP_TURN
+```
+
+**ChallengePortion handoff object.** Returned to `ReviewModeRhythm` on exit:
+
+```yaml
+round_output: <cf-brainstorm round result>    # full brainstorm output
+panel_decisions: []                           # accepted decisions from round
+drafted_comments: []                          # comments drafted during round
+timestamp: <ISO 8601>
+merge_strategy: success | error
+challenge_label: "challenge:round-{N}:{slug}"
+parent_round_id: null                         # null if first round
+validation_status: passed | <error_code>
+scorer_triggered: false                       # true if cf-explorer was invoked
+summary_mode: false                           # true if payload was compressed
+recovery_action: null                         # null on success
+```
+
+```json
+{
+  "round_output": "...",
+  "panel_decisions": [],
+  "drafted_comments": [],
+  "timestamp": "...",
+  "merge_strategy": "success",
+  "challenge_label": "challenge:round-1:plan-item-slug",
+  "parent_round_id": null,
+  "validation_status": "passed",
+  "scorer_triggered": false,
+  "summary_mode": false,
+  "recovery_action": null
+}
 ```
 
 **classified_mode label.** Every comment drafted in review mode is automatically classified by intent into one of `generate` / `fix` / `brainstorm`, using a tiered heuristic (Tier 1: prefix tokens like `fix:`, `add:`, `idea:`; Tier 2: signals like imperative on a code line ⇒ `fix`, question form on an artifact ⇒ `brainstorm`; Tier 3: defaults — code-mode ⇒ `fix`, artifact-mode ⇒ `brainstorm`). The classified mode appears as a label on the comment (e.g. `Q-3 [fix]`) and is stored as `intent_initial` plus `intent_initial_tier ∈ {1,2,3}` on the buffer entry (see `{cf-studio-path}/.core/requirements/storytelling-phases.md` § Open-question buffer entry shape). The label is informational; the user may override it via `change to {mode}` or via the inline shorthand `1 fix` / `2 brainstorm` at the generate-routing sub-prompt.
@@ -274,9 +444,10 @@ This module specifies the table-row level deltas per mode. Strict vs underspecif
 - Per-portion rhythm — number of portions per plan item, presence of Body before lens, mid-section vs separate-portion placement
 - Slot-name deltas — Ask → Comment (review); Lateral → Context (onboarding); Deeper → Pros/Cons (decision); Deeper → Why + Lateral → Affected (change-impact); 7-slot count, Back availability, and Next-first ordering invariant
 - Source-grounding, page-size invariant, no-scroll rule, clickable Markdown refs, audience adaptation, visualize-by-default — all unchanged
+- ChallengePortion lifecycle — entry/exit conditions, pre-flight validation, cf-brainstorm INVOKE semantics, panel synthesis, post-round menu, handoff object, error states (see `UNIT ChallengePortion`)
 
 **Underspecified** (best-effort with required inline fallback ack):
-- Panel composition algorithm — exact role set per artifact KIND beyond table examples
+- Panel composition algorithm — role synthesis heuristic beyond examples given in `UNIT ChallengePortion`
 - Comment / answer / hint buffer file formats and on-disk layout
 - Wrap-output mode-specific extras' precise field schema
 - Scoring heuristics for socratic

--- a/requirements/storytelling-modes.md
+++ b/requirements/storytelling-modes.md
@@ -223,12 +223,21 @@ DO:
   # Panel dispatch — build question_queue
   - LOAD {cf-studio-path}/.core/skills/studio/agents/cf-brainstorm-panel.md
     NOTES: Open, load, and strictly follow the agent contract from that file.
-           Payload: panel=synthesized_roles, topic="{plan-item}: challenge",
-                    resource_context=context_slice, mode="topic",
-                    protocol="independent-then-critique".
-           From the result: flatten contributions into question_queue
-             ordered by panel order then question order within each contribution.
-           Each item: { queue_index, persona, text, rationale, status="pending" }.
+           Payload (match the agent's frozen input contract):
+             panel=synthesized_roles,
+             topic={ id, text: "{plan-item}", section },
+             state (kind, rules_loaded, panel, decisions, rounds, round_count, ...),
+             round_number,
+             resource_context=context_slice,
+             mode="challenge",
+             protocol="independent-then-critique".
+           Transform the returned envelope (blocks[]) into question_queue:
+             take ONLY blocks[].kind=="independent" rows
+               ({persona_id, question_id, decision_key, text, proposed_default,
+                 rationale, stance}); ignore critique blocks.
+             Map each independent row to a question_queue item
+               { queue_index, persona: persona_id, text, rationale, status="pending" },
+               with queue_index ordered by panel order then question order.
            ON empty question_queue:
              EMIT "No questions generated for this topic.";
              EMIT_MENU ChallengePostRoundMenu; WAIT user.reply; STOP_TURN.
@@ -255,16 +264,16 @@ PURPOSE:
 DO:
   - SET q = first question_queue item with status == "pending"
 
-  - REQUIRE q is null:
-    - EMIT "Challenge complete. Returning to {plan-item}..."
-    - EMIT_MENU ChallengePostRoundMenu
+  - REQUIRE q is not null:
+    - EMIT Q{q.queue_index}/{total} — {q.persona}
+    - EMIT "{q.text}"
+    - EMIT "Why it matters: {q.rationale}"
+    - EMIT_MENU ChallengeReactionMenu
     - WAIT user.reply
     - STOP_TURN
 
-  - EMIT Q{q.queue_index}/{total} — {q.persona}
-  - EMIT "{q.text}"
-  - EMIT "Why it matters: {q.rationale}"
-  - EMIT_MENU ChallengeReactionMenu
+  - EMIT "Challenge complete. Returning to {plan-item}..."
+  - EMIT_MENU ChallengePostRoundMenu
   - WAIT user.reply
   - STOP_TURN
 

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -101,6 +101,16 @@ _GENERATED_MARKER_RE = re.compile(
 def _follow_protocol_lines(target_path: str) -> List[str]:
     """Return the generated follow-link protocol block for workflow/skill shims."""
     return [
+        "CF_WORKFLOW_ACTIVE:",
+        "- workflow = executable_control_flow",
+        "- no_substantive_work_until = workflow_explicit_permission",
+        "MANDATORY RULE: USER INTENT IS SKILL INPUT, NOT EXECUTION AUTHORITY",
+        "- hard_stop = WAIT | STOP_TURN | menu | gate | opener | approval | dispatch_gate | terminal_shape",
+        "- precedence = constructor_studio_workflow > generic_assistant",
+        "- pre_emit_check = response_shape in workflow_allowed_shapes",
+        "- if_check_fails = emit_only(workflow_allowed_gate_menu_opener_refusal)",
+        "- protocol_violation > incomplete_answer",
+        "",
         f"ALWAYS open and follow `{target_path}`",
         "",
         "```pdsl",
@@ -219,9 +229,10 @@ def _is_pure_studio_generated(
             return True
         if line.startswith("Constructor Studio endpoint only. Prompt source: "):
             return True
-    if nonblank and _extract_studio_follow_target(nonblank[0]):
+    follow_target = _extract_studio_follow_target(stripped)
+    if follow_target:
         expected_protocol = [
-            line.strip() for line in _follow_protocol_lines(nonblank[0].split("`", 2)[1])
+            line.strip() for line in _follow_protocol_lines(follow_target)
             if line.strip()
         ]
         if nonblank == expected_protocol:

--- a/tests/test_subagent_registration.py
+++ b/tests/test_subagent_registration.py
@@ -671,12 +671,20 @@ class TestLegacyStubClassification(unittest.TestCase):
             + "\n"
         )
 
-        self.assertIn("ALWAYS open and follow `{cf-studio-path}/.core/workflows/analyze.md`", block)
-        self.assertIn("UNIT GeneratedFollowProtocol", "\n".join(block))
-        self.assertIn("ALWAYS treat target as controlling protocol", "\n".join(block))
-        self.assertIn("ALWAYS traverse declared steps/units in order", "\n".join(block))
-        self.assertIn("ALWAYS load every required unconditional LOAD/CONTINUE", "\n".join(block))
-        self.assertIn("NEVER skip, summarize, or defer required instructions", "\n".join(block))
+        joined = "\n".join(block)
+        self.assertEqual(block[0], "CF_WORKFLOW_ACTIVE:")
+        self.assertLess(
+            block.index("- workflow = executable_control_flow"),
+            block.index("ALWAYS open and follow `{cf-studio-path}/.core/workflows/analyze.md`"),
+        )
+        self.assertIn("- no_substantive_work_until = workflow_explicit_permission", block)
+        self.assertIn("- precedence = constructor_studio_workflow > generic_assistant", block)
+        self.assertIn("- pre_emit_check = response_shape in workflow_allowed_shapes", block)
+        self.assertIn("UNIT GeneratedFollowProtocol", joined)
+        self.assertIn("ALWAYS treat target as controlling protocol", joined)
+        self.assertIn("ALWAYS traverse declared steps/units in order", joined)
+        self.assertIn("ALWAYS load every required unconditional LOAD/CONTINUE", joined)
+        self.assertIn("NEVER skip, summarize, or defer required instructions", joined)
         self.assertTrue(_is_pure_studio_generated(content, expected_name="cf-analyze"))
 
 

--- a/workflows/shared/plan-escalation-gate.md
+++ b/workflows/shared/plan-escalation-gate.md
@@ -94,7 +94,8 @@ UNIT NoNativeDispatchPlanHandoff
 
 PURPOSE:
   Prevent local single-context continuation when native sub-agent dispatch is
-  unavailable, unset, or explicitly bypassed; route to plan handoff or stop.
+  unavailable, unset, or explicitly bypassed; route to plan handoff, stop, or
+  a narrowly gated inline continuation by user confirmation.
 
 WHEN:
   - REQUIRE INLINE_FALLBACK == true
@@ -125,10 +126,11 @@ MENU PlanEscalationMenu:
     Options:
     1. Switch to Invoke skill `cf-plan`
     2. Stop
+    3. Continue inline
 
     Suggested: 1 because plan decomposition is the safe fallback when native
     sub-agent dispatch is not active.
-    Reply with `1` or `2`.
+    Reply with `1`, `2`, or `3`.
   OPTIONS:
     1 ->
       EMIT "Invoke skill `cf-plan` to generate {KIND} with the same parameters."
@@ -136,8 +138,11 @@ MENU PlanEscalationMenu:
     2 ->
       EMIT "Stopped before local single-context generation."
       STOP_TURN
+    3 ->
+      EMIT "Proceeding inline."
+      CONTINUE next generate phase
   INVALID:
-    EMIT "Reply with 1 or 2."
+    EMIT "Reply with 1, 2, or 3."
     WAIT user.reply
     STOP_TURN
 

--- a/workflows/shared/plan-escalation-gate.md
+++ b/workflows/shared/plan-escalation-gate.md
@@ -95,7 +95,7 @@ UNIT NoNativeDispatchPlanHandoff
 PURPOSE:
   Prevent local single-context continuation when native sub-agent dispatch is
   unavailable, unset, or explicitly bypassed; route to plan handoff, stop, or
-  a narrowly gated inline continuation by user confirmation.
+  an inline continuation when the user explicitly chooses it.
 
 WHEN:
   - REQUIRE INLINE_FALLBACK == true
@@ -121,7 +121,8 @@ MENU PlanEscalationMenu:
 
     Local single-context continuation is not allowed as a default. Use Invoke skill `cf-plan`
     to decompose this into focused phases, or stop and rerun with native
-    sub-agents enabled.
+    sub-agents enabled. You may also choose to continue inline — that is your
+    explicit decision, not a default.
 
     Options:
     1. Switch to Invoke skill `cf-plan`
@@ -139,7 +140,7 @@ MENU PlanEscalationMenu:
       EMIT "Stopped before local single-context generation."
       STOP_TURN
     3 ->
-      EMIT "Proceeding inline."
+      EMIT "Proceeding inline at your request."
       CONTINUE next generate phase
   INVALID:
     EMIT "Reply with 1, 2, or 3."
@@ -147,11 +148,13 @@ MENU PlanEscalationMenu:
     STOP_TURN
 
 RULES:
-  - NEVER continue to the next generate phase from this branch
+  - NEVER continue to the next generate phase from this branch automatically or
+    by default; continue inline ONLY when the user explicitly selects option 3
   - ALWAYS treat an unresolved NativeSubAgentPolicyConflictMenu from
     workflows/shared/inline-fallback-probe.md as higher precedence than this
     menu; do not reinterpret that conflict as permission to hand off to Invoke skill `cf-plan`
     or continue locally
-  - NEVER offer a "continue here" or local single-context option
-  - ALWAYS route to Invoke skill `cf-plan` handoff or stop
+  - NEVER offer an automatic or default "continue here" / local single-context option
+  - ALWAYS route to one of three options: Invoke skill `cf-plan` handoff, stop,
+    or user-confirmed inline continuation (option 3)
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised review-mode spec: challenge portion now runs interactive, per-question brainstorm rounds and a stricter lifecycle with post-round menu and recovery/summary handoff.

* **New Features**
  * One-question-per-turn brainstorm flow with panel-driven question queue.
  * Post-round actions to classify/post comments, save round output, continue presentation, or wrap.
  * Added “Continue inline” option to plan escalation menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->