### PR TITLE
Fix GitHub coauthor trailer rendering and enforce trailer message rules

### DIFF
--- a/skills/studio/SKILL.md
+++ b/skills/studio/SKILL.md
@@ -322,10 +322,10 @@ NOTES:
     conflict_policy: "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit"
     user_instruction_precedence: "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers"
     hard_stop_policy: "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers"
-    rendering: "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Do not include separate rendered footer lines in this payload."
+    rendering: "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload."
     required_trailers:
       - order: 10
-        token: "Co-Authored-By"
+        token: "Co-authored-by"
         value: "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>"
       - order: 20
         token: "Studio-Generated-By"

--- a/skills/studio/SKILL.md
+++ b/skills/studio/SKILL.md
@@ -322,7 +322,7 @@ NOTES:
     conflict_policy: "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit"
     user_instruction_precedence: "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers"
     hard_stop_policy: "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers"
-    rendering: "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload."
+    rendering: "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload."
     required_trailers:
       - order: 10
         token: "Co-authored-by"

--- a/skills/studio/agents/cf-generate-author-worker.md
+++ b/skills/studio/agents/cf-generate-author-worker.md
@@ -148,11 +148,11 @@ RULES:
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,
-        "token": "Co-Authored-By",
+        "token": "Co-authored-by",
         "value": "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>"
       },
       {

--- a/skills/studio/agents/cf-generate-author-worker.md
+++ b/skills/studio/agents/cf-generate-author-worker.md
@@ -148,7 +148,7 @@ RULES:
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,

--- a/skills/studio/agents/cf-phase-compiler.md
+++ b/skills/studio/agents/cf-phase-compiler.md
@@ -40,11 +40,11 @@ rediscover workflows, requirements, specs, AGENTS, SKILL, or kit prompt files.
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,
-        "token": "Co-Authored-By",
+        "token": "Co-authored-by",
         "value": "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>"
       },
       {

--- a/skills/studio/agents/cf-phase-compiler.md
+++ b/skills/studio/agents/cf-phase-compiler.md
@@ -40,7 +40,7 @@ rediscover workflows, requirements, specs, AGENTS, SKILL, or kit prompt files.
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,

--- a/skills/studio/agents/cf-phase-runner.md
+++ b/skills/studio/agents/cf-phase-runner.md
@@ -40,11 +40,11 @@ rediscover workflows, requirements, specs, AGENTS, SKILL, or kit prompt files.
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,
-        "token": "Co-Authored-By",
+        "token": "Co-authored-by",
         "value": "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>"
       },
       {

--- a/skills/studio/agents/cf-phase-runner.md
+++ b/skills/studio/agents/cf-phase-runner.md
@@ -40,7 +40,7 @@ rediscover workflows, requirements, specs, AGENTS, SKILL, or kit prompt files.
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,

--- a/tests/test_workflow_subagents_dispatch.py
+++ b/tests/test_workflow_subagents_dispatch.py
@@ -302,8 +302,10 @@ COMMIT_FOOTER_CONTRACT = {
     "rendering": (
         "Render every included trailer as '{token}: {value}' in ascending order "
         "across required_trailers and optional_trailers. Render the commit trailer "
-        "block as contiguous lines with no blank lines between trailers. Do not "
-        "include separate rendered footer lines in this payload."
+        "block as contiguous lines with no blank lines between trailers. When "
+        "invoking git commit, do not pass individual trailers as separate -m or "
+        "--message arguments. Do not include separate rendered footer lines in "
+        "this payload."
     ),
 }
 
@@ -672,6 +674,7 @@ def _assert_commit_footer_contract_shape(contract: dict) -> None:
     assert "skill=1.0.1, cli=0.2.0" in version["value_policy"]
     assert "contiguous lines" in contract["rendering"]
     assert "no blank lines between trailers" in contract["rendering"]
+    assert "do not pass individual trailers as separate -m" in contract["rendering"]
 
     orders = [entry["order"] for entry in required + optional]
     assert orders == sorted(orders), "trailers must use one total canonical order"
@@ -737,6 +740,7 @@ def test_git_commit_mode_gate_declares_studio_footer_contract_without_prompt_sna
         "Co-authored-by",
         "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>",
         "contiguous lines with no blank lines between trailers",
+        "do not pass individual trailers as separate -m",
         "Studio-Source-Repo",
         "Constructor-Fabric",
         "semver tokens extracted from cfs --version",

--- a/tests/test_workflow_subagents_dispatch.py
+++ b/tests/test_workflow_subagents_dispatch.py
@@ -259,7 +259,7 @@ COMMIT_FOOTER_CONTRACT = {
     ),
     "required_trailers": [
         {
-            "token": "Co-Authored-By",
+            "token": "Co-authored-by",
             "value": "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>",
             "order": 10,
         },
@@ -301,8 +301,9 @@ COMMIT_FOOTER_CONTRACT = {
     ],
     "rendering": (
         "Render every included trailer as '{token}: {value}' in ascending order "
-        "across required_trailers and optional_trailers. Do not include separate "
-        "rendered footer lines in this payload."
+        "across required_trailers and optional_trailers. Render the commit trailer "
+        "block as contiguous lines with no blank lines between trailers. Do not "
+        "include separate rendered footer lines in this payload."
     ),
 }
 
@@ -652,7 +653,7 @@ def _assert_commit_footer_contract_shape(contract: dict) -> None:
     required = contract["required_trailers"]
     assert [(entry["token"], entry["value"], entry["order"]) for entry in required] == [
         (
-            "Co-Authored-By",
+            "Co-authored-by",
             "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>",
             10,
         ),
@@ -669,6 +670,8 @@ def _assert_commit_footer_contract_shape(contract: dict) -> None:
     assert "semver" in version["include_when"]
     assert "do not include raw cfs --version output" in version["value_policy"]
     assert "skill=1.0.1, cli=0.2.0" in version["value_policy"]
+    assert "contiguous lines" in contract["rendering"]
+    assert "no blank lines between trailers" in contract["rendering"]
 
     orders = [entry["order"] for entry in required + optional]
     assert orders == sorted(orders), "trailers must use one total canonical order"
@@ -731,8 +734,9 @@ def test_git_commit_mode_gate_declares_studio_footer_contract_without_prompt_sna
         "DCO/Signed-off-by when required",
         "does not replace project-policy trailers",
         "does not grant permission to commit",
-        "Co-Authored-By",
+        "Co-authored-by",
         "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>",
+        "contiguous lines with no blank lines between trailers",
         "Studio-Source-Repo",
         "Constructor-Fabric",
         "semver tokens extracted from cfs --version",


### PR DESCRIPTION
Ensure the Studio commit footer correctly uses the GitHub-recognized spelling for co-authored trailers and requires that trailers render as a contiguous block without blank lines. This change prevents passing individual trailers as separate message arguments to maintain proper parsing by GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated commit footer specifications to standardize co-author trailer format to GitHub conventions and clarify trailer rendering rules.

* **Bug Fixes**
  * Corrected co-author trailer token casing to match industry standards and ensure proper git commit trailer formatting without blank lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->