### PR TITLE
Generate cache notes from GitHub releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,10 +225,10 @@ seed-cache:
 	@rm -rf "$$HOME/.cf-studio/cache"
 	@mkdir -p "$$HOME/.cf-studio/cache"
 	@cp -R requirements schemas workflows skills architecture "$$HOME/.cf-studio/cache/"
-	@if [ -f whatsnew.toml ]; then cp whatsnew.toml "$$HOME/.cf-studio/cache/"; fi
 	@if [ -d .bootstrap/config/kits ]; then \
 		mkdir -p "$$HOME/.cf-studio/cache/kits"; \
 		cp -R .bootstrap/config/kits/* "$$HOME/.cf-studio/cache/kits/"; \
+		find "$$HOME/.cf-studio/cache/kits" -name whatsnew.toml -type f -delete; \
 	fi
 
 ensure-bootstrap:

--- a/skills/studio/scripts/studio/commands/kit.py
+++ b/skills/studio/scripts/studio/commands/kit.py
@@ -72,6 +72,10 @@ _GITHUB_TARBALL_MAX_TOTAL_SIZE = 512 * 1024 * 1024
 _GITHUB_TARBALL_MAX_EXPANSION_RATIO = 200
 
 
+class _WhatsnewGenerationError(RuntimeError):
+    """Internal sentinel for optional GitHub whatsnew generation failures."""
+
+
 _SEMVER_TAG_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
 
 
@@ -361,6 +365,7 @@ def _download_kit_from_github(
             f"Unexpected archive structure: expected 1 directory, found {len(subdirs)}"
         )
 
+    _try_write_kit_whatsnew_from_github_releases(subdirs[0], owner, repo)
     return subdirs[0], version
 # @cpt-end:cpt-studio-algo-kit-github-helpers:p1:inst-download
 
@@ -422,6 +427,78 @@ def _resolve_latest_github_release(owner: str, repo: str) -> str:
     # No releases found — use the highest semver-like tag if available.
     return _resolve_latest_semver_tag(owner, repo)
 # @cpt-end:cpt-studio-algo-kit-github-helpers:p1:inst-resolve-release
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _github_release_notes_to_whatsnew_toml(releases: List[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    for release in releases:
+        tag = str(release.get("tag_name") or "").strip()
+        if not tag:
+            continue
+        name = str(release.get("name") or "").strip()
+        body = str(release.get("body") or "").strip()
+        lines.extend([
+            f'[whatsnew.{_toml_string(tag)}]',
+            f"summary = {_toml_string(name or tag)}",
+            f"details = {_toml_string(body)}",
+            "",
+        ])
+    return "\n".join(lines)
+
+
+def _warn_kit_whatsnew_generation_failed(owner: str, repo: str, exc: BaseException) -> None:
+    ui.warn(
+        f"{owner}/{repo}: unable to generate whatsnew.toml from GitHub release notes: {exc}"
+    )
+
+
+def _write_kit_whatsnew_from_github_releases(
+    kit_source_dir: Path,
+    owner: str,
+    repo: str,
+) -> None:
+    """Generate kit whatsnew.toml only from GitHub release notes."""
+    whatsnew_path = kit_source_dir / "whatsnew.toml"
+    whatsnew_path.unlink(missing_ok=True)
+    from ..utils.mirrors import apply_override
+
+    url = apply_override(f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100")
+    req = urllib.request.Request(url, headers=_github_headers())
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except (
+        urllib.error.HTTPError,
+        urllib.error.URLError,
+        json.JSONDecodeError,
+        OSError,
+        ValueError,
+    ) as exc:
+        _warn_kit_whatsnew_generation_failed(owner, repo, exc)
+        return
+    except AssertionError as exc:
+        raise _WhatsnewGenerationError(str(exc)) from exc
+    if not isinstance(data, list):
+        return
+    releases = [item for item in data if isinstance(item, dict)]
+    content = _github_release_notes_to_whatsnew_toml(releases)
+    if content.strip():
+        whatsnew_path.write_text(content, encoding="utf-8")
+
+
+def _try_write_kit_whatsnew_from_github_releases(
+    kit_source_dir: Path,
+    owner: str,
+    repo: str,
+) -> None:
+    try:
+        _write_kit_whatsnew_from_github_releases(kit_source_dir, owner, repo)
+    except _WhatsnewGenerationError as exc:
+        _warn_kit_whatsnew_generation_failed(owner, repo, exc)
 
 # ---------------------------------------------------------------------------
 # Config seeding — copy default .toml configs from kit scripts to config/

--- a/src/studio_proxy/cache.py
+++ b/src/studio_proxy/cache.py
@@ -18,7 +18,7 @@ import tarfile
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
@@ -34,6 +34,10 @@ GITHUB_OWNER = "constructorfabric"
 GITHUB_REPO = "studio"
 GITHUB_API_BASE = f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}"
 USER_AGENT = "constructor-studio/1.0"
+
+
+class _WhatsnewGenerationError(RuntimeError):
+    """Internal sentinel for optional GitHub whatsnew generation failures."""
 
 
 def _patch_cached_version(cache_dir: Path, version: str) -> None:
@@ -92,6 +96,73 @@ def _github_json(url: str) -> Dict[str, Any]:
     with urlopen(req, timeout=30) as resp:
         data = json.loads(resp.read().decode("utf-8"))
     return data if isinstance(data, dict) else {}
+
+
+def _github_json_list(url: str) -> List[Dict[str, Any]]:
+    req = Request(url, headers=_get_github_headers())
+    try:
+        with urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except (HTTPError, URLError, json.JSONDecodeError, OSError, ValueError) as exc:
+        raise _WhatsnewGenerationError(str(exc)) from exc
+    except AssertionError as exc:
+        raise _WhatsnewGenerationError(str(exc)) from exc
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _warn_whatsnew_generation_failed(scope: str, exc: BaseException) -> None:
+    sys.stderr.write(
+        f"Warning: unable to generate {scope} whatsnew.toml from GitHub release notes: {exc}\n"
+    )
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _release_notes_to_whatsnew_toml(releases: List[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    for release in releases:
+        tag = str(release.get("tag_name") or "").strip()
+        if not tag:
+            continue
+        name = str(release.get("name") or "").strip()
+        body = str(release.get("body") or "").strip()
+        lines.extend([
+            f'[whatsnew.{_toml_string(tag)}]',
+            f"summary = {_toml_string(name or tag)}",
+            f"details = {_toml_string(body)}",
+            "",
+        ])
+    return "\n".join(lines)
+
+
+def _write_github_whatsnew(cache_dir: Path, api_base: str) -> None:
+    """Generate cache whatsnew.toml only from GitHub release notes."""
+    whatsnew_path = cache_dir / "whatsnew.toml"
+    whatsnew_path.unlink(missing_ok=True)
+    try:
+        from studio_proxy.mirrors import apply_override
+
+        releases = _github_json_list(apply_override(f"{api_base}/releases?per_page=100"))
+        content = _release_notes_to_whatsnew_toml(releases)
+    except _WhatsnewGenerationError as exc:
+        _warn_whatsnew_generation_failed("Studio cache", exc)
+        return
+    if content.strip():
+        whatsnew_path.write_text(content, encoding="utf-8")
+
+
+def _remove_non_github_whatsnew(cache_dir: Path) -> None:
+    """Remove whatsnew files copied from local/source trees."""
+    paths = [cache_dir / "whatsnew.toml"]
+    kits_dir = cache_dir / "kits"
+    if kits_dir.is_dir():
+        paths.extend(kits_dir.glob("*/whatsnew.toml"))
+    for path in paths:
+        path.unlink(missing_ok=True)
 
 
 def _select_release_download_url(release_data: Dict[str, Any]) -> Optional[str]:
