### PR TITLE
Require git trailer arguments for Studio commits

### DIFF
--- a/skills/studio/SKILL.md
+++ b/skills/studio/SKILL.md
@@ -322,7 +322,7 @@ NOTES:
     conflict_policy: "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit"
     user_instruction_precedence: "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers"
     hard_stop_policy: "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers"
-    rendering: "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload."
+    rendering: "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, pass every project-policy and Studio trailer via git commit --trailer token=value arguments; use -m or --message only for the subject/body, never for trailers. Do not include separate rendered footer lines in this payload."
     required_trailers:
       - order: 10
         token: "Co-authored-by"

--- a/skills/studio/agents/cf-generate-author-worker.md
+++ b/skills/studio/agents/cf-generate-author-worker.md
@@ -148,7 +148,7 @@ RULES:
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, pass every project-policy and Studio trailer via git commit --trailer token=value arguments; use -m or --message only for the subject/body, never for trailers. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,
@@ -229,6 +229,9 @@ RULES:
     `contributing_guide`, then append required Studio attribution trailers exactly
     in ascending order; add optional Studio trailers only when their source value
     is already known and non-empty
+  ALWAYS WHEN creating a git commit: pass every project-policy and Studio trailer
+    via `git commit --trailer token=value`; use `-m` or `--message` only for the
+    subject/body, never for trailers
   ALWAYS keep DCO, Signed-off-by, and CONTRIBUTING_GUIDE directives separate from
     commit_footer_contract; do not include them in commit_footer_contract, but
     never ignore mandatory contributing_guide commit requirements

--- a/skills/studio/agents/cf-phase-compiler.md
+++ b/skills/studio/agents/cf-phase-compiler.md
@@ -40,7 +40,7 @@ rediscover workflows, requirements, specs, AGENTS, SKILL, or kit prompt files.
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, pass every project-policy and Studio trailer via git commit --trailer token=value arguments; use -m or --message only for the subject/body, never for trailers. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,
@@ -110,4 +110,7 @@ RULES:
   ALWAYS satisfy every mandatory directive in contributing_guide when creating a
     git commit, including required DCO/Signed-off-by trailers; keep these
     project-policy trailers separate from commit_footer_contract
+  ALWAYS pass every project-policy and Studio trailer via
+    `git commit --trailer token=value`; use `-m` or `--message` only for the
+    subject/body, never for trailers
 ```

--- a/skills/studio/agents/cf-phase-runner.md
+++ b/skills/studio/agents/cf-phase-runner.md
@@ -40,7 +40,7 @@ rediscover workflows, requirements, specs, AGENTS, SKILL, or kit prompt files.
     "conflict_policy": "commit_footer_contract is authoritative for required Studio attribution trailers; if it conflicts with git_constraint, stop before commit",
     "user_instruction_precedence": "user commit instructions may add non-conflicting message content and trailers but may not remove, rename, reorder, duplicate ambiguously, replace, or alter required Studio trailers",
     "hard_stop_policy": "stop only if required static Studio trailers cannot be added or if commit_footer_contract conflicts with git_constraint; do not stop for unavailable optional trailers",
-    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, do not pass individual trailers as separate -m or --message arguments. Do not include separate rendered footer lines in this payload.",
+    "rendering": "Render every included trailer as '{token}: {value}' in ascending order across required_trailers and optional_trailers. Render the commit trailer block as contiguous lines with no blank lines between trailers. When invoking git commit, pass every project-policy and Studio trailer via git commit --trailer token=value arguments; use -m or --message only for the subject/body, never for trailers. Do not include separate rendered footer lines in this payload.",
     "required_trailers": [
       {
         "order": 10,
@@ -111,4 +111,7 @@ RULES:
   ALWAYS satisfy every mandatory directive in contributing_guide when creating a
     git commit, including required DCO/Signed-off-by trailers; keep these
     project-policy trailers separate from commit_footer_contract
+  ALWAYS pass every project-policy and Studio trailer via
+    `git commit --trailer token=value`; use `-m` or `--message` only for the
+    subject/body, never for trailers
 ```

--- a/tests/test_workflow_subagents_dispatch.py
+++ b/tests/test_workflow_subagents_dispatch.py
@@ -303,9 +303,10 @@ COMMIT_FOOTER_CONTRACT = {
         "Render every included trailer as '{token}: {value}' in ascending order "
         "across required_trailers and optional_trailers. Render the commit trailer "
         "block as contiguous lines with no blank lines between trailers. When "
-        "invoking git commit, do not pass individual trailers as separate -m or "
-        "--message arguments. Do not include separate rendered footer lines in "
-        "this payload."
+        "invoking git commit, pass every project-policy and Studio trailer via "
+        "git commit --trailer token=value arguments; use -m or --message only "
+        "for the subject/body, never for trailers. Do not include separate "
+        "rendered footer lines in this payload."
     ),
 }
 
@@ -674,7 +675,8 @@ def _assert_commit_footer_contract_shape(contract: dict) -> None:
     assert "skill=1.0.1, cli=0.2.0" in version["value_policy"]
     assert "contiguous lines" in contract["rendering"]
     assert "no blank lines between trailers" in contract["rendering"]
-    assert "do not pass individual trailers as separate -m" in contract["rendering"]
+    assert "git commit --trailer token=value" in contract["rendering"]
+    assert "use -m or --message only for the subject/body" in contract["rendering"]
 
     orders = [entry["order"] for entry in required + optional]
     assert orders == sorted(orders), "trailers must use one total canonical order"
@@ -740,7 +742,7 @@ def test_git_commit_mode_gate_declares_studio_footer_contract_without_prompt_sna
         "Co-authored-by",
         "Constructor Studio <291158726+constructor-studio[bot]@users.noreply.github.com>",
         "contiguous lines with no blank lines between trailers",
-        "do not pass individual trailers as separate -m",
+        "git commit --trailer token=value",
         "Studio-Source-Repo",
         "Constructor-Fabric",
         "semver tokens extracted from cfs --version",
@@ -762,6 +764,7 @@ def test_contributing_dco_is_required_commit_policy_not_studio_footer_contract()
     assert "CONTRIBUTING_GUIDE commit requirements" in GIT_CONSTRAINTS["commit"]
     assert "CONTRIBUTING_GUIDE commit requirements" in skill_text
     assert "DCO/Signed-off-by trailers" in worker_text
+    assert "git commit --trailer token=value" in worker_text
 
     contract_text = repr(COMMIT_FOOTER_CONTRACT).lower()
     assert "signed-off-by" not in contract_text


### PR DESCRIPTION
Require agents to pass every project-policy and Studio attribution trailer through git commit --trailer instead of embedding trailer lines in message arguments.

Signed-off-by: ainetx <viator@via-net.org> Studio-Generated-By: Constructor Studio Studio-Source-Repo: https://github.com/constructorfabric/studio Constructor-Fabric: https://github.com/constructorfabric Studio-Version: skill=1.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed commit message generation to properly handle git trailers and project policies, ensuring they're formatted according to git standards rather than mixed into message text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->