### PR TITLE
fix: restrict agent config manifests to kits

### DIFF
--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -4320,7 +4320,12 @@ def cmd_generate_agents(argv: List[str]) -> int:
 
     # ── NEW: Multi-layer discovery path ────────────────────────────────────
     # @cpt-begin:cpt-studio-flow-project-extensibility-generate-with-multi-layer:p1:inst-step2-discover-layers
-    layers = _discover_layers(project_root, studio_root)
+    discovered_layers = _discover_layers(project_root, studio_root)
+    # Agent configuration generation is intentionally sourced only from
+    # installed kit manifests. Repo/master manifest layers can describe broader
+    # project extensibility, but must not implicitly affect generated agent
+    # configuration files.
+    layers = [layer for layer in discovered_layers if layer.scope == "kit"]
     # @cpt-end:cpt-studio-flow-project-extensibility-generate-with-multi-layer:p1:inst-step2-discover-layers
 
     if _layers_have_v2_manifests(layers):
@@ -4333,7 +4338,8 @@ def cmd_generate_agents(argv: List[str]) -> int:
         # Step 4: Handle --discover flag
         if getattr(args, "discover", False):
             _run_discover_flag(args, project_root, studio_root)
-            layers = _discover_layers(project_root, studio_root)
+            discovered_layers = _discover_layers(project_root, studio_root)
+            layers = [layer for layer in discovered_layers if layer.scope == "kit"]
             resolved_layers, has_v2_errors = _resolve_includes_for_layers(layers, project_root)
             if has_v2_errors:
                 return 1

--- a/skills/studio/scripts/studio/utils/layer_discovery.py
+++ b/skills/studio/scripts/studio/utils/layer_discovery.py
@@ -245,21 +245,17 @@ def discover_layers(repo_root: Path, studio_root: Path) -> List[ManifestLayer]:
     layers.extend(kit_layers)
     # @cpt-end:cpt-studio-algo-project-extensibility-walk-up-discovery:p1:step-1-kit-layers
 
-    # Step 3-6: Load master manifest — check project root first, then walk up
+    # Step 3-6: Load master manifest — walk up from the project root parent
     # @cpt-begin:cpt-studio-algo-project-extensibility-walk-up-discovery:p1:step-3-6-walkup
-    # A project may be its own master repo (manifest.toml at project root with
-    # scope = "master").  Check repo_root itself before walking up to a parent.
-    root_manifest = repo_root / _MANIFEST_TOML
-    if root_manifest.is_file():
-        master_layer = _load_master_layer(repo_root)
+    # The current kit-based extensibility model treats project-root
+    # manifest.toml files as ordinary repository files unless they are
+    # explicitly registered as a kit. Project-scoped manifest layers live under
+    # {studio_root}/config/manifest.toml.
+    master_root = _detect_master_repo(repo_root)
+    if master_root is not None:
+        master_layer = _load_master_layer(master_root)
         if master_layer is not None:
             layers.append(master_layer)
-    else:
-        master_root = _detect_master_repo(repo_root)
-        if master_root is not None:
-            master_layer = _load_master_layer(master_root)
-            if master_layer is not None:
-                layers.append(master_layer)
     # @cpt-end:cpt-studio-algo-project-extensibility-walk-up-discovery:p1:step-3-6-walkup
 
     # Step 2: Load repo layer from {studio_root}/config/manifest.toml

--- a/tests/test_cmd_generate_agents_v2.py
+++ b/tests/test_cmd_generate_agents_v2.py
@@ -321,6 +321,27 @@ class TestCmdGenerateAgentsDiscover(unittest.TestCase):
 class TestCmdGenerateAgentsLegacyPath(unittest.TestCase):
     """Legacy path (no v2 manifest) still works."""
 
