### PR TITLE
feat(workflows): add brainstorming gates for coding, documentation, and skills workflows

### DIFF
--- a/workflows/coding.md
+++ b/workflows/coding.md
@@ -53,9 +53,28 @@ RULES:
 MENU CodingExploreMenu
 TITLE: Before writing or reviewing code, discover task-relevant project context (existing conventions, related modules, call sites) with cf-explore — or skip? Skip is the default when the target and its context are already clear; explore for unfamiliar or cross-cutting code. Reply with a number.
 OPTIONS:
-  1 explore -> INVOKE skill `cf-explore` with intent=generate and return_context=true, SET RESOURCE_CONTEXT = provided, then CONTINUE CodingDispatch
-  2 skip -> CONTINUE CodingDispatch
+  1 explore -> INVOKE skill `cf-explore` with intent=generate and return_context=true, SET RESOURCE_CONTEXT = provided, then CONTINUE CodingBrainstormGate
+  2 skip -> CONTINUE CodingBrainstormGate
   INVALID -> EMIT_MENU CodingExploreMenu
+```
+
+```pdsl
+UNIT CodingBrainstormGate
+PURPOSE: Offer decision/design exploration via cf-brainstorm as the next step after the explore gate, before any code is authored or reviewed.
+DO:
+  EMIT_MENU CodingBrainstormMenu
+  WAIT user.reply
+  STOP_TURN
+RULES:
+  ALWAYS offer cf-brainstorm decision exploration after the explore gate and before authoring or reviewing code, and ALWAYS let the user skip it
+  ALWAYS default to skip when the coding approach and its decisions are already clear and unambiguous
+  ALWAYS carry any brainstorm decisions into every coder and reviewer dispatch payload as read-only context, NEVER as a gate on a verdict
+MENU CodingBrainstormMenu
+TITLE: Before writing or reviewing code, brainstorm ambiguous decisions or design options with cf-brainstorm — or skip? Skip is the default when the approach is already clear; brainstorm for ambiguous requirements or open design questions. Reply with a number.
+OPTIONS:
+  1 brainstorm -> INVOKE skill `cf-brainstorm`, then CONTINUE CodingDispatch
+  2 skip -> CONTINUE CodingDispatch
+  INVALID -> EMIT_MENU CodingBrainstormMenu
 ```
 
 ```pdsl

--- a/workflows/write-docs.md
+++ b/workflows/write-docs.md
@@ -57,9 +57,28 @@ RULES:
 MENU WriteDocsExploreMenu
 TITLE: Before writing or reviewing docs, discover task-relevant project context (existing docs, related guides, source material, conventions) with cf-explore — or skip? Skip is the default when the target and its context are already clear; explore for unfamiliar or cross-cutting documentation. Reply with a number.
 OPTIONS:
-  1 explore -> INVOKE skill `cf-explore` with intent=generate and return_context=true, SET RESOURCE_CONTEXT = provided, then CONTINUE WriteDocsDispatch
-  2 skip -> CONTINUE WriteDocsDispatch
+  1 explore -> INVOKE skill `cf-explore` with intent=generate and return_context=true, SET RESOURCE_CONTEXT = provided, then CONTINUE WriteDocsBrainstormGate
+  2 skip -> CONTINUE WriteDocsBrainstormGate
   INVALID -> EMIT_MENU WriteDocsExploreMenu
+```
+
+```pdsl
+UNIT WriteDocsBrainstormGate
+PURPOSE: Offer decision/design exploration via cf-brainstorm as the next step after the explore gate, before any document is authored or reviewed.
+DO:
+  EMIT_MENU WriteDocsBrainstormMenu
+  WAIT user.reply
+  STOP_TURN
+RULES:
+  ALWAYS offer cf-brainstorm decision exploration after the explore gate and before authoring or reviewing docs, and ALWAYS let the user skip it
+  ALWAYS default to skip when the document approach and its decisions are already clear and unambiguous
+  ALWAYS carry any brainstorm decisions into every author and reviewer dispatch payload as read-only context, NEVER as a gate on a verdict
+MENU WriteDocsBrainstormMenu
+TITLE: Before writing or reviewing docs, brainstorm ambiguous decisions or framing options with cf-brainstorm — or skip? Skip is the default when the approach is already clear; brainstorm for ambiguous requirements or open framing questions. Reply with a number.
+OPTIONS:
+  1 brainstorm -> INVOKE skill `cf-brainstorm`, then CONTINUE WriteDocsDispatch
+  2 skip -> CONTINUE WriteDocsDispatch
+  INVALID -> EMIT_MENU WriteDocsBrainstormMenu
 ```
 
 ```pdsl

--- a/workflows/write-skills.md
+++ b/workflows/write-skills.md
@@ -52,9 +52,28 @@ RULES:
 MENU WriteSkillsExploreMenu
 TITLE: Before writing or reviewing a skill, discover task-relevant project context (sibling skills, workflows, agent contracts, referenced requirements, PDSL conventions) with cf-explore — or skip? Skip is the default when the target and its context are already clear; explore for unfamiliar or cross-cutting prompt work. Reply with a number.
 OPTIONS:
-  1 explore -> INVOKE skill `cf-explore` with intent=generate and return_context=true, SET RESOURCE_CONTEXT = provided, then CONTINUE WriteSkillsDispatch
-  2 skip -> CONTINUE WriteSkillsDispatch
+  1 explore -> INVOKE skill `cf-explore` with intent=generate and return_context=true, SET RESOURCE_CONTEXT = provided, then CONTINUE WriteSkillsBrainstormGate
+  2 skip -> CONTINUE WriteSkillsBrainstormGate
   INVALID -> EMIT_MENU WriteSkillsExploreMenu
+```
+
+```pdsl
+UNIT WriteSkillsBrainstormGate
+PURPOSE: Offer decision/design exploration via cf-brainstorm as the next step after the explore gate, before any skill file is authored or reviewed.
+DO:
+  EMIT_MENU WriteSkillsBrainstormMenu
+  WAIT user.reply
+  STOP_TURN
+RULES:
+  ALWAYS offer cf-brainstorm decision exploration after the explore gate and before authoring or reviewing a skill, and ALWAYS let the user skip it
+  ALWAYS default to skip when the skill approach and its decisions are already clear and unambiguous
+  ALWAYS carry any brainstorm decisions into every author and reviewer dispatch payload as read-only context, NEVER as a gate on a verdict
+MENU WriteSkillsBrainstormMenu
+TITLE: Before writing or reviewing a skill, brainstorm ambiguous decisions or design options with cf-brainstorm — or skip? Skip is the default when the approach is already clear; brainstorm for ambiguous requirements or open design questions. Reply with a number.
+OPTIONS:
+  1 brainstorm -> INVOKE skill `cf-brainstorm`, then CONTINUE WriteSkillsDispatch
+  2 skip -> CONTINUE WriteSkillsDispatch
+  INVALID -> EMIT_MENU WriteSkillsBrainstormMenu
 ```
 
 ```pdsl


### PR DESCRIPTION
Signed-off-by: ainetx <viator@via-net.org>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a brainstorming step to the coding, documentation-writing, and skills workflows. Users now have an optional decision-exploration stage between the context-exploration phase and main processing to address design ambiguities before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->