### PR TITLE
Emit prerequisite-enforcement directive in entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,6 @@
 ```toml
 cf-studio-path = ".bootstrap"
 ```
+
+ALWAYS resolve and enforce prerequisites of skills/workflows/commands BEFORE applying user intent.
 <!-- /@cf:root-agents -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,5 +2,7 @@
 ```toml
 cf-studio-path = ".bootstrap"
 ```
+
+ALWAYS resolve and enforce prerequisites of skills/workflows/commands BEFORE applying user intent.
 <!-- /@cf:root-agents -->
 

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -37,6 +37,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from ..constants import ROOT_AGENTS_PIPELINE_INSTRUCTION
 from ..utils._tomllib_compat import tomllib
 from ..utils.files import (
     core_subpath,
@@ -110,6 +111,8 @@ def _follow_protocol_lines(target_path: str) -> List[str]:
         "- pre_emit_check = response_shape in workflow_allowed_shapes",
         "- if_check_fails = emit_only(workflow_allowed_gate_menu_opener_refusal)",
         "- protocol_violation > incomplete_answer",
+        "",
+        ROOT_AGENTS_PIPELINE_INSTRUCTION,
         "",
         f"ALWAYS open and follow `{target_path}`",
         "",

--- a/skills/studio/scripts/studio/commands/init.py
+++ b/skills/studio/scripts/studio/commands/init.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..constants import ROOT_AGENTS_PIPELINE_INSTRUCTION
 from ..utils._tomllib_compat import tomllib
 from ..utils.artifacts_meta import create_backup, generate_default_registry, generate_slug
 from ..utils import toml_utils
@@ -291,6 +292,8 @@ def _compute_managed_block(install_dir: str) -> str:
         f"```toml\n"
         f'cf-studio-path = "{install_dir}"\n'
         f"```\n"
+        f"\n"
+        f"{ROOT_AGENTS_PIPELINE_INSTRUCTION}\n"
         f"{MARKER_END}"
     )
     # @cpt-end:cpt-studio-algo-core-infra-inject-root-agents:p1:inst-compute-block

--- a/skills/studio/scripts/studio/constants.py
+++ b/skills/studio/scripts/studio/constants.py
@@ -16,6 +16,14 @@ import re
 ARTIFACTS_REGISTRY_FILENAME = "artifacts.toml"
 WORKSPACE_CONFIG_FILENAME = ".cf-workspace.toml"
 
+# Pipeline directive emitted into generated entrypoints (root @cf:root-agents
+# managed block and per-skill/workflow follow-protocol preamble) so every agent
+# resolves and enforces instruction prerequisites before applying user intent.
+ROOT_AGENTS_PIPELINE_INSTRUCTION = (
+    "ALWAYS resolve and enforce prerequisites of skills/workflows/commands "
+    "BEFORE applying user intent."
+)
+
 # === ARTIFACT STRUCTURE PATTERNS ===
 
 SECTION_RE = re.compile(r"^###\s+Section\s+([A-Z0-9]+):\s+(.+?)\s*$")

--- a/tests/test_init_inject.py
+++ b/tests/test_init_inject.py
@@ -97,6 +97,18 @@ class TestInjectRootWrappers(unittest.TestCase):
             self.assertTrue(agents.is_file())
             self.assertIn('cf-studio-path = "cypilot"', agents.read_text())
 
+    def test_managed_block_emits_pipeline_instruction(self):
+        """The managed block carries the pipeline directive, outside the TOML
+        fence, so it cannot silently regress."""
+        from studio.commands.init import _compute_managed_block, MARKER_END
+        from studio.constants import ROOT_AGENTS_PIPELINE_INSTRUCTION
+        block = _compute_managed_block("cypilot")
+        self.assertIn(ROOT_AGENTS_PIPELINE_INSTRUCTION, block)
+        # The directive sits after the closing toml fence and before MARKER_END,
+        # i.e. it is plain markdown, never parsed as TOML.
+        self.assertLess(block.index("```\n"), block.index(ROOT_AGENTS_PIPELINE_INSTRUCTION))
+        self.assertLess(block.index(ROOT_AGENTS_PIPELINE_INSTRUCTION), block.index(MARKER_END))
+
     def test_inject_root_agents_updates(self):
         from studio.commands.init import _inject_root_agents, MARKER_START, MARKER_END
         with TemporaryDirectory() as td:

--- a/tests/test_subagent_registration.py
+++ b/tests/test_subagent_registration.py
@@ -659,6 +659,7 @@ class TestLegacyStubClassification(unittest.TestCase):
             _follow_protocol_lines,
             _is_pure_studio_generated,
         )
+        from studio.constants import ROOT_AGENTS_PIPELINE_INSTRUCTION
 
         block = _follow_protocol_lines("{cf-studio-path}/.core/workflows/analyze.md")
         content = (
@@ -680,6 +681,17 @@ class TestLegacyStubClassification(unittest.TestCase):
         self.assertIn("- no_substantive_work_until = workflow_explicit_permission", block)
         self.assertIn("- precedence = constructor_studio_workflow > generic_assistant", block)
         self.assertIn("- pre_emit_check = response_shape in workflow_allowed_shapes", block)
+        # The pipeline directive is emitted between the mandatory-rule block and
+        # the "ALWAYS open and follow" target line.
+        self.assertIn(ROOT_AGENTS_PIPELINE_INSTRUCTION, block)
+        self.assertLess(
+            block.index("- protocol_violation > incomplete_answer"),
+            block.index(ROOT_AGENTS_PIPELINE_INSTRUCTION),
+        )
+        self.assertLess(
+            block.index(ROOT_AGENTS_PIPELINE_INSTRUCTION),
+            block.index("ALWAYS open and follow `{cf-studio-path}/.core/workflows/analyze.md`"),
+        )
         self.assertIn("UNIT GeneratedFollowProtocol", joined)
         self.assertIn("ALWAYS treat target as controlling protocol", joined)
         self.assertIn("ALWAYS traverse declared steps/units in order", joined)


### PR DESCRIPTION
Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AGENTS.md and CLAUDE.md with explicit instructions requiring skill, workflow, and command prerequisites to be resolved and enforced before applying user intent.

* **New Features**
  * Agent protocols now include automatic prerequisite enforcement, ensuring all skills, workflows, and commands have their dependencies resolved and validated before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->