+    def test_project_root_manifest_does_not_enable_v2_pipeline(self):
+        """A root manifest.toml is not a generate-agents layer unless registered/configured."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root, cypilot_root = _make_project(tmpdir)
+            (project_root / ".git").mkdir()
+            (project_root / "manifest.toml").write_text(_MANIFEST_V2_AGENT, encoding="utf-8")
+
+            src = project_root / "agents" / "my-agent.md"
+            src.parent.mkdir(parents=True, exist_ok=True)
+            src.write_text("# My Agent\nDo something.", encoding="utf-8")
+
+            ret = cmd_generate_agents([
+                "--root", str(project_root),
+                "--cf-constructor-root", str(cypilot_root),
+                "--agent", "claude",
+                "--dry-run",
+            ])
+
+            self.assertEqual(ret, 0)
+            self.assertFalse((project_root / ".claude" / "agents" / "my-agent.md").exists())
+
     def test_legacy_path_dry_run(self):
         """cmd_generate_agents in legacy mode with --dry-run returns 0."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_cmd_generate_agents_v2.py
+++ b/tests/test_cmd_generate_agents_v2.py
@@ -341,13 +341,15 @@ class TestCmdGenerateAgentsLegacyPath(unittest.TestCase):
             src.parent.mkdir(parents=True, exist_ok=True)
             src.write_text("# My Agent\nDo something.", encoding="utf-8")
 
-            ret = cmd_generate_agents([
-                "--root", str(project_root),
-                "--cf-constructor-root", str(cypilot_root),
-                "--agent", "claude",
-                "--dry-run",
-            ])
+            with mock.patch("studio.commands.agents._resolve_includes_for_layers") as mock_resolve:
+                ret = cmd_generate_agents([
+                    "--root", str(project_root),
+                    "--cf-constructor-root", str(cypilot_root),
+                    "--agent", "claude",
+                    "--dry-run",
+                ])
 
+            mock_resolve.assert_not_called()
             self.assertEqual(ret, 0)
             self.assertFalse((project_root / ".claude" / "agents" / "my-agent.md").exists())
 
@@ -361,13 +363,15 @@ class TestCmdGenerateAgentsLegacyPath(unittest.TestCase):
             src.parent.mkdir(parents=True, exist_ok=True)
             src.write_text("# My Agent\nDo something.", encoding="utf-8")
 
-            ret = cmd_generate_agents([
-                "--root", str(project_root),
-                "--cf-constructor-root", str(cypilot_root),
-                "--agent", "claude",
-                "--dry-run",
-            ])
+            with mock.patch("studio.commands.agents._resolve_includes_for_layers") as mock_resolve:
+                ret = cmd_generate_agents([
+                    "--root", str(project_root),
+                    "--cf-constructor-root", str(cypilot_root),
+                    "--agent", "claude",
+                    "--dry-run",
+                ])
 
+            mock_resolve.assert_not_called()
             self.assertEqual(ret, 0)
             self.assertFalse((project_root / ".claude" / "agents" / "my-agent.md").exists())
 
@@ -398,13 +402,15 @@ class TestCmdGenerateAgentsLegacyPath(unittest.TestCase):
             src.parent.mkdir(parents=True, exist_ok=True)
             src.write_text("# My Agent\nDo something.", encoding="utf-8")
 
-            ret = cmd_generate_agents([
-                "--root", str(project_root),
-                "--cf-constructor-root", str(cypilot_root),
-                "--agent", "claude",
-                "--dry-run",
-            ])
+            with mock.patch("studio.commands.agents._resolve_includes_for_layers") as mock_resolve:
+                ret = cmd_generate_agents([
+                    "--root", str(project_root),
+                    "--cf-constructor-root", str(cypilot_root),
+                    "--agent", "claude",
+                    "--dry-run",
+                ])
 
+            mock_resolve.assert_not_called()
             self.assertEqual(ret, 0)
             self.assertFalse((project_root / ".claude" / "agents" / "my-agent.md").exists())
 

--- a/tests/test_cmd_generate_agents_v2.py
+++ b/tests/test_cmd_generate_agents_v2.py
@@ -136,6 +136,15 @@ def _write_manifest(cypilot_root: Path, content: str) -> Path:
     return manifest_path
 
 
+def _write_registered_kit_manifest(cypilot_root: Path, content: str, kit_name: str = "testkit") -> Path:
+    _register_kit(cypilot_root, kit_name)
+    kit_root = cypilot_root / "config" / "kits" / kit_name
+    kit_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = kit_root / "manifest.toml"
+    manifest_path.write_text(content, encoding="utf-8")
+    return manifest_path
+
+
 # ---------------------------------------------------------------------------
 # Tests: cmd_generate_agents — v2 manifest pipeline
 # ---------------------------------------------------------------------------