@@ -449,6 +520,7 @@ def copy_from_local(
             shutil.copytree(item, dst)
         elif item.is_file():
             shutil.copy2(item, dst)
+    _remove_non_github_whatsnew(cache_dir)
 
     display_version = f"local:{local_version}"
     version_file.write_text(display_version, encoding="utf-8")
@@ -631,6 +703,8 @@ def download_and_cache(
 
     # Patch __version__ in cached skill's __init__.py with resolved version
     _patch_cached_version(cache_dir, resolved_version)
+    _remove_non_github_whatsnew(cache_dir)
+    _write_github_whatsnew(cache_dir, api_base)
 
     # @cpt-begin:cpt-studio-algo-core-infra-cache-skill:p1:inst-write-version
     version_file.write_text(resolved_version, encoding="utf-8")

--- a/tests/test_kit.py
+++ b/tests/test_kit.py
@@ -2018,6 +2018,64 @@ class TestDownloadKitFromGithub(unittest.TestCase):
             # Cleanup
             shutil.rmtree(result_dir.parent, ignore_errors=True)
 
+    def test_download_generates_whatsnew_from_github_releases(self):
+        from studio.commands.kit import _download_kit_from_github
+
+        tar_bytes = self._make_tarball_bytes([
+            {"name": "owner-repo-abc123/", "type": tarfile.DIRTYPE},
+            {"name": "owner-repo-abc123/conf.toml", "data": b"version = 1\n"},
+            {
+                "name": "owner-repo-abc123/whatsnew.toml",
+                "data": b'[whatsnew."0.0.0"]\nsummary = "local"\ndetails = ""\n',
+            },
+        ])
+
+        def fake_urlopen(req, **_kwargs):
+            url = req.full_url
+            if url.endswith("/tarball/v1.0"):
+                return self._fake_response(tar_bytes)
+            if url.endswith("/releases?per_page=100"):
+                return self._fake_response(io.BytesIO(json.dumps([
+                    {"tag_name": "v1.0", "name": "Kit release", "body": "- GitHub note"},
+                ]).encode()))
+            raise AssertionError(url)
+
+        with patch("studio.commands.kit.urllib.request.urlopen", side_effect=fake_urlopen):
+            result_dir, ver = _download_kit_from_github("owner", "repo", "v1.0")
+            self.assertEqual(ver, "v1.0")
+            whatsnew = (result_dir / "whatsnew.toml").read_text(encoding="utf-8")
+            self.assertIn('[whatsnew."v1.0"]', whatsnew)
+            self.assertIn('summary = "Kit release"', whatsnew)
+            self.assertIn("GitHub note", whatsnew)
+            self.assertNotIn('summary = "local"', whatsnew)
+            shutil.rmtree(result_dir.parent, ignore_errors=True)
+
+    def test_download_warns_when_github_whatsnew_generation_fails(self):
+        from studio.commands.kit import _download_kit_from_github
+
+        tar_bytes = self._make_tarball_bytes([
+            {"name": "owner-repo-abc123/", "type": tarfile.DIRTYPE},
+            {"name": "owner-repo-abc123/conf.toml", "data": b"version = 1\n"},
+            {
+                "name": "owner-repo-abc123/whatsnew.toml",
+                "data": b'[whatsnew."0.0.0"]\nsummary = "local"\ndetails = ""\n',
+            },
+        ])
+
+        def fake_urlopen(req, **_kwargs):
+            url = req.full_url
+            if url.endswith("/tarball/v1.0"):
+                return self._fake_response(tar_bytes)
+            raise AssertionError(url)
+
+        with patch("studio.commands.kit.urllib.request.urlopen", side_effect=fake_urlopen):
+            with patch("studio.commands.kit.ui.warn") as warn:
+                result_dir, _ver = _download_kit_from_github("owner", "repo", "v1.0")
+        self.assertFalse((result_dir / "whatsnew.toml").exists())
+        warn.assert_called_once()
+        self.assertIn("unable to generate whatsnew.toml", warn.call_args.args[0])
+        shutil.rmtree(result_dir.parent, ignore_errors=True)
+
     def test_with_authority_derives_commit_identity_from_tar_root(self):
         from studio.commands.kit import _download_kit_from_github_with_authority
 

--- a/tests/test_studio_proxy_cli.py
+++ b/tests/test_studio_proxy_cli.py
@@ -128,6 +128,84 @@ def test_download_and_cache_writes_github_provenance(monkeypatch, tmp_path):
     assert '"verified": "verified"' in provenance
 
 
+def test_download_and_cache_generates_whatsnew_from_github_releases(monkeypatch, tmp_path):
+    import studio_proxy.cache as cache
+
+    monkeypatch.setenv("CFS_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(
+        cache,
+        "_resolve_latest_version_with_metadata",
+        lambda api_base=None: ("v9.8.7", "https://downloads.example/studio.tar.gz", {}),
+    )
+
+    class FakeResp:
+        def __init__(self, data):
+            self._data = data
+        def __enter__(self):
+            return self
+        def __exit__(self, *_args):
+            return None
+        def read(self):
+            return self._data
+
+    def fake_urlopen(req, **_kwargs):
+        url = req.full_url
+        if url == "https://downloads.example/studio.tar.gz":
+            return FakeResp(_skill_tarball())
+        if url.endswith("/releases?per_page=100"):
+            return FakeResp(json.dumps([
+                {"tag_name": "v9.8.7", "name": "Release title", "body": "- GitHub-only note"},
+            ]).encode())
+        raise AssertionError(url)
+
+    monkeypatch.setattr(cache, "urlopen", fake_urlopen)
+
+    success, _message = cache.download_and_cache()
+
+    assert success is True
+    whatsnew = (tmp_path / "cache" / "whatsnew.toml").read_text(encoding="utf-8")
+    assert '[whatsnew."v9.8.7"]' in whatsnew
+    assert 'summary = "Release title"' in whatsnew
+    assert "GitHub-only note" in whatsnew
+
+
+def test_download_and_cache_warns_when_github_whatsnew_generation_fails(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    import studio_proxy.cache as cache
+
+    monkeypatch.setenv("CFS_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setattr(
+        cache,
+        "_resolve_latest_version_with_metadata",
+        lambda api_base=None: ("v9.8.7", "https://downloads.example/studio.tar.gz", {}),
+    )
+
+    class FakeResp:
+        def __enter__(self):
+            return self
+        def __exit__(self, *_args):
+            return None
+        def read(self):
+            return _skill_tarball()
+
+    def fake_urlopen(req, **_kwargs):
+        url = req.full_url
+        if url == "https://downloads.example/studio.tar.gz":
+            return FakeResp()
+        raise AssertionError(url)
+
+    monkeypatch.setattr(cache, "urlopen", fake_urlopen)
+
+    success, _message = cache.download_and_cache()
+
+    assert success is True
+    assert not (tmp_path / "cache" / "whatsnew.toml").exists()
+    assert "unable to generate Studio cache whatsnew.toml" in capsys.readouterr().err
+
+
 def test_download_and_cache_no_releases_uses_default_branch_snapshot(monkeypatch, tmp_path):
     import studio_proxy.cache as cache
 
@@ -563,6 +641,15 @@ def test_copy_from_local_writes_non_github_provenance(monkeypatch, tmp_path):
     pkg.mkdir(parents=True)
     (pkg / "__init__.py").write_text('__version__ = "dev-local"\n', encoding="utf-8")
     (source / "skills" / "studio" / "scripts" / "studio.py").write_text("print('ok')\n", encoding="utf-8")
+    (source / "whatsnew.toml").write_text(
+        '[whatsnew."0.0.0"]\nsummary = "local file must not be cached"\ndetails = ""\n',
+        encoding="utf-8",
+    )
+    (source / "kits" / "demo").mkdir(parents=True)
+    (source / "kits" / "demo" / "whatsnew.toml").write_text(
+        '[whatsnew."0.0.0"]\nsummary = "local kit file must not be cached"\ndetails = ""\n',
+        encoding="utf-8",
+    )
 
     success, message = cache.copy_from_local(str(source))
 
@@ -573,6 +660,8 @@ def test_copy_from_local_writes_non_github_provenance(monkeypatch, tmp_path):
     assert '"source_type": "local_path"' in provenance
     assert '"resolver_mode": "local_path"' in provenance
     assert '"verified": "unknown"' in provenance
+    assert not (tmp_path / "cache" / "whatsnew.toml").exists()
+    assert not (tmp_path / "cache" / "kits" / "demo" / "whatsnew.toml").exists()
 
 
 def test_version_output_uses_cache_provenance(monkeypatch, capsys):


### PR DESCRIPTION
Implement functionality to generate `whatsnew.toml` files from GitHub release notes, ensuring that local source tree files are removed from the cache. Add regression tests to cover the new behavior. This change enhances the caching mechanism by relying solely on GitHub for release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kits installed from GitHub now generate changelog entries automatically from GitHub release notes.

* **Changes**
  * Local changelog files are no longer copied into the cache; cache is populated with GitHub-derived changelogs when available.
  * Failures during changelog generation produce a warning instead of aborting installation.

* **Tests**
  * Added tests verifying changelog generation, cache cleanup, and graceful failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->