@@ -145,7 +154,7 @@ class TestCmdGenerateAgentsV2ManifestPipeline(unittest.TestCase):
 
     def _run(self, tmpdir: str, extra_argv: list = None) -> int:
         project_root, cypilot_root = _make_project(tmpdir)
-        _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+        _write_registered_kit_manifest(cypilot_root, _MANIFEST_V2_AGENT)
 
         # Write the agent source file
         src = project_root / "agents" / "my-agent.md"
@@ -172,7 +181,7 @@ class TestCmdGenerateAgentsV2ManifestPipeline(unittest.TestCase):
         """dry_run=True prevents files being written even with v2 manifest."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root, cypilot_root = _make_project(tmpdir)
-            _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+            _write_registered_kit_manifest(cypilot_root, _MANIFEST_V2_AGENT)
 
             src = project_root / "agents" / "my-agent.md"
             src.parent.mkdir(parents=True, exist_ok=True)
@@ -192,7 +201,7 @@ class TestCmdGenerateAgentsV2ManifestPipeline(unittest.TestCase):
         """cmd_generate_agents writes agent files with v2 manifest (no dry-run)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root, cypilot_root = _make_project(tmpdir)
-            _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+            _write_registered_kit_manifest(cypilot_root, _MANIFEST_V2_AGENT)
 
             src = project_root / "agents" / "my-agent.md"
             src.parent.mkdir(parents=True, exist_ok=True)
@@ -217,7 +226,7 @@ class TestCmdGenerateAgentsShowLayers(unittest.TestCase):
         """--show-layers returns 0 with v2 manifest."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root, cypilot_root = _make_project(tmpdir)
-            _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+            _write_registered_kit_manifest(cypilot_root, _MANIFEST_V2_AGENT)
 
             src = project_root / "agents" / "my-agent.md"
             src.parent.mkdir(parents=True, exist_ok=True)
@@ -250,7 +259,7 @@ class TestCmdGenerateAgentsShowLayers(unittest.TestCase):
         """--show-layers in v2 mode outputs provenance report (JSON or text)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root, cypilot_root = _make_project(tmpdir)
-            _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+            _write_registered_kit_manifest(cypilot_root, _MANIFEST_V2_AGENT)
 
             src = project_root / "agents" / "my-agent.md"
             src.parent.mkdir(parents=True, exist_ok=True)
@@ -301,7 +310,7 @@ class TestCmdGenerateAgentsDiscover(unittest.TestCase):
         """--discover in v2 mode re-runs discovery after writing manifest."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root, cypilot_root = _make_project(tmpdir)
-            _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+            _write_registered_kit_manifest(cypilot_root, _MANIFEST_V2_AGENT)
 
             src = project_root / "agents" / "my-agent.md"
             src.parent.mkdir(parents=True, exist_ok=True)
@@ -327,6 +336,63 @@ class TestCmdGenerateAgentsLegacyPath(unittest.TestCase):
             project_root, cypilot_root = _make_project(tmpdir)
             (project_root / ".git").mkdir()
             (project_root / "manifest.toml").write_text(_MANIFEST_V2_AGENT, encoding="utf-8")
+
+            src = project_root / "agents" / "my-agent.md"
+            src.parent.mkdir(parents=True, exist_ok=True)
+            src.write_text("# My Agent\nDo something.", encoding="utf-8")
+
+            ret = cmd_generate_agents([
+                "--root", str(project_root),
+                "--cf-constructor-root", str(cypilot_root),
+                "--agent", "claude",
+                "--dry-run",
+            ])
+
+            self.assertEqual(ret, 0)
+            self.assertFalse((project_root / ".claude" / "agents" / "my-agent.md").exists())
+
+    def test_repo_config_manifest_does_not_enable_v2_pipeline(self):
+        """A Studio config manifest.toml is not used for agent configuration generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_root, cypilot_root = _make_project(tmpdir)
+            _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+
+            src = project_root / "agents" / "my-agent.md"
+            src.parent.mkdir(parents=True, exist_ok=True)
+            src.write_text("# My Agent\nDo something.", encoding="utf-8")
+
+            ret = cmd_generate_agents([
+                "--root", str(project_root),
+                "--cf-constructor-root", str(cypilot_root),
+                "--agent", "claude",
+                "--dry-run",
+            ])
+
+            self.assertEqual(ret, 0)
+            self.assertFalse((project_root / ".claude" / "agents" / "my-agent.md").exists())
+
+    def test_parent_master_manifest_does_not_enable_v2_pipeline(self):
+        """A parent repo manifest.toml is not used for agent configuration generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workspace = Path(tmpdir) / "workspace"
+            workspace.mkdir()
+            (workspace / ".git").mkdir()
+            (workspace / "manifest.toml").write_text(_MANIFEST_V2_AGENT, encoding="utf-8")
+
+            project_root = workspace / "project"
+            project_root.mkdir()
+            (project_root / "AGENTS.md").write_text(_AGENTS_MD, encoding="utf-8")
+            cypilot_root = project_root / ".bootstrap"
+            core = cypilot_root / ".core"
+            (core / "requirements").mkdir(parents=True)
+            (core / "workflows").mkdir(parents=True)
+            (cypilot_root / "config").mkdir(parents=True)
+            skill_dir = core / "skills" / "cypilot"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: cypilot\ndescription: Cypilot\n---\n# Cypilot\n",
+                encoding="utf-8",
+            )
 
             src = project_root / "agents" / "my-agent.md"
             src.parent.mkdir(parents=True, exist_ok=True)
@@ -669,8 +735,8 @@ class TestV2PreviewCountsLegacyWorkflows(unittest.TestCase):
         """
         project_root, cypilot_root = _make_project(tmpdir)
 
-        # Write a v2 manifest with an agent entry
-        _write_manifest(cypilot_root, _MANIFEST_V2_AGENT)
+        # Write a registered kit v2 manifest with an agent entry.
+        _write_registered_kit_manifest(cypilot_root, _MANIFEST_V2_AGENT)
 
         # Write the v2 agent source file
         src = project_root / "agents" / "my-agent.md"

--- a/tests/test_layer_discovery.py
+++ b/tests/test_layer_discovery.py
@@ -438,6 +438,19 @@ class TestDiscoverLayers:
             scopes = [l.scope for l in layers]
             assert "repo" not in scopes
 
+    def test_project_root_manifest_is_not_loaded_as_master_layer(self):
+        """A project-root manifest.toml is ignored unless registered or copied into Studio config."""
+        with TemporaryDirectory() as tmp:
+            repo_root = Path(tmp) / "project"
+            repo_root.mkdir()
+            (repo_root / ".git").mkdir()
+            _write(repo_root / "manifest.toml", _VALID_V2_MANIFEST)
+            cypilot_root = repo_root / ".bootstrap"
+            (cypilot_root / "config").mkdir(parents=True)
+
+            layers = discover_layers(repo_root, cypilot_root)
+            assert [l.scope for l in layers] == []
+
     def test_parse_error_results_in_parse_error_state(self):
         """Parse error at repo manifest results in PARSE_ERROR state layer."""
         with TemporaryDirectory() as tmp:

--- a/tests/test_layer_discovery.py
+++ b/tests/test_layer_discovery.py
@@ -449,7 +449,7 @@ class TestDiscoverLayers:
             (cypilot_root / "config").mkdir(parents=True)
 
             layers = discover_layers(repo_root, cypilot_root)
-            assert [l.scope for l in layers] == []
+            assert [layer.scope for layer in layers] == []
 
     def test_parse_error_results_in_parse_error_state(self):
         """Parse error at repo manifest results in PARSE_ERROR state layer."""


### PR DESCRIPTION
## Summary
- stop generate-agents from treating repo/master manifest layers as inputs for generated agent configurations
- keep v2 agent configuration generation scoped to registered kit manifests
- add regression coverage for project-root, repo config, and parent/master manifests

## Validation
- pytest tests/test_cmd_generate_agents_v2.py -q
- pytest tests/test_layer_discovery.py -q
- make validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * v2 manifest generation now only considers kit-scoped layers and ignores project-root manifests unless registered as a kit; master manifest discovery uses walk-up detection.
* **Tests**
  * Added and updated tests covering manifest discovery, v2 generation flows, and regressions ensuring legacy manifest locations do not enable v2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->