### PR TITLE
Enhance artifact binding functionality in constraints resources

### DIFF
--- a/architecture/features/kit-management.md
+++ b/architecture/features/kit-management.md
@@ -495,7 +495,7 @@ Enables users to install, update, and validate kit packages with interactive fil
 1. [x] - `p1` - Resolve kit directory, verify exists - `inst-resolve-dir`
 2. [x] - `p1` - **Phase 1 — Structural**: load and validate all `kind = "constraints"` resources in manifest order, falling back to legacy `constraints.toml` only for legacy path validation - `inst-structural-check`
 3. [x] - `p1` - **Phase 1b — Manifest resources**: **IF** manifest-driven kit, verify all registered resource paths exist on disk - `inst-verify-resource-paths`
-4. [x] - `p1` - Build synthetic `ArtifactsMeta` from kit's artifacts/ directory - `inst-build-artifacts-meta`
+4. [x] - `p1` - Build synthetic `ArtifactsMeta` from explicit constraints artifact bindings for canonical/core KitModel inputs; use kit `artifacts/` directory only as the legacy layout fallback - `inst-build-artifacts-meta`
 5. [x] - `p1` - **Phase 2 — Templates**: run `self_check` for template/example validation - `inst-template-check`
 6. [x] - `p1` - Build result: aggregate errors, set PASS/FAIL - `inst-build-result`
 
@@ -879,7 +879,7 @@ Enables users to install, update, and validate kit packages with interactive fil
 | `skills/studio/scripts/studio/utils/kit_model.py` | `cpt-studio-algo-kit-model-normalize`, `cpt-studio-algo-kit-canonical-manifest`, `cpt-studio-algo-kit-public-component-generation`, `cpt-studio-algo-kit-tool-permission-risk`, `cpt-studio-algo-kit-manifest-normalize` |
 | `skills/studio/scripts/studio/utils/manifest.py` | legacy manifest adapter, `cpt-studio-algo-kit-manifest-resolve`, `cpt-studio-algo-kit-manifest-source-mapping`, `cpt-studio-algo-kit-variable-resolution` |
 | `skills/studio/scripts/studio/utils/diff_engine.py` | `cpt-studio-algo-kit-file-update`, `cpt-studio-algo-kit-file-enumerate`, `cpt-studio-algo-kit-file-classify`, `cpt-studio-algo-kit-interactive-review`, `cpt-studio-algo-kit-diff-display`, `cpt-studio-algo-kit-conflict-merge`, `cpt-studio-algo-kit-toc-handling`, `cpt-studio-algo-kit-snapshot` |
-| `skills/studio/scripts/studio/commands/validate_kits.py` | `cpt-studio-algo-kit-validate`, `cpt-studio-algo-kit-validate-by-path`, `cpt-studio-flow-kit-validate-cli` |
+| `skills/studio/scripts/studio/commands/validate_kits.py`, `skills/studio/scripts/studio/commands/self_check.py` | `cpt-studio-algo-kit-validate`, `cpt-studio-algo-kit-validate-by-path`, `cpt-studio-flow-kit-validate-cli` |
 | `skills/studio/scripts/studio/commands/adapter_info.py` | `cpt-studio-algo-kit-info-model-output` |
 | `skills/studio/scripts/studio/commands/agents.py` | `cpt-studio-algo-kit-public-component-generation` |
 | `skills/studio/scripts/studio/utils/whatsnew.py` | `cpt-studio-algo-kit-whatsnew-display` |

--- a/architecture/features/kit-management.md
+++ b/architecture/features/kit-management.md
@@ -479,8 +479,9 @@ Enables users to install, update, and validate kit packages with interactive fil
 1. [x] - `p1` - Get context and initialize validation state - `inst-init-context`
 2. [x] - `p1` - **Phase 1 — Structural**: for each registered Studio-format kit, load and validate all `kind = "constraints"` resources in manifest order, falling back to legacy `constraints.toml` only for legacy kits without constraints resources - `inst-structural-check`
 3. [x] - `p1` - **Phase 1b — Resource paths**: for manifest-driven kits, resolve paths to constraints resources, templates, and examples from resource bindings in `core.toml` via `cpt-studio-algo-kit-manifest-resolve` instead of assuming default kit directory structure - `inst-resolve-resource-paths`
-4. [x] - `p1` - **Phase 2 — Templates**: load `artifacts_meta`, run `self_check` for template/example consistency - `inst-template-check`
-5. [x] - `p1` - Build result: aggregate errors, set overall PASS/FAIL status - `inst-build-result`
+4. [x] - `p1` - **Phase 2 — Bound artifact map**: when a loaded kit exposes artifact-kind bindings on a `kind = "constraints"` resource, build self-check input only from those explicit resource IDs; if constraints declare artifact kinds but no template/example bindings are known, skip checking that kind and emit a warning rather than guessing from filenames or resource naming conventions - `inst-manifest-bound-artifact-map`
+5. [x] - `p1` - **Phase 2 — Templates**: load `artifacts_meta`, run `self_check` for template/example consistency - `inst-template-check`
+6. [x] - `p1` - Build result: aggregate errors, set overall PASS/FAIL status - `inst-build-result`
 
 ### Kit Validate by Path
 
@@ -575,6 +576,7 @@ Enables users to install, update, and validate kit packages with interactive fil
 10. [x] - `p1` - Public resources and nested subagents generate agent-facing names as `cf-{kit-slug}-{resource-id}` by default; `prefix_generated_name = false` disables that prefix for a resource or subagent and uses its `id` as-is - `inst-canonical-public-name-prefix`
 11. [x] - `p1` - `generated_targets` defaults to `installed`, accepts an explicit target list or `all`, and controls which agent tools receive public component output - `inst-canonical-generated-targets`
 12. [x] - `p1` - The manifest MUST NOT expose author-facing `binding_path`; effective paths are installation state recorded in `core.toml` - `inst-canonical-no-binding-path`
+13. [x] - `p1` - A `kind = "constraints"` resource MAY declare nested `artifacts.<ARTIFACT_KIND>` bindings whose `template`, `examples`, `rules`, and `checklist` values are resource IDs; these bindings are authoritative for template/example self-check, may be partial, and are invalid on non-constraints resources - `inst-canonical-artifact-bindings`
 
 ### Local Path Install Mode
 
@@ -684,6 +686,7 @@ Enables users to install, update, and validate kit packages with interactive fil
 5. [x] - `p1` - Preserve resource IDs, user-modifiable path defaults, aliases, generated targets, agent configuration, and source provenance wherever they can be inferred deterministically - `inst-normalize-preserve-fields`
 6. [x] - `p1` - Report fields that require user choice rather than guessing, including ambiguous resource kinds, conflicting aliases, missing source files, or unsafe paths - `inst-normalize-report-ambiguity`
 7. [x] - `p1` - Refuse to write a canonical manifest that would reference sources outside the selected kit root unless the user explicitly chooses a safe local registration root and containment passes - `inst-normalize-containment`
+8. [x] - `p1` - Preserve explicit constraints-to-artifact resource bindings when normalizing canonical manifests or installed `core.toml` bindings, without inferring missing template/example links from resource names or package layout - `inst-normalize-artifact-bindings`
 
 **Rollout Phases**:
 1. [x] - `p1` - Add parser/model/converter tests with no install behavior change - `inst-rollout-kitmodel-tests`

--- a/skills/studio/scripts/studio/commands/kit.py
+++ b/skills/studio/scripts/studio/commands/kit.py
@@ -4326,6 +4326,10 @@ def update_kit(
                         f"kit: warning: manifest migration for '{kit_slug}' failed: "
                         f"{_mig_result.get('errors', [])}\n"
                     )
+                    result["version"] = {"status": "failed"}
+                    result["gen"] = {"files_written": 0}
+                    result["errors"] = _mig_result.get("errors", [])
+                    return result
                 installed_kit_entry = _read_kits_from_core_toml(config_dir).get(kit_slug, installed_kit_entry)
             synced_resources = _sync_manifest_resource_bindings(_manifest, config_dir, kit_slug)
             resources_changed = False

--- a/skills/studio/scripts/studio/commands/kit.py
+++ b/skills/studio/scripts/studio/commands/kit.py
@@ -1079,6 +1079,9 @@ def _manifest_resource_bindings(
         kind = str(getattr(res, "kind", "") or "").strip()
         if kind:
             entry["kind"] = kind
+        artifact_bindings = getattr(res, "artifact_bindings", None)
+        if isinstance(artifact_bindings, dict) and artifact_bindings:
+            entry["artifacts"] = artifact_bindings
         entry["public"] = bool(getattr(res, "public", False))
         bindings[res.id] = entry
     return bindings
@@ -1100,6 +1103,9 @@ def _manifest_register_resource_bindings(
         kind = str(getattr(res, "kind", "") or "").strip()
         if kind:
             entry["kind"] = kind
+        artifact_bindings = getattr(res, "artifact_bindings", None)
+        if isinstance(artifact_bindings, dict) and artifact_bindings:
+            entry["artifacts"] = artifact_bindings
         entry["public"] = bool(getattr(res, "public", False))
         bindings[res.id] = entry
     return bindings

--- a/skills/studio/scripts/studio/commands/kit.py
+++ b/skills/studio/scripts/studio/commands/kit.py
@@ -1051,7 +1051,6 @@ def _path_is_within(path: Path, root: Path) -> bool:
     # @cpt-end:cpt-studio-algo-kit-local-path-install-mode:p1:inst-local-register-containment
 
 
-# @cpt-begin:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
 def _manifest_resource_target(
     kit_root: Path,
     res: Any,
@@ -1062,29 +1061,43 @@ def _manifest_resource_target(
     return (kit_root / _resource_install_path(res)).resolve()
 
 
+def _manifest_resource_binding_entry(
+    *,
+    res: Any,
+    path: str,
+) -> Dict[str, Any]:
+    # @cpt-begin:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
+    entry: Dict[str, Any] = {"path": path}
+    kind = str(getattr(res, "kind", "") or "").strip()
+    if kind:
+        entry["kind"] = kind
+    artifact_bindings = getattr(res, "artifact_bindings", None)
+    if isinstance(artifact_bindings, dict) and artifact_bindings:
+        entry["artifacts"] = artifact_bindings
+    entry["public"] = bool(getattr(res, "public", False))
+    return entry
+    # @cpt-end:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
+
+
 def _manifest_resource_bindings(
     studio_dir: Path,
     kit_root: Path,
     resources: List[Any],
     resource_overrides: Dict[str, Path],
 ) -> Dict[str, Dict[str, Any]]:
+    # @cpt-begin:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
     bindings: Dict[str, Dict[str, Any]] = {}
     for res in resources:
-        entry = {
-            "path": _serialize_manifest_binding_path(
+        entry = _manifest_resource_binding_entry(
+            res=res,
+            path=_serialize_manifest_binding_path(
                 _manifest_resource_target(kit_root, res, resource_overrides),
                 studio_dir,
-            )
-        }
-        kind = str(getattr(res, "kind", "") or "").strip()
-        if kind:
-            entry["kind"] = kind
-        artifact_bindings = getattr(res, "artifact_bindings", None)
-        if isinstance(artifact_bindings, dict) and artifact_bindings:
-            entry["artifacts"] = artifact_bindings
-        entry["public"] = bool(getattr(res, "public", False))
+            ),
+        )
         bindings[res.id] = entry
     return bindings
+    # @cpt-end:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
 
 
 def _manifest_register_resource_bindings(
@@ -1092,24 +1105,19 @@ def _manifest_register_resource_bindings(
     kit_source: Path,
     resources: List[Any],
 ) -> Dict[str, Dict[str, Any]]:
+    # @cpt-begin:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
     bindings: Dict[str, Dict[str, Any]] = {}
     for res in resources:
-        entry = {
-            "path": _serialize_manifest_binding_path(
+        entry = _manifest_resource_binding_entry(
+            res=res,
+            path=_serialize_manifest_binding_path(
                 (kit_source / res.source).resolve(),
                 studio_dir,
-            )
-        }
-        kind = str(getattr(res, "kind", "") or "").strip()
-        if kind:
-            entry["kind"] = kind
-        artifact_bindings = getattr(res, "artifact_bindings", None)
-        if isinstance(artifact_bindings, dict) and artifact_bindings:
-            entry["artifacts"] = artifact_bindings
-        entry["public"] = bool(getattr(res, "public", False))
+            ),
+        )
         bindings[res.id] = entry
     return bindings
-# @cpt-end:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
+    # @cpt-end:cpt-studio-algo-kit-manifest-install:p1:inst-manifest-register-bindings
 
 
 # @cpt-begin:cpt-studio-algo-kit-model-normalize:p1:inst-kitmodel-hashes
@@ -2188,7 +2196,7 @@ def migrate_legacy_kit_to_manifest(
         if expected_path.exists():
             # File/directory already on disk — register silently
             binding_path = _serialize_manifest_binding_path(expected_path, studio_dir)
-            resource_bindings[res.id] = {"path": binding_path}
+            resource_bindings[res.id] = _manifest_resource_binding_entry(res=res, path=binding_path)
             migrated_count += 1
             continue
         # @cpt-end:cpt-studio-algo-kit-manifest-legacy-migration:p1:inst-legacy-register-existing
@@ -2215,7 +2223,7 @@ def migrate_legacy_kit_to_manifest(
 
         _copy_manifest_resource(kit_source, res, target_abs)
         binding_path = _serialize_manifest_binding_path(target_abs, studio_dir)
-        resource_bindings[res.id] = {"path": binding_path}
+        resource_bindings[res.id] = _manifest_resource_binding_entry(res=res, path=binding_path)
         new_count += 1
     # @cpt-end:cpt-studio-algo-kit-manifest-legacy-migration:p1:inst-legacy-prompt-new
     # @cpt-end:cpt-studio-algo-kit-manifest-legacy-migration:p1:inst-legacy-foreach-resource
@@ -4051,6 +4059,11 @@ def _sync_manifest_resource_bindings(
         if kind:
             merged[res.id]["kind"] = kind
         merged[res.id]["public"] = bool(getattr(res, "public", False))
+        artifact_bindings = getattr(res, "artifact_bindings", None)
+        if isinstance(artifact_bindings, dict) and artifact_bindings:
+            merged[res.id]["artifacts"] = artifact_bindings
+        else:
+            merged[res.id].pop("artifacts", None)
     return merged
 # @cpt-end:cpt-studio-algo-kit-update:p1:inst-sync-manifest-bindings
 
@@ -4303,7 +4316,38 @@ def update_kit(
             and not _authority_commit_changed(authority_metadata, installed_kit_entry)
             and not _risk_changed
         ):
-            result["version"] = {"status": "current"}
+            if _manifest is not None and not installed_kit_entry.get("resources"):
+                _mig_result = migrate_legacy_kit_to_manifest(
+                    source_dir, studio_dir, kit_slug, interactive=interactive,
+                )
+                result["manifest_migration"] = _mig_result
+                if _mig_result.get("status") == "FAIL":
+                    sys.stderr.write(
+                        f"kit: warning: manifest migration for '{kit_slug}' failed: "
+                        f"{_mig_result.get('errors', [])}\n"
+                    )
+                installed_kit_entry = _read_kits_from_core_toml(config_dir).get(kit_slug, installed_kit_entry)
+            synced_resources = _sync_manifest_resource_bindings(_manifest, config_dir, kit_slug)
+            resources_changed = False
+            if synced_resources is not None:
+                current_resources = installed_kit_entry.get("resources", {})
+                resources_changed = current_resources != synced_resources
+                if resources_changed:
+                    registration_errors = _register_kit_in_core_toml(
+                        config_dir,
+                        kit_slug,
+                        source_version,
+                        studio_dir,
+                        source=source or str(installed_kit_entry.get("source") or ""),
+                        resources=synced_resources,
+                        kit_path=_resolve_manifest_kit_root_rel(_manifest, synced_resources, kit_slug),
+                    )
+                    if registration_errors:
+                        result["version"] = {"status": "failed"}
+                        result["gen"] = {"files_written": 0}
+                        result["errors"] = registration_errors
+                        return result
+            result["version"] = {"status": "updated" if resources_changed else "current"}
             result["gen"] = {"files_written": 0}
             authority_source_type = str(authority_metadata.get("source_type") or "") if authority_metadata else ""
             authority_freshness = str(authority_metadata.get("freshness") or "") if authority_metadata else ""

--- a/skills/studio/scripts/studio/commands/self_check.py
+++ b/skills/studio/scripts/studio/commands/self_check.py
@@ -39,7 +39,7 @@ def run_self_check_from_meta(
     It does NOT do studio/project discovery.
     """
     # @cpt-end:cpt-studio-flow-developer-experience-self-check:p1:inst-user-self-check
-    from ..utils.constraints import load_constraints_toml
+    from ..utils.constraints import load_constraints_files, load_constraints_toml
 
     # @cpt-begin:cpt-studio-algo-developer-experience-self-check:p1:inst-validate-headings
     def _check_template_constraints_consistency(
@@ -50,6 +50,7 @@ def run_self_check_from_meta(
         kit_base: Path,
         kit_constraints,
         artifacts_meta: ArtifactsMeta,
+        constraints_path: Optional[Path] = None,
     ) -> Dict[str, List[Dict[str, object]]]:
         errs: List[Dict[str, object]] = []
         warns: List[Dict[str, object]] = []
@@ -65,11 +66,11 @@ def run_self_check_from_meta(
         if constraints_for_kind is None:
             return {"errors": errs, "warnings": warns}
 
-        constraints_path = None
-        try:
-            constraints_path = (kit_base / "constraints.toml").resolve()
-        except OSError:
-            constraints_path = None
+        if constraints_path is None:
+            try:
+                constraints_path = (kit_base / "constraints.toml").resolve()
+            except OSError:
+                constraints_path = None
 
         # 1) Heading contract must hold for templates too.
         rep = validate_headings_contract(
@@ -392,14 +393,31 @@ def run_self_check_from_meta(
         artifacts_dir = kit_base / "artifacts"
         # NOTE: With explicit kit.artifacts mapping, artifacts_dir may be absent.
 
-        kit_constraints, kit_constraint_errs = load_constraints_toml(kit_base)
+        explicit_constraints_paths = [
+            Path(p)
+            for p in (getattr(kit_obj, "constraints_paths", None) or [])
+            if p
+        ]
+        explicit_constraints_path = getattr(kit_obj, "constraints_path", None)
+        if explicit_constraints_path and not explicit_constraints_paths:
+            explicit_constraints_paths = [Path(explicit_constraints_path)]
+
+        constraints_path = explicit_constraints_paths[0] if explicit_constraints_paths else None
+        if explicit_constraints_paths:
+            kit_constraints, kit_constraint_errs = load_constraints_files(explicit_constraints_paths)
+        else:
+            kit_constraints, kit_constraint_errs = load_constraints_toml(kit_base)
+            try:
+                constraints_path = (kit_base / "constraints.toml").resolve()
+            except OSError:
+                constraints_path = None
         if kit_constraint_errs:
             results.append({
                 "kit": kit_id,
                 "kind": None,
                 "status": "FAIL",
                 "error_count": len(kit_constraint_errs),
-                "errors": [constraints_error("constraints", "Invalid constraints.toml", path=(kit_base / "constraints.toml"), line=1, errors=list(kit_constraint_errs))],
+                "errors": [constraints_error("constraints", "Invalid constraints.toml", path=(constraints_path or (kit_base / "constraints.toml")), line=1, errors=list(kit_constraint_errs))],
             })
             overall_status = "FAIL"
             kits_checked += 1
@@ -426,6 +444,9 @@ def run_self_check_from_meta(
             kind = str(kind).strip()
             if not kind:
                 continue
+            # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
+            explicit_kind = bool(isinstance(raw_map, dict) and str(kind).upper() in {str(k).strip().upper() for k in raw_map.keys()})
+            # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
             template_path = None
             examples_dir = None
@@ -435,27 +456,31 @@ def run_self_check_from_meta(
                 # resolution.
                 try:
                     rel = kit_obj.get_template_path(kind)
-                    candidate = (adapter_dir / rel).resolve()
-                    if not candidate.is_file():
-                        candidate = (project_root / rel).resolve()
-                    template_path = candidate
+                    if str(rel or "").strip():
+                        candidate = (adapter_dir / rel).resolve()
+                        if not candidate.is_file():
+                            candidate = (project_root / rel).resolve()
+                        template_path = candidate
                 except (OSError, ValueError, KeyError):
                     template_path = None
                 try:
                     rel = kit_obj.get_examples_path(kind)
-                    candidate = (adapter_dir / rel).resolve()
-                    if not candidate.exists():
-                        candidate = (project_root / rel).resolve()
-                    examples_dir = candidate
+                    if str(rel or "").strip():
+                        candidate = (adapter_dir / rel).resolve()
+                        if not candidate.exists():
+                            candidate = (project_root / rel).resolve()
+                        examples_dir = candidate
                 except (OSError, ValueError, KeyError):
                     examples_dir = None
 
             # Fallback to legacy layout if explicit paths are unavailable.
+            # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
             kind_dir = artifacts_dir / kind
-            if template_path is None:
+            if template_path is None and not explicit_kind:
                 template_path = (kind_dir / "template.md").resolve()
-            if examples_dir is None:
+            if examples_dir is None and not explicit_kind:
                 examples_dir = (kind_dir / "examples").resolve()
+            # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
             example_paths: List[Path] = []
             try:
@@ -493,6 +518,7 @@ def run_self_check_from_meta(
                     kit_base=kit_base,
                     kit_constraints=kit_constraints,
                     artifacts_meta=artifacts_meta,
+                    constraints_path=constraints_path,
                 )
                 errs.extend(list(trep.get("errors", []) or []))
                 warns.extend(list(trep.get("warnings", []) or []))
@@ -503,15 +529,6 @@ def run_self_check_from_meta(
                 constraints_for_kind = None
                 if kit_constraints is not None and getattr(kit_constraints, "by_kind", None) and str(kind).upper() in kit_constraints.by_kind:
                     constraints_for_kind = kit_constraints.by_kind[str(kind).upper()]
-                constraints_path = None
-                try:
-                    # NOTE: This assumes self-check constraints live at
-                    # kit_base / "constraints.toml". If self-check is unified
-                    # with loaded-kit semantics, use the shared authoritative
-                    # constraints-path resolver here.
-                    constraints_path = (kit_base / "constraints.toml").resolve()
-                except OSError:
-                    constraints_path = None
                 for example_path in example_paths:
                     rep = validate_artifact_file(
                         artifact_path=example_path,
@@ -548,5 +565,3 @@ def run_self_check_from_meta(
     # @cpt-begin:cpt-studio-flow-developer-experience-self-check:p1:inst-return-self-check
     return (0 if overall_status == "PASS" else 2), out
     # @cpt-end:cpt-studio-flow-developer-experience-self-check:p1:inst-return-self-check
-
-

--- a/skills/studio/scripts/studio/commands/validate_kits.py
+++ b/skills/studio/scripts/studio/commands/validate_kits.py
@@ -9,11 +9,183 @@ consistency against constraints.
 # @cpt-begin:cpt-studio-flow-kit-validate-cli:p1:inst-validate-kits-imports
 import argparse
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..utils.constraints import error as constraints_error
 from ..utils.ui import ui
 # @cpt-end:cpt-studio-flow-kit-validate-cli:p1:inst-validate-kits-imports
+
+# @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
+def _constraint_artifact_bindings(loaded_kit: Any) -> Dict[str, Dict[str, str]]:
+    """Return explicit artifact-kind bindings declared on constraints resources."""
+    entries = getattr(loaded_kit, "resource_entries", None)
+    if not isinstance(entries, dict):
+        return {}
+    artifact_bindings: Dict[str, Dict[str, str]] = {}
+    for _resource_id, raw_entry in sorted(entries.items()):
+        if not isinstance(raw_entry, dict):
+            continue
+        if str(raw_entry.get("kind", "") or "").strip().lower() != "constraints":
+            continue
+        raw_artifacts = raw_entry.get("artifacts")
+        if not isinstance(raw_artifacts, dict):
+            continue
+        for kind, raw_spec in raw_artifacts.items():
+            if not isinstance(raw_spec, dict):
+                continue
+            kind_s = str(kind or "").strip().upper()
+            if not kind_s:
+                continue
+            spec = artifact_bindings.setdefault(kind_s, {})
+            for role in ("template", "rules", "checklist", "examples", "example"):
+                raw_ref = raw_spec.get(role)
+                if isinstance(raw_ref, str) and raw_ref.strip():
+                    spec["examples" if role == "example" else role] = raw_ref.strip()
+    return artifact_bindings
+
+
+def _constraints_binding_path(loaded_kit: Any, resource_bindings: Dict[str, str]) -> str:
+    entries = getattr(loaded_kit, "resource_entries", None)
+    if isinstance(entries, dict):
+        for resource_id, raw_entry in sorted(entries.items()):
+            if not isinstance(raw_entry, dict):
+                continue
+            if str(raw_entry.get("kind", "") or "").strip().lower() == "constraints":
+                path = _resource_binding_path(resource_bindings, str(resource_id))
+                if path:
+                    return path
+    return _resource_binding_path(resource_bindings, "constraints")
+
+
+def _known_constraint_kinds(loaded_kit: Any) -> Set[str]:
+    constraints = getattr(loaded_kit, "constraints", None)
+    return {str(kind).strip().upper() for kind in (getattr(constraints, "by_kind", {}) or {}).keys() if str(kind).strip()}
+
+
+def _resource_binding_path(resource_bindings: Dict[str, str], resource_id: str) -> str:
+    return str(resource_bindings.get(resource_id, "") or "").strip()
+
+
+def _missing_bound_artifact_warnings(
+    *,
+    kit_id: str,
+    known_kinds: Set[str],
+    artifacts: Dict[str, Dict[str, str]],
+) -> List[Dict[str, object]]:
+    results: List[Dict[str, object]] = []
+    for kind in sorted(known_kinds):
+        spec = artifacts.get(kind, {})
+        missing_roles = [
+            role
+            for role in ("template", "examples")
+            if not str(spec.get(role, "") or "").strip()
+        ]
+        if not missing_roles:
+            continue
+        warning = constraints_error(
+            "template",
+            "Constraints declare artifact kind but no manifest resource binding is available for template/example self-check",
+            path=None,
+            line=1,
+            kit_id=str(kit_id),
+            artifact_kind=kind,
+            missing_bindings=missing_roles,
+        )
+        results.append({
+            "kit": str(kit_id),
+            "kind": kind,
+            "example_path": None,
+            "example_paths": [],
+            "examples_checked": 0,
+            "status": "PASS",
+            "error_count": 0,
+            "warning_count": 1,
+            "warnings": [warning],
+        })
+    return results
+
+
+def _synthesized_meta_from_resource_bindings(
+    *,
+    base_meta: Any,
+    adapter_dir: Path,
+    kit_id: str,
+    loaded_kit: Any,
+) -> Tuple[Optional[Any], List[Dict[str, object]]]:
+    """Build self-check metadata from loaded manifest resource bindings."""
+    from ..utils.artifacts_meta import ArtifactsMeta, Kit
+
+    rb = getattr(loaded_kit, "resource_bindings", None)
+    if not isinstance(rb, dict) or not rb:
+        return None, []
+
+    artifact_bindings = _constraint_artifact_bindings(loaded_kit)
+    artifacts: Dict[str, Dict[str, str]] = {}
+    for kind, binding_spec in sorted(artifact_bindings.items()):
+        spec: Dict[str, str] = {}
+        template = _resource_binding_path(rb, str(binding_spec.get("template", "") or ""))
+        if not template:
+            template = ""
+        if template:
+            spec["template"] = template
+        example_path = _resource_binding_path(rb, str(binding_spec.get("examples", "") or ""))
+        if example_path:
+            spec["examples"] = example_path
+        if spec:
+            artifacts[kind] = spec
+
+    warnings = _missing_bound_artifact_warnings(
+        kit_id=kit_id,
+        known_kinds=_known_constraint_kinds(loaded_kit),
+        artifacts=artifacts,
+    )
+    if not artifacts:
+        return None, warnings
+
+    constraints_path = _constraints_binding_path(loaded_kit, rb)
+    if constraints_path:
+        kit_base = Path(constraints_path).parent
+    else:
+        kit_root = getattr(loaded_kit, "kit_root", None)
+        kit_base = kit_root if isinstance(kit_root, Path) else adapter_dir
+
+    kit = Kit(
+        kit_id=kit_id,
+        format="CFS",
+        path=str(kit_base),
+        artifacts=artifacts,
+    )
+    if constraints_path:
+        setattr(kit, "constraints_path", Path(constraints_path))
+        setattr(kit, "constraints_paths", [Path(constraints_path)])
+
+    return ArtifactsMeta(
+        version=str(getattr(base_meta, "version", "1.0") or "1.0"),
+        project_root=str(getattr(base_meta, "project_root", "..") or ".."),
+        kits={kit_id: kit},
+        systems=list(getattr(base_meta, "systems", []) or []),
+        ignore=list(getattr(base_meta, "ignore", []) or []),
+    ), warnings
+
+
+def _merge_self_check_report(
+    target: Dict[str, object],
+    source: Dict[str, object],
+) -> None:
+    """Merge one self-check report into an aggregate report."""
+    if not source:
+        return
+    target.setdefault("results", [])
+    target["templates_checked"] = int(target.get("templates_checked", 0) or 0) + int(source.get("templates_checked", 0) or 0)
+    target["kits_checked"] = int(target.get("kits_checked", 0) or 0) + int(source.get("kits_checked", 0) or 0)
+    if source.get("status") == "FAIL":
+        target["status"] = "FAIL"
+    elif "status" not in target:
+        target["status"] = source.get("status", "PASS")
+    results = source.get("results", [])
+    if isinstance(results, list):
+        target["results"].extend(results)  # type: ignore[union-attr]
+# @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
 
 # @cpt-dod:cpt-studio-dod-kit-validate:p1
@@ -130,19 +302,56 @@ def run_validate_kits(
     # @cpt-end:cpt-studio-flow-developer-experience-self-check:p1:inst-load-registry
     if artifacts_meta is not None and not meta_err:
         from .self_check import run_self_check_from_meta
-        _, sc_out = run_self_check_from_meta(
-            project_root=project_root,
-            adapter_dir=adapter_dir,
-            artifacts_meta=artifacts_meta,
-            kit_filter=kit_filter,
-            verbose=verbose,
-        )
-        self_check_report = sc_out
-        sc_results = sc_out.get("results", [])
-        for r in sc_results:
-            if r.get("status") == "FAIL":
+        manifest_checked_kits: Set[str] = set()
+        for kit_id, loaded_kit in (ctx.kits or {}).items():
+            kit_id_str = str(kit_id)
+            if kit_filter and kit_id_str != str(kit_filter):
+                continue
+            bound_meta, binding_warnings = _synthesized_meta_from_resource_bindings(
+                base_meta=artifacts_meta,
+                adapter_dir=adapter_dir,
+                kit_id=kit_id_str,
+                loaded_kit=loaded_kit,
+            )
+            if binding_warnings:
+                self_check_report.setdefault("results", [])
+                self_check_report["results"].extend(binding_warnings)  # type: ignore[union-attr]
+                self_check_report.setdefault("status", "PASS")
+                self_check_report.setdefault("templates_checked", 0)
+                self_check_report.setdefault("kits_checked", 0)
+            if getattr(loaded_kit, "resource_bindings", None):
+                manifest_checked_kits.add(kit_id_str)
+            if bound_meta is None:
+                continue
+            _, sc_out = run_self_check_from_meta(
+                project_root=project_root,
+                adapter_dir=adapter_dir,
+                artifacts_meta=bound_meta,
+                kit_filter=kit_id_str,
+                verbose=verbose,
+            )
+            _merge_self_check_report(self_check_report, sc_out)
+
+        for kit_id in (artifacts_meta.kits or {}).keys():
+            kit_id_str = str(kit_id)
+            if kit_filter and kit_id_str != str(kit_filter):
+                continue
+            if kit_id_str in manifest_checked_kits:
+                continue
+            _, sc_out = run_self_check_from_meta(
+                project_root=project_root,
+                adapter_dir=adapter_dir,
+                artifacts_meta=artifacts_meta,
+                kit_filter=kit_id_str,
+                verbose=verbose,
+            )
+            _merge_self_check_report(self_check_report, sc_out)
+
+        for r in self_check_report.get("results", []):
+            if isinstance(r, dict) and r.get("status") == "FAIL":
                 sc_errs = r.get("errors", [])
-                all_errors.extend(sc_errs)
+                if isinstance(sc_errs, list):
+                    all_errors.extend(sc_errs)
     # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-template-check
 
     # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-build-result

--- a/skills/studio/scripts/studio/commands/validate_kits.py
+++ b/skills/studio/scripts/studio/commands/validate_kits.py
@@ -9,15 +9,16 @@ consistency against constraints.
 # @cpt-begin:cpt-studio-flow-kit-validate-cli:p1:inst-validate-kits-imports
 import argparse
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..utils.constraints import error as constraints_error
 from ..utils.ui import ui
 # @cpt-end:cpt-studio-flow-kit-validate-cli:p1:inst-validate-kits-imports
 
-# @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 def _constraint_artifact_bindings(loaded_kit: Any) -> Dict[str, Dict[str, str]]:
     """Return explicit artifact-kind bindings declared on constraints resources."""
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
     entries = getattr(loaded_kit, "resource_entries", None)
     if not isinstance(entries, dict):
         return {}
@@ -42,9 +43,11 @@ def _constraint_artifact_bindings(loaded_kit: Any) -> Dict[str, Dict[str, str]]:
                 if isinstance(raw_ref, str) and raw_ref.strip():
                     spec["examples" if role == "example" else role] = raw_ref.strip()
     return artifact_bindings
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
 
 def _constraints_binding_path(loaded_kit: Any, resource_bindings: Dict[str, str]) -> str:
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
     entries = getattr(loaded_kit, "resource_entries", None)
     if isinstance(entries, dict):
         for resource_id, raw_entry in sorted(entries.items()):
@@ -55,15 +58,20 @@ def _constraints_binding_path(loaded_kit: Any, resource_bindings: Dict[str, str]
                 if path:
                     return path
     return _resource_binding_path(resource_bindings, "constraints")
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
 
 def _known_constraint_kinds(loaded_kit: Any) -> Set[str]:
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
     constraints = getattr(loaded_kit, "constraints", None)
     return {str(kind).strip().upper() for kind in (getattr(constraints, "by_kind", {}) or {}).keys() if str(kind).strip()}
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
 
 def _resource_binding_path(resource_bindings: Dict[str, str], resource_id: str) -> str:
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
     return str(resource_bindings.get(resource_id, "") or "").strip()
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
 
 def _missing_bound_artifact_warnings(
@@ -72,15 +80,11 @@ def _missing_bound_artifact_warnings(
     known_kinds: Set[str],
     artifacts: Dict[str, Dict[str, str]],
 ) -> List[Dict[str, object]]:
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
     results: List[Dict[str, object]] = []
     for kind in sorted(known_kinds):
         spec = artifacts.get(kind, {})
-        missing_roles = [
-            role
-            for role in ("template", "examples")
-            if not str(spec.get(role, "") or "").strip()
-        ]
-        if not missing_roles:
+        if str(spec.get("template", "") or "").strip() or str(spec.get("examples", "") or "").strip():
             continue
         warning = constraints_error(
             "template",
@@ -89,7 +93,7 @@ def _missing_bound_artifact_warnings(
             line=1,
             kit_id=str(kit_id),
             artifact_kind=kind,
-            missing_bindings=missing_roles,
+            missing_bindings=["template", "examples"],
         )
         results.append({
             "kit": str(kit_id),
@@ -103,6 +107,48 @@ def _missing_bound_artifact_warnings(
             "warnings": [warning],
         })
     return results
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
+
+
+def _constraints_binding_paths(
+    loaded_kit: Any,
+    resource_bindings: Dict[str, str],
+) -> List[Path]:
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
+    paths: List[Path] = []
+    loaded_paths = getattr(loaded_kit, "constraints_paths", None)
+    if isinstance(loaded_paths, list):
+        for path in loaded_paths:
+            if isinstance(path, Path):
+                paths.append(path)
+            elif isinstance(path, str) and path.strip():
+                paths.append(Path(path))
+
+    entries = getattr(loaded_kit, "resource_entries", None)
+    if isinstance(entries, dict):
+        for resource_id, raw_entry in sorted(entries.items()):
+            if not isinstance(raw_entry, dict):
+                continue
+            if str(raw_entry.get("kind", "") or "").strip().lower() != "constraints":
+                continue
+            path = _resource_binding_path(resource_bindings, str(resource_id))
+            if path:
+                paths.append(Path(path))
+
+    fallback = _resource_binding_path(resource_bindings, "constraints")
+    if fallback:
+        paths.append(Path(fallback))
+
+    unique: List[Path] = []
+    seen: Set[str] = set()
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
 
 def _synthesized_meta_from_resource_bindings(
@@ -113,6 +159,7 @@ def _synthesized_meta_from_resource_bindings(
     loaded_kit: Any,
 ) -> Tuple[Optional[Any], List[Dict[str, object]]]:
     """Build self-check metadata from loaded manifest resource bindings."""
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
     from ..utils.artifacts_meta import ArtifactsMeta, Kit
 
     rb = getattr(loaded_kit, "resource_bindings", None)
@@ -155,9 +202,11 @@ def _synthesized_meta_from_resource_bindings(
         path=str(kit_base),
         artifacts=artifacts,
     )
+    constraints_paths = _constraints_binding_paths(loaded_kit, rb)
     if constraints_path:
         setattr(kit, "constraints_path", Path(constraints_path))
-        setattr(kit, "constraints_paths", [Path(constraints_path)])
+    if constraints_paths:
+        setattr(kit, "constraints_paths", constraints_paths)
 
     return ArtifactsMeta(
         version=str(getattr(base_meta, "version", "1.0") or "1.0"),
@@ -166,6 +215,53 @@ def _synthesized_meta_from_resource_bindings(
         systems=list(getattr(base_meta, "systems", []) or []),
         ignore=list(getattr(base_meta, "ignore", []) or []),
     ), warnings
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
+
+
+def _synthesized_meta_from_kit_model(
+    *,
+    base_meta: Any,
+    kit_dir: Path,
+    kit_id: str,
+    model: Any,
+    constraints: Any,
+) -> Tuple[Optional[Any], List[Dict[str, object]]]:
+    """Build self-check metadata from a standalone canonical KitModel."""
+    # @cpt-begin:cpt-studio-algo-kit-validate-by-path:p1:inst-build-artifacts-meta
+    resource_bindings: Dict[str, str] = {}
+    resource_entries: Dict[str, Dict[str, object]] = {}
+    constraints_paths: List[Path] = []
+    for resource in getattr(model, "resources", []) or []:
+        resource_id = str(getattr(resource, "id", "") or "").strip()
+        source = str(getattr(resource, "source", "") or "").strip()
+        if not resource_id or not source:
+            continue
+        resource_path = (kit_dir / source).resolve()
+        resource_bindings[resource_id] = str(resource_path)
+        entry: Dict[str, object] = {
+            "kind": str(getattr(resource, "kind", "") or "").strip(),
+        }
+        if entry["kind"].lower() == "constraints":
+            constraints_paths.append(resource_path)
+        artifact_bindings = getattr(resource, "artifact_bindings", None)
+        if isinstance(artifact_bindings, dict) and artifact_bindings:
+            entry["artifacts"] = artifact_bindings
+        resource_entries[resource_id] = entry
+
+    loaded_kit = SimpleNamespace(
+        resource_bindings=resource_bindings,
+        resource_entries=resource_entries,
+        constraints=constraints,
+        constraints_paths=constraints_paths,
+        kit_root=kit_dir,
+    )
+    return _synthesized_meta_from_resource_bindings(
+        base_meta=base_meta,
+        adapter_dir=kit_dir.parent,
+        kit_id=kit_id,
+        loaded_kit=loaded_kit,
+    )
+    # @cpt-end:cpt-studio-algo-kit-validate-by-path:p1:inst-build-artifacts-meta
 
 
 def _merge_self_check_report(
@@ -173,6 +269,7 @@ def _merge_self_check_report(
     source: Dict[str, object],
 ) -> None:
     """Merge one self-check report into an aggregate report."""
+    # @cpt-begin:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
     if not source:
         return
     target.setdefault("results", [])
@@ -185,7 +282,7 @@ def _merge_self_check_report(
     results = source.get("results", [])
     if isinstance(results, list):
         target["results"].extend(results)  # type: ignore[union-attr]
-# @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
+    # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-manifest-bound-artifact-map
 
 
 # @cpt-dod:cpt-studio-dod-kit-validate:p1
@@ -514,42 +611,71 @@ def _validate_kit_by_path(kit_path: Path, *, verbose: bool = False) -> Tuple[int
 
     # @cpt-begin:cpt-studio-algo-kit-validate-by-path:p1:inst-build-artifacts-meta
     # ── Phase 2: Template & example validation ────────────────────────
-    # Build a synthetic ArtifactsMeta so run_self_check_from_meta can work
-    artifacts_dict: Dict[str, Dict[str, str]] = {}
-    artifacts_dir = kit_dir / "artifacts"
-    if artifacts_dir.is_dir():
-        for kind_dir in sorted(artifacts_dir.iterdir()):
-            if not kind_dir.is_dir():
-                continue
-            kind = kind_dir.name
-            tpl = kind_dir / "template.md"
-            examples = kind_dir / "examples"
-            if tpl.is_file():
-                artifacts_dict[kind] = {
-                    "template": str(tpl),
-                    "examples": str(examples),  # path may not exist; self_check handles that
-                }
-
-    meta = ArtifactsMeta.from_dict({
+    base_meta = ArtifactsMeta.from_dict({
         "version": "1.1",
         "project_root": str(kit_dir.parent),
-        "kits": {slug: {"format": "CFS", "path": str(kit_dir), "artifacts": artifacts_dict}},
+        "kits": {slug: {"format": "CFS", "path": str(kit_dir)}},
     })
+    meta = base_meta
+    binding_warnings: List[Dict[str, object]] = []
+    model_source = str(getattr(model, "manifest_source", "") or "") if model is not None else ""
+    if model is not None and model_source in {"canonical", "core"}:
+        bound_meta, binding_warnings = _synthesized_meta_from_kit_model(
+            base_meta=base_meta,
+            kit_dir=kit_dir,
+            kit_id=slug,
+            model=model,
+            constraints=_kc,
+        )
+        meta = bound_meta
+    else:
+        # Legacy package-layout fallback. Canonical manifests must use explicit
+        # constraints artifact bindings instead of this directory convention.
+        artifacts_dict: Dict[str, Dict[str, str]] = {}
+        artifacts_dir = kit_dir / "artifacts"
+        if artifacts_dir.is_dir():
+            for kind_dir in sorted(artifacts_dir.iterdir()):
+                if not kind_dir.is_dir():
+                    continue
+                kind = kind_dir.name
+                tpl = kind_dir / "template.md"
+                examples = kind_dir / "examples"
+                if tpl.is_file():
+                    artifacts_dict[kind] = {
+                        "template": str(tpl),
+                        "examples": str(examples),  # path may not exist; self_check handles that
+                    }
+
+        meta = ArtifactsMeta.from_dict({
+            "version": "1.1",
+            "project_root": str(kit_dir.parent),
+            "kits": {slug: {"format": "CFS", "path": str(kit_dir), "artifacts": artifacts_dict}},
+        })
     # @cpt-end:cpt-studio-algo-kit-validate-by-path:p1:inst-build-artifacts-meta
 
     # @cpt-begin:cpt-studio-algo-kit-validate-by-path:p1:inst-template-check
     self_check_report: Dict[str, object] = {}
     if not kc_errs:  # Only run template checks if constraints parsed OK
         from .self_check import run_self_check_from_meta
-        _, sc_out = run_self_check_from_meta(
-            project_root=kit_dir.parent,
-            adapter_dir=kit_dir.parent,
-            artifacts_meta=meta,
-            kit_filter=slug,
-            verbose=verbose,
-        )
-        self_check_report = sc_out
-        for r in sc_out.get("results", []):
+        if binding_warnings:
+            self_check_report = {
+                "status": "PASS",
+                "project_root": kit_dir.parent.as_posix(),
+                "studio_dir": kit_dir.parent.as_posix(),
+                "kits_checked": 0,
+                "templates_checked": 0,
+                "results": list(binding_warnings),
+            }
+        if meta is not None:
+            _, sc_out = run_self_check_from_meta(
+                project_root=kit_dir.parent,
+                adapter_dir=kit_dir.parent,
+                artifacts_meta=meta,
+                kit_filter=slug,
+                verbose=verbose,
+            )
+            _merge_self_check_report(self_check_report, sc_out)
+        for r in self_check_report.get("results", []):
             if r.get("status") == "FAIL":
                 all_errors.extend(r.get("errors", []))
     # @cpt-end:cpt-studio-algo-kit-validate-by-path:p1:inst-template-check

--- a/skills/studio/scripts/studio/commands/validate_kits.py
+++ b/skills/studio/scripts/studio/commands/validate_kits.py
@@ -181,9 +181,13 @@ def _synthesized_meta_from_resource_bindings(
         if spec:
             artifacts[kind] = spec
 
+    known_kinds = _known_constraint_kinds(loaded_kit)
+    for kind in sorted(known_kinds):
+        artifacts.setdefault(kind, {})
+
     warnings = _missing_bound_artifact_warnings(
         kit_id=kit_id,
-        known_kinds=_known_constraint_kinds(loaded_kit),
+        known_kinds=known_kinds,
         artifacts=artifacts,
     )
     if not artifacts:

--- a/skills/studio/scripts/studio/utils/artifacts_meta.py
+++ b/skills/studio/scripts/studio/utils/artifacts_meta.py
@@ -86,10 +86,13 @@ class Kit:
                     continue
                 if not isinstance(spec, dict):
                     continue
-                tpl = spec.get("template")
-                ex = spec.get("examples")
-                if isinstance(tpl, str) and tpl.strip() and isinstance(ex, str) and ex.strip():
-                    artifacts[kind.strip().upper()] = {"template": tpl.strip(), "examples": ex.strip()}
+                item: Dict[str, str] = {}
+                for key in ("template", "examples", "rules", "checklist"):
+                    value = spec.get(key)
+                    if isinstance(value, str) and value.strip():
+                        item[key] = value.strip()
+                if item:
+                    artifacts[kind.strip().upper()] = item
 
         raw_source = (data or {}).get("source", None)
         source = str(raw_source).strip() if isinstance(raw_source, str) and str(raw_source).strip() else None
@@ -123,6 +126,7 @@ class Kit:
             tpl = (self.artifacts.get(k) or {}).get("template")
             if isinstance(tpl, str) and tpl.strip():
                 return self._substitute_registry_tokens(tpl.strip())
+            return ""
         # Backward compatible default: {path}/artifacts/{KIND}/template.md
         return f"{self.path.rstrip('/')}/artifacts/{kind}/template.md"
 
@@ -133,6 +137,7 @@ class Kit:
             ex = (self.artifacts.get(k) or {}).get("examples")
             if isinstance(ex, str) and ex.strip():
                 return self._substitute_registry_tokens(ex.strip())
+            return ""
         # Backward compatible default: {path}/artifacts/{KIND}/examples
         return f"{self.path.rstrip('/')}/artifacts/{kind}/examples"
 

--- a/skills/studio/scripts/studio/utils/artifacts_meta.py
+++ b/skills/studio/scripts/studio/utils/artifacts_meta.py
@@ -119,25 +119,25 @@ class Kit:
         out = out.replace(_TOKEN_PROJECT_ROOT, ".")
         return out
 
-    def get_template_path(self, kind: str) -> str:
+    def get_template_path(self, kind: str) -> Optional[str]:
         """Get template file path for a given artifact kind."""
         k = str(kind or "").strip().upper()
         if self.artifacts and k in self.artifacts:
             tpl = (self.artifacts.get(k) or {}).get("template")
             if isinstance(tpl, str) and tpl.strip():
                 return self._substitute_registry_tokens(tpl.strip())
-            return ""
+            return None
         # Backward compatible default: {path}/artifacts/{KIND}/template.md
         return f"{self.path.rstrip('/')}/artifacts/{kind}/template.md"
 
-    def get_examples_path(self, kind: str) -> str:
+    def get_examples_path(self, kind: str) -> Optional[str]:
         """Get examples directory path for a given artifact kind."""
         k = str(kind or "").strip().upper()
         if self.artifacts and k in self.artifacts:
             ex = (self.artifacts.get(k) or {}).get("examples")
             if isinstance(ex, str) and ex.strip():
                 return self._substitute_registry_tokens(ex.strip())
-            return ""
+            return None
         # Backward compatible default: {path}/artifacts/{KIND}/examples
         return f"{self.path.rstrip('/')}/artifacts/{kind}/examples"
 

--- a/skills/studio/scripts/studio/utils/context.py
+++ b/skills/studio/scripts/studio/utils/context.py
@@ -39,6 +39,7 @@ class LoadedKit:
     kit_root: Optional[Path] = None
     constraints_path: Optional[Path] = None
     constraints_paths: Optional[List[Path]] = None
+    resource_entries: Optional[Dict[str, object]] = None
 
 @dataclass
 class StudioContext:
@@ -360,6 +361,7 @@ def _load_single_kit(kit_id, kit, adapter_dir, project_root):
         kit_root=kit_root,
         constraints_path=resolved_constraints_path,
         constraints_paths=resolved_constraints_paths,
+        resource_entries=resource_entries,
     )
     return loaded, errors
 

--- a/skills/studio/scripts/studio/utils/kit_model.py
+++ b/skills/studio/scripts/studio/utils/kit_model.py
@@ -1195,6 +1195,11 @@ def _load_core_model(kit_source: Path) -> KitModel:
         origin = str(binding.get("origin", "")).strip() if isinstance(binding, dict) else ""
         if not origin and kind == "skill" and source.startswith("workflows/"):
             origin = "legacy-workflow"
+        artifact_bindings = _artifact_bindings(binding.get("artifacts") if isinstance(binding, dict) else None, f"resources.{resource_id}.artifacts")
+        if artifact_bindings and kind != "constraints":
+            raise ValueError(
+                f"Resource '{resource_id}': artifacts bindings are only allowed for constraints resources",
+            )
         resources.append(KitResource(
             id=str(resource_id),
             kind=kind,
@@ -1209,7 +1214,7 @@ def _load_core_model(kit_source: Path) -> KitModel:
             origin=origin,
             generated_name=_normalize_public_name(slug, str(resource_id)) if kind in _PUBLIC_KINDS else "",
             # @cpt-begin:cpt-studio-algo-kit-manifest-normalize:p1:inst-normalize-artifact-bindings
-            artifact_bindings=_artifact_bindings(binding.get("artifacts") if isinstance(binding, dict) else None, f"resources.{resource_id}.artifacts"),
+            artifact_bindings=artifact_bindings,
             # @cpt-end:cpt-studio-algo-kit-manifest-normalize:p1:inst-normalize-artifact-bindings
         ))
     if not resources:

--- a/skills/studio/scripts/studio/utils/kit_model.py
+++ b/skills/studio/scripts/studio/utils/kit_model.py
@@ -76,6 +76,9 @@ class KitResource:
     context_window: Optional[str] = None
     subagents: List[Dict[str, Any]] = field(default_factory=list)
     target_configs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    # @cpt-begin:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
+    artifact_bindings: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    # @cpt-end:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
 
 
 @dataclass(frozen=True)
@@ -242,6 +245,36 @@ def _config_table(raw: Dict[str, Any], key: str, field_name: str) -> Dict[str, D
     # @cpt-end:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-agent-config
 
 
+def _artifact_bindings(value: Any, field_name: str) -> Dict[str, Dict[str, str]]:
+    # @cpt-begin:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Field '{field_name}' must be a table")
+    result: Dict[str, Dict[str, str]] = {}
+    allowed = {"template", "rules", "checklist", "example", "examples"}
+    for kind, raw_binding in value.items():
+        kind_s = str(kind).strip().upper()
+        if not kind_s:
+            raise ValueError(f"Field '{field_name}' contains an empty artifact kind")
+        if not isinstance(raw_binding, dict):
+            raise ValueError(f"Field '{field_name}.{kind_s}' must be a table")
+        item: Dict[str, str] = {}
+        for key, raw_value in raw_binding.items():
+            key_s = str(key).strip()
+            if key_s not in allowed:
+                raise ValueError(
+                    f"Field '{field_name}.{kind_s}.{key_s}' is unsupported; expected one of {sorted(allowed)}",
+                )
+            if not isinstance(raw_value, str) or not raw_value.strip():
+                raise ValueError(f"Field '{field_name}.{kind_s}.{key_s}' must be a non-empty string")
+            item["examples" if key_s == "example" else key_s] = raw_value.strip()
+        if item:
+            result[kind_s] = item
+    return result
+    # @cpt-end:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
+
+
 def _normalize_kind(kind: str, *, warnings: List[str], resource_id: str) -> str:
     cleaned = kind.strip().lower()
     # @cpt-begin:cpt-studio-algo-kit-model-normalize:p1:inst-kitmodel-workflow-to-skill
@@ -405,6 +438,7 @@ def _semantic_resource_data(resource: KitResource) -> Dict[str, Any]:
         "context_window": resource.context_window,
         "subagents": resource.subagents,
         "target_configs": resource.target_configs,
+        "artifact_bindings": resource.artifact_bindings,
     }
     # @cpt-end:cpt-studio-algo-kit-model-normalize:p1:inst-kitmodel-resource-id-vs-generated-name
     return data
@@ -546,6 +580,9 @@ def _with_hashes(kit_source: Path, model: KitModel) -> KitModel:
             context_window=resource.context_window,
             subagents=resource.subagents,
             target_configs=resource.target_configs,
+            # @cpt-begin:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
+            artifact_bindings=resource.artifact_bindings,
+            # @cpt-end:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
         )
         for resource in model.resources
     ]
@@ -635,7 +672,7 @@ def _canonical_model_from_entry(
                 "origin", "generated_name", "prefix_generated_name", "agent", "targets", "permissions",
                 "tools", "disallowed_tools", "mode", "isolation", "model",
                 "skills", "color", "memory_dir", "role", "target", "provider",
-                "reasoning_effort", "context_window", "subagents",
+                "reasoning_effort", "context_window", "subagents", "artifacts",
             },
             resource_context,
             warnings,
@@ -680,6 +717,13 @@ def _canonical_model_from_entry(
             raise ValueError(
                 f"Resource '{resource_id}': generated_targets is only allowed for public resources",
             )
+        # @cpt-begin:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
+        artifact_bindings = _artifact_bindings(raw.get("artifacts"), f"resources.{resource_id}.artifacts")
+        if artifact_bindings and kind != "constraints":
+            raise ValueError(
+                f"Resource '{resource_id}': artifacts bindings are only allowed for constraints resources",
+            )
+        # @cpt-end:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-artifact-bindings
         permissions_config = raw.get("permissions") if isinstance(raw.get("permissions"), dict) else {}
         resource = KitResource(
             id=resource_id,
@@ -723,6 +767,7 @@ def _canonical_model_from_entry(
             context_window=_config_optional_string(raw, agent_config, "context_window"),
             subagents=_config_subagents(raw, agent_config, f"resources.{resource_id}.subagents"),
             target_configs=_config_table(raw, "targets", f"resources.{resource_id}.targets"),
+            artifact_bindings=artifact_bindings,
             # @cpt-end:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-agent-fields
             # @cpt-end:cpt-studio-algo-kit-canonical-manifest:p1:inst-canonical-agent-config
         )
@@ -1163,6 +1208,9 @@ def _load_core_model(kit_source: Path) -> KitModel:
             generated_targets=_string_list(binding.get("generated_targets") if isinstance(binding, dict) else None, f"resources.{resource_id}.generated_targets") or ["installed"],
             origin=origin,
             generated_name=_normalize_public_name(slug, str(resource_id)) if kind in _PUBLIC_KINDS else "",
+            # @cpt-begin:cpt-studio-algo-kit-manifest-normalize:p1:inst-normalize-artifact-bindings
+            artifact_bindings=_artifact_bindings(binding.get("artifacts") if isinstance(binding, dict) else None, f"resources.{resource_id}.artifacts"),
+            # @cpt-end:cpt-studio-algo-kit-manifest-normalize:p1:inst-normalize-artifact-bindings
         ))
     if not resources:
         raise ValueError(f"No usable resource bindings found for kit '{slug}'")
@@ -1265,6 +1313,10 @@ def kit_model_to_toml_data(model: KitModel) -> Dict[str, Any]:
             item["subagents"] = resource.subagents
         if resource.target_configs:
             item["targets"] = resource.target_configs
+        # @cpt-begin:cpt-studio-algo-kit-manifest-normalize:p1:inst-normalize-artifact-bindings
+        if resource.artifact_bindings:
+            item["artifacts"] = resource.artifact_bindings
+        # @cpt-end:cpt-studio-algo-kit-manifest-normalize:p1:inst-normalize-artifact-bindings
         resources.append(item)
     # @cpt-end:cpt-studio-algo-kit-manifest-normalize:p1:inst-normalize-convert
 

--- a/skills/studio/scripts/studio/utils/manifest.py
+++ b/skills/studio/scripts/studio/utils/manifest.py
@@ -40,6 +40,9 @@ class ManifestResource:
     type: str  # "file" or "directory"
     description: str = ""
     user_modifiable: bool = True
+    kind: str = ""
+    public: bool = False
+    artifact_bindings: Dict[str, Dict[str, str]] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -1110,6 +1113,9 @@ def _load_canonical_kit_manifest(kit_source: Path, kit_slug: str = "") -> Option
                 type=res.type,
                 description=res.description,
                 user_modifiable=res.user_modifiable,
+                kind=res.kind,
+                public=res.public,
+                artifact_bindings=res.artifact_bindings,
             )
             for res in model.resources
         ],

--- a/tests/test_cli_py_coverage.py
+++ b/tests/test_cli_py_coverage.py
@@ -426,6 +426,176 @@ class TestCLIPyCoverageSelfCheckMoreBranches(unittest.TestCase):
             self.assertEqual(out.get("status"), "PASS")
             self.assertGreaterEqual(int(out.get("kits_checked", 0)), 1)
 
+    def test_explicit_examples_binding_does_not_fallback_to_layout_template(self):
+        from studio.commands.self_check import run_self_check_from_meta
+        from studio.utils.artifacts_meta import ArtifactsMeta
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            kit_root = root / "kits" / "k"
+            (kit_root / "artifacts" / "REQ").mkdir(parents=True)
+            (kit_root / "artifacts" / "REQ" / "template.md").write_text(
+                "# Legacy template without required placeholder\n",
+                encoding="utf-8",
+            )
+            examples_dir = root / "bound-examples"
+            examples_dir.mkdir()
+            (examples_dir / "example.md").write_text(
+                "- [x] `p1` - **ID**: `cpt-test-req-login`\n",
+                encoding="utf-8",
+            )
+            from _test_helpers import write_constraints_toml
+            write_constraints_toml(kit_root, {
+                "REQ": {
+                    "identifiers": {
+                        "req": {"required": True, "template": "cpt-{system}-req-{slug}"}
+                    }
+                }
+            })
+            meta = ArtifactsMeta.from_dict({
+                "version": "1.1",
+                "project_root": ".",
+                "systems": [],
+                "kits": {
+                    "k": {
+                        "format": "CFS",
+                        "path": "kits/k",
+                        "artifacts": {
+                            "REQ": {
+                                "examples": "{project_root}/bound-examples",
+                            }
+                        },
+                    }
+                },
+            })
+
+            rc, out = run_self_check_from_meta(project_root=root, adapter_dir=(root / "adapter"), artifacts_meta=meta)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.get("status"), "PASS")
+        self.assertEqual(out["results"][0]["examples_checked"], 1)
+
+    def test_explicit_template_binding_does_not_fallback_to_layout_examples(self):
+        from studio.commands.self_check import run_self_check_from_meta
+        from studio.utils.artifacts_meta import ArtifactsMeta
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            kit_root = root / "kits" / "k"
+            examples_dir = kit_root / "artifacts" / "REQ" / "examples"
+            examples_dir.mkdir(parents=True)
+            (examples_dir / "example.md").write_text(
+                "- [x] `p1` - **ID**: `not-valid`\n",
+                encoding="utf-8",
+            )
+            template_path = root / "bound-template.md"
+            template_path.write_text(
+                "# Template\n\n- [ ] `p1` - **ID**: `cpt-{system}-req-{slug}`\n",
+                encoding="utf-8",
+            )
+            from _test_helpers import write_constraints_toml
+            write_constraints_toml(kit_root, {
+                "REQ": {
+                    "identifiers": {
+                        "req": {"required": True, "template": "cpt-{system}-req-{slug}"}
+                    }
+                }
+            })
+            meta = ArtifactsMeta.from_dict({
+                "version": "1.1",
+                "project_root": ".",
+                "systems": [],
+                "kits": {
+                    "k": {
+                        "format": "CFS",
+                        "path": "kits/k",
+                        "artifacts": {
+                            "REQ": {
+                                "template": "{project_root}/bound-template.md",
+                            }
+                        },
+                    }
+                },
+            })
+
+            rc, out = run_self_check_from_meta(project_root=root, adapter_dir=(root / "adapter"), artifacts_meta=meta)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.get("status"), "PASS")
+        self.assertEqual(out["results"][0]["examples_checked"], 0)
+
+    def test_legacy_layout_without_explicit_artifact_map_uses_template_and_examples(self):
+        from studio.commands.self_check import run_self_check_from_meta
+        from studio.utils.artifacts_meta import ArtifactsMeta
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            kit_root = root / "kits" / "k"
+            examples_dir = kit_root / "artifacts" / "REQ" / "examples"
+            examples_dir.mkdir(parents=True)
+            (kit_root / "artifacts" / "REQ" / "template.md").write_text(
+                "# Template\n\n- [ ] `p1` - **ID**: `cpt-{system}-req-{slug}`\n",
+                encoding="utf-8",
+            )
+            (examples_dir / "example.md").write_text(
+                "- [x] `p1` - **ID**: `cpt-test-req-login`\n",
+                encoding="utf-8",
+            )
+            from _test_helpers import write_constraints_toml
+            write_constraints_toml(kit_root, {
+                "REQ": {
+                    "identifiers": {
+                        "req": {"required": True, "template": "cpt-{system}-req-{slug}"}
+                    }
+                }
+            })
+            meta = ArtifactsMeta.from_dict({
+                "version": "1.1",
+                "project_root": ".",
+                "systems": [],
+                "kits": {
+                    "k": {
+                        "format": "CFS",
+                        "path": "kits/k",
+                    }
+                },
+            })
+
+            rc, out = run_self_check_from_meta(project_root=root, adapter_dir=(root / "adapter"), artifacts_meta=meta)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.get("status"), "PASS")
+        self.assertEqual(out["results"][0]["examples_checked"], 1)
+
+    def test_self_check_falls_back_to_layout_when_kit_methods_return_empty_paths(self):
+        from studio.commands.self_check import run_self_check_from_meta
+
+        class EmptyPathKit:
+            format = "CFS"
+            path = "kits/k"
+            artifacts = {}
+
+            def get_template_path(self, _kind):
+                return ""
+
+            def get_examples_path(self, _kind):
+                return ""
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            kit_root = root / "adapter" / "kits" / "k"
+            examples_dir = kit_root / "artifacts" / "REQ" / "examples"
+            examples_dir.mkdir(parents=True)
+            (kit_root / "artifacts" / "REQ" / "template.md").write_text("# Template\n", encoding="utf-8")
+            (examples_dir / "example.md").write_text("# Example\n", encoding="utf-8")
+            meta = types.SimpleNamespace(kits={"k": EmptyPathKit()})
+
+            rc, out = run_self_check_from_meta(project_root=root, adapter_dir=(root / "adapter"), artifacts_meta=meta)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.get("status"), "PASS")
+        self.assertEqual(out["results"][0]["examples_checked"], 1)
+
     def test_run_self_check_fails_on_invalid_constraints(self):
         from studio.commands.self_check import run_self_check_from_meta
 

--- a/tests/test_cli_py_coverage.py
+++ b/tests/test_cli_py_coverage.py
@@ -569,6 +569,7 @@ class TestCLIPyCoverageSelfCheckMoreBranches(unittest.TestCase):
 
     def test_self_check_falls_back_to_layout_when_kit_methods_return_empty_paths(self):
         from studio.commands.self_check import run_self_check_from_meta
+        from studio.utils.artifacts_meta import ArtifactsMeta
 
         class EmptyPathKit:
             format = "CFS"
@@ -588,7 +589,7 @@ class TestCLIPyCoverageSelfCheckMoreBranches(unittest.TestCase):
             examples_dir.mkdir(parents=True)
             (kit_root / "artifacts" / "REQ" / "template.md").write_text("# Template\n", encoding="utf-8")
             (examples_dir / "example.md").write_text("# Example\n", encoding="utf-8")
-            meta = types.SimpleNamespace(kits={"k": EmptyPathKit()})
+            meta = ArtifactsMeta(version="1.0", project_root=".", kits={"k": EmptyPathKit()}, systems=[])
 
             rc, out = run_self_check_from_meta(project_root=root, adapter_dir=(root / "adapter"), artifacts_meta=meta)
 

--- a/tests/test_kit.py
+++ b/tests/test_kit.py
@@ -5039,12 +5039,225 @@ class TestCollectKitMetadataOsError(unittest.TestCase):
                 "ALWAYS invoke `C:/external-kits/sdlc/SKILL.md` FIRST",
             )
 
+    def test_registered_resource_metadata_uses_public_bindings_only(self):
+        from studio.commands.kit import _collect_registered_kit_metadata
+
+        with TemporaryDirectory() as td:
+            studio_dir = Path(td) / ".bootstrap"
+            public_skill = studio_dir / "custom" / "SKILL.md"
+            public_rule = studio_dir / "custom" / "AGENTS.md"
+            private_rule = studio_dir / "custom" / "PRIVATE.md"
+            public_skill.parent.mkdir(parents=True)
+            public_skill.write_text("# Skill\n", encoding="utf-8")
+            public_rule.write_text("PUBLIC RULE\n", encoding="utf-8")
+            private_rule.write_text("PRIVATE RULE\n", encoding="utf-8")
+
+            meta = _collect_registered_kit_metadata(
+                studio_dir,
+                "sdlc",
+                {
+                    "resources": {
+                        "skill": {"path": "custom/SKILL.md", "kind": "skill", "public": "yes"},
+                        "rule": {"path": "custom/AGENTS.md", "kind": "rule", "public": True},
+                        "private-rule": {"path": "custom/PRIVATE.md", "kind": "rule", "public": False},
+                        "constraints": {"path": "custom/constraints.toml", "kind": "constraints", "public": True},
+                        "missing": {"path": ""},
+                    },
+                },
+            )
+
+        self.assertEqual(
+            meta["skill_nav"],
+            "ALWAYS invoke `{cf-studio-path}/custom/SKILL.md` FIRST",
+        )
+        self.assertEqual(meta["agents_content"], "PUBLIC RULE\n")
+        self.assertNotIn("PRIVATE RULE", meta["agents_content"])
+
+    def test_registered_resource_metadata_infers_legacy_skill_and_rule_kinds(self):
+        from studio.commands.kit import _collect_registered_kit_metadata
+
+        with TemporaryDirectory() as td:
+            studio_dir = Path(td) / ".bootstrap"
+            kit_dir = studio_dir / "external"
+            kit_dir.mkdir(parents=True)
+            (kit_dir / "SKILL.md").write_text("# Legacy skill\n", encoding="utf-8")
+            (kit_dir / "AGENTS.md").write_text("LEGACY RULE\n", encoding="utf-8")
+
+            meta = _collect_registered_kit_metadata(
+                studio_dir,
+                "legacy",
+                {
+                    "resources": {
+                        "skill": "external/SKILL.md",
+                        "agents": "external/AGENTS.md",
+                    },
+                },
+            )
+
+        self.assertIn("{cf-studio-path}/external/SKILL.md", meta["skill_nav"])
+        self.assertEqual(meta["agents_content"], "LEGACY RULE\n")
+
+    def test_prompt_manifest_install_plan_allows_root_and_resource_overrides(self):
+        from studio.commands.kit import _prompt_manifest_install_plan
+
+        with TemporaryDirectory() as td:
+            studio_dir = Path(td) / ".bootstrap"
+            kit_root = studio_dir / "config" / "kits" / "sdlc"
+            studio_dir.mkdir(parents=True)
+            resource = SimpleNamespace(
+                id="constraints",
+                type="file",
+                source="constraints.toml",
+                default_path="constraints.toml",
+                install_path="constraints.toml",
+                user_modifiable=True,
+                public=False,
+                kind="constraints",
+                artifact_bindings={"FEATURE": {"template": "feature-template"}},
+            )
+            manifest = SimpleNamespace(user_modifiable=True, resources=[resource])
+
+            with patch("studio.commands.kit.sys.stdin.isatty", return_value=True), patch(
+                "studio.commands.kit._input_stderr",
+                side_effect=["yes", "1", "custom-root", "yes", "2", "overrides/constraints.toml", "done"],
+            ):
+                new_root, new_root_rel, bindings = _prompt_manifest_install_plan(
+                    "sdlc",
+                    studio_dir,
+                    kit_root,
+                    manifest,
+                    interactive=True,
+                )
+
+        self.assertEqual(new_root, (studio_dir / "custom-root").resolve())
+        self.assertEqual(new_root_rel, "custom-root")
+        self.assertEqual(bindings["constraints"]["path"], "custom-root/overrides/constraints.toml")
+        self.assertEqual(bindings["constraints"]["artifacts"], {"FEATURE": {"template": "feature-template"}})
+
+    def test_manifest_root_resolution_helpers_cover_fallbacks(self):
+        from studio.commands.kit import (
+            _resolve_declared_manifest_root,
+            _resolve_manifest_kit_root_rel,
+            _resolve_manifest_root_from_binding,
+        )
+
+        self.assertIsNone(_resolve_manifest_root_from_binding(None, "constraints.toml"))
+        self.assertIsNone(_resolve_manifest_root_from_binding("short.toml", "nested/constraints.toml"))
+        self.assertIsNone(_resolve_manifest_root_from_binding("kit/other.toml", "constraints.toml"))
+        self.assertEqual(_resolve_manifest_root_from_binding("kit/constraints.toml", "constraints.toml"), "kit")
+        self.assertEqual(_resolve_manifest_root_from_binding("constraints.toml", "constraints.toml"), "")
+
+        self.assertEqual(
+            _resolve_declared_manifest_root(SimpleNamespace(root="{cf-studio-path}/kits/{slug}"), "sdlc"),
+            "kits/sdlc",
+        )
+        self.assertEqual(_resolve_declared_manifest_root(SimpleNamespace(root="."), "sdlc"), "config/kits/sdlc")
+
+        manifest = SimpleNamespace(
+            root="fallback/{slug}",
+            resources=[SimpleNamespace(id="constraints", install_path="constraints.toml")],
+        )
+        self.assertEqual(
+            _resolve_manifest_kit_root_rel(
+                manifest,
+                {"constraints": {"path": "registered/constraints.toml"}},
+                "sdlc",
+            ),
+            "registered",
+        )
+        self.assertEqual(_resolve_manifest_kit_root_rel(manifest, {}, "sdlc"), "fallback/sdlc")
+
+    def test_validate_register_manifest_containment_reports_escape_branches(self):
+        from studio.commands.kit import _validate_register_manifest_containment
+
+        with TemporaryDirectory() as td:
+            project_root = Path(td) / "project"
+            studio_dir = project_root / ".bootstrap"
+            kit_source = project_root / "kits" / "sdlc"
+            kit_source.mkdir(parents=True)
+            (kit_source / ".cf-studio-kit.toml").write_text("manifest\n", encoding="utf-8")
+            manifest = SimpleNamespace(
+                root="/outside",
+                resources=[
+                    SimpleNamespace(id="absolute", source="/tmp/constraints.toml"),
+                    SimpleNamespace(id="escape", source="../../../outside.toml"),
+                ],
+            )
+
+            missing_root_errors = _validate_register_manifest_containment(
+                None,
+                studio_dir,
+                kit_source,
+                "sdlc",
+                manifest,
+            )
+            errors = _validate_register_manifest_containment(
+                project_root,
+                studio_dir,
+                kit_source,
+                "sdlc",
+                manifest,
+            )
+
+        self.assertEqual(missing_root_errors, ["Register install mode requires a resolved project root"])
+        self.assertTrue(any("Manifest root" in error for error in errors))
+        self.assertTrue(any("must be relative" in error for error in errors))
+        self.assertTrue(any("escapes the project root" in error for error in errors))
+
+    def test_project_root_from_core_toml_handles_relative_absolute_and_invalid(self):
+        from studio.commands.kit import _project_root_from_core_toml
+
+        with TemporaryDirectory() as td:
+            studio_dir = Path(td) / ".bootstrap"
+            config_dir = studio_dir / "config"
+            config_dir.mkdir(parents=True)
+
+            self.assertIsNone(_project_root_from_core_toml(config_dir, studio_dir))
+
+            core = config_dir / "core.toml"
+            core.write_text("project_root = \"..\"\n", encoding="utf-8")
+            self.assertEqual(_project_root_from_core_toml(config_dir, studio_dir), studio_dir.parent.resolve())
+
+            absolute_root = Path(td).resolve()
+            core.write_text(f"project_root = \"{absolute_root.as_posix()}\"\n", encoding="utf-8")
+            self.assertEqual(_project_root_from_core_toml(config_dir, studio_dir), absolute_root)
+
+            core.write_text("project_root = 123\n", encoding="utf-8")
+            self.assertIsNone(_project_root_from_core_toml(config_dir, studio_dir))
+
+            core.write_text("{{bad", encoding="utf-8")
+            self.assertIsNone(_project_root_from_core_toml(config_dir, studio_dir))
+
 
 # ---------------------------------------------------------------------------
 # _read_project_name_from_registry
 # ---------------------------------------------------------------------------
 
 class TestResolveRegisteredKitMetadataTarget(unittest.TestCase):
+    def test_uses_resource_binding_when_registered_kit_dir_has_no_metadata(self):
+        from studio.commands.kit import _resolve_registered_kit_metadata_target
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "proj"
+            adapter = _bootstrap_project(root)
+            resource_dir = adapter / "registered"
+            resource_dir.mkdir()
+            (resource_dir / "AGENTS.md").write_text("RULE\n", encoding="utf-8")
+
+            kit_dir, kit_rel_path = _resolve_registered_kit_metadata_target(
+                adapter,
+                "sdlc",
+                {
+                    "path": "config/kits/sdlc",
+                    "resources": {
+                        "rule": {"path": "registered/AGENTS.md", "kind": "rule", "public": True},
+                    },
+                },
+            )
+
+        self.assertEqual(kit_dir, resource_dir.resolve())
+        self.assertEqual(kit_rel_path, "registered")
+
     def test_uses_existing_raw_windows_backslash_registered_path(self):
         from studio.commands.kit import _resolve_registered_kit_metadata_target
         with TemporaryDirectory() as td:

--- a/tests/test_kit.py
+++ b/tests/test_kit.py
@@ -5174,12 +5174,16 @@ class TestCollectKitMetadataOsError(unittest.TestCase):
             project_root = Path(td) / "project"
             studio_dir = project_root / ".bootstrap"
             kit_source = project_root / "kits" / "sdlc"
+            external_dir = Path(td) / "external"
+            external_dir.mkdir()
+            external_constraints = external_dir / "constraints.toml"
+            external_constraints.write_text("", encoding="utf-8")
             kit_source.mkdir(parents=True)
             (kit_source / ".cf-studio-kit.toml").write_text("manifest\n", encoding="utf-8")
             manifest = SimpleNamespace(
                 root="/outside",
                 resources=[
-                    SimpleNamespace(id="absolute", source="/tmp/constraints.toml"),
+                    SimpleNamespace(id="absolute", source=external_constraints.as_posix()),
                     SimpleNamespace(id="escape", source="../../../outside.toml"),
                 ],
             )

--- a/tests/test_kit_manifest_install.py
+++ b/tests/test_kit_manifest_install.py
@@ -14,6 +14,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "cypilot" / "scripts"))
 
@@ -160,6 +161,51 @@ class TestManifestInstallAdapter(unittest.TestCase):
             assert manifest is not None
             self.assertEqual(manifest.resources[0].id, "skill")
 
+    def test_canonical_manifest_adapter_preserves_artifact_bindings(self):
+        from studio.commands.kit import _load_manifest_install_adapter
+
+        with TemporaryDirectory() as td:
+            kit_src = Path(td) / "kit"
+            kit_src.mkdir()
+            (kit_src / "constraints.toml").write_text("[FEATURE.identifiers.flow]\nrequired = true\n", encoding="utf-8")
+            (kit_src / "feature-template.md").write_text("# Feature\n", encoding="utf-8")
+            (kit_src / ".cf-studio-kit.toml").write_text(
+                textwrap.dedent(
+                    """\
+                    manifest_version = "1.0"
+
+                    [[kits]]
+                    slug = "mykit"
+                    name = "My Kit"
+                    version = "1.0"
+
+                    [[kits.resources]]
+                    id = "ruleset"
+                    kind = "constraints"
+                    source = "constraints.toml"
+                    type = "file"
+
+                    [kits.resources.artifacts.FEATURE]
+                    template = "feature-template"
+
+                    [[kits.resources]]
+                    id = "feature-template"
+                    kind = "template"
+                    source = "feature-template.md"
+                    type = "file"
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            manifest = _load_manifest_install_adapter(kit_src, kit_slug="mykit")
+
+            self.assertIsNotNone(manifest)
+            assert manifest is not None
+            ruleset = [res for res in manifest.resources if res.id == "ruleset"][0]
+            self.assertEqual(ruleset.kind, "constraints")
+            self.assertEqual(ruleset.artifact_bindings, {"FEATURE": {"template": "feature-template"}})
+
     def test_source_without_manifest_returns_none(self):
         from studio.commands.kit import _load_manifest_install_adapter
 
@@ -169,6 +215,89 @@ class TestManifestInstallAdapter(unittest.TestCase):
             (kit_src / "conf.toml").write_text('name = "legacy"\n', encoding="utf-8")
 
             self.assertIsNone(_load_manifest_install_adapter(kit_src, kit_slug="legacy"))
+
+    def test_sync_manifest_resource_bindings_preserves_artifact_bindings(self):
+        from studio.commands.kit import _sync_manifest_resource_bindings
+        from studio.utils import toml_utils
+
+        with TemporaryDirectory() as td:
+            config = Path(td) / "config"
+            config.mkdir()
+            toml_utils.dump({
+                "version": "1.0",
+                "project_root": "..",
+                "kits": {
+                    "mykit": {
+                        "format": "CFS",
+                        "path": "config/kits/mykit",
+                        "resources": {
+                            "ruleset": {
+                                "path": "config/kits/mykit/constraints.toml",
+                                "kind": "constraints",
+                                "artifacts": {"OLD": {"template": "old-template"}},
+                            },
+                            "feature-template": {
+                                "path": "config/kits/mykit/feature-template.md",
+                                "kind": "template",
+                                "artifacts": {"OLD": {"template": "old-template"}},
+                            },
+                        },
+                    },
+                },
+            }, config / "core.toml")
+            manifest = SimpleNamespace(
+                root="{cf-studio-path}/config/kits/{slug}",
+                resources=[
+                    SimpleNamespace(
+                        id="ruleset",
+                        kind="constraints",
+                        install_path="constraints.toml",
+                        default_path="constraints.toml",
+                        public=False,
+                        artifact_bindings={"FEATURE": {"template": "feature-template"}},
+                    ),
+                    SimpleNamespace(
+                        id="feature-template",
+                        kind="template",
+                        install_path="feature-template.md",
+                        default_path="feature-template.md",
+                        public=False,
+                        artifact_bindings={},
+                    ),
+                ],
+            )
+
+            merged = _sync_manifest_resource_bindings(manifest, config, "mykit")
+
+        assert merged is not None
+        self.assertEqual(
+            merged["ruleset"]["artifacts"],
+            {"FEATURE": {"template": "feature-template"}},
+        )
+        self.assertNotIn("artifacts", merged["feature-template"])
+
+    def test_manifest_resource_bindings_writer_persists_artifact_bindings(self):
+        from studio.commands.kit import _manifest_resource_bindings
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            kit_root = root / "adapter" / "config" / "kits" / "mykit"
+            kit_root.mkdir(parents=True)
+            res = SimpleNamespace(
+                id="ruleset",
+                kind="constraints",
+                install_path="constraints.toml",
+                default_path="constraints.toml",
+                public=False,
+                artifact_bindings={"FEATURE": {"template": "feature-template"}},
+            )
+
+            bindings = _manifest_resource_bindings(root / "adapter", kit_root, [res], {})
+
+        self.assertEqual(
+            bindings["ruleset"]["artifacts"],
+            {"FEATURE": {"template": "feature-template"}},
+        )
 
 
 class TestInstallKitWithManifest(unittest.TestCase):

--- a/tests/test_kit_manifest_install.py
+++ b/tests/test_kit_manifest_install.py
@@ -202,7 +202,9 @@ class TestManifestInstallAdapter(unittest.TestCase):
 
             self.assertIsNotNone(manifest)
             assert manifest is not None
-            ruleset = [res for res in manifest.resources if res.id == "ruleset"][0]
+            ruleset = next((res for res in manifest.resources if res.id == "ruleset"), None)
+            self.assertIsNotNone(ruleset)
+            assert ruleset is not None
             self.assertEqual(ruleset.kind, "constraints")
             self.assertEqual(ruleset.artifact_bindings, {"FEATURE": {"template": "feature-template"}})
 

--- a/tests/test_kit_manifest_migration.py
+++ b/tests/test_kit_manifest_migration.py
@@ -601,6 +601,43 @@ class TestUpdateKitLegacyMigration(unittest.TestCase):
             # Original binding preserved
             self.assertIn("adr_artifacts", kit_entry["resources"])
 
+    def test_update_stops_same_version_fast_path_when_manifest_migration_fails(self):
+        """Failed migration must not fall through to invented resource bindings."""
+        from studio.commands.kit import update_kit
+        from studio.utils import toml_utils
+
+        with TemporaryDirectory() as td:
+            td_path = Path(td)
+            kit_src = _make_kit_source_with_manifest(td_path, "mykit")
+            adapter = _setup_legacy_project(td_path, "mykit")
+            config = adapter / "config"
+            with open(config / "core.toml", "rb") as f:
+                data = tomllib.load(f)
+            data["kits"]["mykit"]["version"] = "2.0"
+            toml_utils.dump(data, config / "core.toml")
+
+            with patch(
+                "studio.commands.kit.migrate_legacy_kit_to_manifest",
+                return_value={"status": "FAIL", "errors": ["migration failed"]},
+            ) as migrate_mock, patch(
+                "studio.commands.kit._sync_manifest_resource_bindings",
+            ) as sync_mock, patch(
+                "studio.commands.kit._register_kit_in_core_toml",
+            ) as register_mock:
+                result = update_kit(
+                    "mykit",
+                    kit_src,
+                    adapter,
+                    interactive=False,
+                    auto_approve=True,
+                )
+
+        migrate_mock.assert_called_once()
+        sync_mock.assert_not_called()
+        register_mock.assert_not_called()
+        self.assertEqual(result["version"], {"status": "failed"})
+        self.assertEqual(result["errors"], ["migration failed"])
+
     def test_update_no_manifest_no_migration(self):
         """update_kit without manifest in source → no migration attempt."""
         from studio.commands.kit import update_kit

--- a/tests/test_kit_manifest_validate.py
+++ b/tests/test_kit_manifest_validate.py
@@ -410,6 +410,85 @@ class TestValidateKitsResourcePaths(unittest.TestCase):
         warnings = [warn.get("message", "") for warn in feature.get("warnings", [])]
         self.assertTrue(any("no manifest resource binding" in msg for msg in warnings), warnings)
 
+    def test_register_mode_self_check_uses_all_constraints_resources(self):
+        """Bound templates are checked against every constraints resource, not just one."""
+        from studio.utils import toml_utils
+        from studio.utils.context import StudioContext, set_context
+        from studio.commands.validate_kits import run_validate_kits
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "proj"
+            adapter = _bootstrap_project(root, ".cf-studio")
+            config = adapter / "config"
+            kit_root = root / "studio-kit"
+            kit_root.mkdir(parents=True)
+            (kit_root / "base.toml").write_text(
+                "[PRD.identifiers.fr]\nrequired = true\n",
+                encoding="utf-8",
+            )
+            (kit_root / "feature.toml").write_text(
+                "[FEATURE.identifiers.flow]\nrequired = true\n"
+                'template = "cpt-{system}-flow-{slug}"\n',
+                encoding="utf-8",
+            )
+            (kit_root / "feature-template.md").write_text(
+                "# Feature\n\nThis template intentionally omits the required flow placeholder.\n",
+                encoding="utf-8",
+            )
+            toml_utils.dump({
+                "version": "1.0",
+                "project_root": "..",
+                "kits": {
+                    "multi": {
+                        "format": "CFS",
+                        "path": "../studio-kit",
+                        "resources": {
+                            "policy-a": {
+                                "path": "../studio-kit/base.toml",
+                                "kind": "constraints",
+                            },
+                            "policy-b": {
+                                "path": "../studio-kit/feature.toml",
+                                "kind": "constraints",
+                                "artifacts": {
+                                    "FEATURE": {"template": "feature-template"},
+                                },
+                            },
+                            "feature-template": {
+                                "path": "../studio-kit/feature-template.md",
+                                "kind": "template",
+                            },
+                        },
+                    },
+                },
+            }, config / "core.toml")
+            toml_utils.dump({
+                "version": "1.0",
+                "project_root": "..",
+                "kits": {"multi": {"format": "CFS", "path": "../studio-kit"}},
+                "systems": [{"name": "Test", "slug": "test", "kit": "multi"}],
+            }, config / "artifacts.toml")
+
+            ctx = StudioContext.load(root)
+            set_context(ctx)
+            try:
+                rc, result = run_validate_kits(
+                    project_root=ctx.project_root,
+                    adapter_dir=ctx.adapter_dir,
+                    verbose=True,
+                )
+            finally:
+                set_context(None)
+
+        self.assertEqual(rc, 2)
+        self.assertEqual(result.get("templates_checked"), 1)
+        feature = [
+            item for item in result.get("self_check_results", [])
+            if item.get("kind") == "FEATURE"
+        ][0]
+        messages = [err.get("message", "") for err in feature.get("errors", [])]
+        self.assertTrue(any("Template missing ID placeholder" in msg for msg in messages), messages)
+
     def test_missing_resource_path_produces_error(self):
         """Registered kit with resource binding pointing to missing path → FAIL."""
         from studio.utils.context import StudioContext, set_context
@@ -995,6 +1074,114 @@ class TestValidateKitByPathManifest(unittest.TestCase):
             {"FEATURE": {"template": "feature-template", "examples": "feature-examples"}},
         )
 
+    def test_validate_kit_by_path_uses_canonical_artifact_bindings_outside_layout(self):
+        """Standalone canonical validation uses explicit bound resources outside artifacts/."""
+        from studio.commands.validate_kits import _validate_kit_by_path
+
+        with TemporaryDirectory() as td:
+            kit_dir = Path(td) / "mykit"
+            kit_dir.mkdir()
+            (kit_dir / "constraints.toml").write_text(
+                "[FEATURE.identifiers.flow]\nrequired = true\n"
+                'template = "cpt-{system}-flow-{slug}"\n',
+                encoding="utf-8",
+            )
+            (kit_dir / "feature-template.md").write_text(
+                "# Feature\n\nThis template intentionally omits the required flow placeholder.\n",
+                encoding="utf-8",
+            )
+            (kit_dir / "feature-examples").mkdir()
+            (kit_dir / "feature-examples" / "valid.md").write_text(
+                "# Feature\n\n- **ID**: `cpt-test-flow-valid`\n",
+                encoding="utf-8",
+            )
+            (kit_dir / ".cf-studio-kit.toml").write_text(
+                "\n".join([
+                    'manifest_version = "1.0"',
+                    "",
+                    "[[kits]]",
+                    'slug = "mykit"',
+                    'version = "1.0"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "ruleset"',
+                    'kind = "constraints"',
+                    'source = "constraints.toml"',
+                    'type = "file"',
+                    "",
+                    "[kits.resources.artifacts.FEATURE]",
+                    'template = "feature-template"',
+                    'examples = "feature-examples"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "feature-template"',
+                    'kind = "template"',
+                    'source = "feature-template.md"',
+                    'type = "file"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "feature-examples"',
+                    'kind = "directory"',
+                    'source = "feature-examples"',
+                    'type = "directory"',
+                ]) + "\n",
+                encoding="utf-8",
+            )
+
+            rc, result = _validate_kit_by_path(kit_dir, verbose=True)
+
+        self.assertEqual(rc, 2)
+        self.assertEqual(result.get("templates_checked"), 1)
+        feature = [
+            item for item in result.get("self_check_results", [])
+            if item.get("kind") == "FEATURE"
+        ][0]
+        messages = [err.get("message", "") for err in feature.get("errors", [])]
+        self.assertTrue(any("Template missing ID placeholder" in msg for msg in messages), messages)
+
+    def test_validate_kit_by_path_canonical_without_bindings_warns_and_skips_layout(self):
+        """Canonical path validation does not infer template bindings from artifacts/ layout."""
+        from studio.commands.validate_kits import _validate_kit_by_path
+
+        with TemporaryDirectory() as td:
+            kit_dir = Path(td) / "mykit"
+            kit_dir.mkdir()
+            (kit_dir / "constraints.toml").write_text(
+                "[FEATURE.identifiers.flow]\nrequired = true\n"
+                'template = "cpt-{system}-flow-{slug}"\n',
+                encoding="utf-8",
+            )
+            artifacts_feature = kit_dir / "artifacts" / "FEATURE"
+            artifacts_feature.mkdir(parents=True)
+            (artifacts_feature / "template.md").write_text("# Feature\n", encoding="utf-8")
+            (kit_dir / ".cf-studio-kit.toml").write_text(
+                "\n".join([
+                    'manifest_version = "1.0"',
+                    "",
+                    "[[kits]]",
+                    'slug = "mykit"',
+                    'version = "1.0"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "ruleset"',
+                    'kind = "constraints"',
+                    'source = "constraints.toml"',
+                    'type = "file"',
+                ]) + "\n",
+                encoding="utf-8",
+            )
+
+            rc, result = _validate_kit_by_path(kit_dir, verbose=True)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result.get("templates_checked"), 0)
+        feature = [
+            item for item in result.get("self_check_results", [])
+            if item.get("kind") == "FEATURE"
+        ][0]
+        warnings = [warn.get("message", "") for warn in feature.get("warnings", [])]
+        self.assertTrue(any("no manifest resource binding" in msg for msg in warnings), warnings)
+
     def test_canonical_constraints_artifact_bindings_reject_invalid_shapes(self):
         """Canonical artifact bindings fail closed on malformed explicit maps."""
         from studio.utils.kit_model import load_kit_model
@@ -1104,6 +1291,35 @@ class TestValidateKitByPathManifest(unittest.TestCase):
             constraints_resource.artifact_bindings,
             {"FEATURE": {"template": "feature-template"}},
         )
+
+    def test_core_resource_artifact_bindings_reject_non_constraints(self):
+        """Installed core.toml cannot attach artifact-kind maps to template resources."""
+        from studio.utils.kit_model import load_kit_model
+
+        with TemporaryDirectory() as td:
+            studio_root = Path(td) / "adapter"
+            kit_dir = studio_root / "config" / "kits" / "mykit"
+            kit_dir.mkdir(parents=True)
+            (kit_dir / "feature-template.md").write_text("# Feature\n", encoding="utf-8")
+            _write_core_toml(studio_root / "config", {
+                "kits": {
+                    "mykit": {
+                        "path": "config/kits/mykit",
+                        "resources": {
+                            "feature-template": {
+                                "path": "config/kits/mykit/feature-template.md",
+                                "kind": "template",
+                                "artifacts": {
+                                    "FEATURE": {"template": "feature-template"},
+                                },
+                            },
+                        },
+                    },
+                },
+            })
+
+            with self.assertRaisesRegex(ValueError, "only allowed for constraints"):
+                load_kit_model(kit_dir, source_hint="core")
 
     def test_malformed_manifest_produces_error(self):
         """Standalone kit with malformed manifest.toml → resource error reported."""

--- a/tests/test_kit_manifest_validate.py
+++ b/tests/test_kit_manifest_validate.py
@@ -225,6 +225,191 @@ class TestContextConstraintsResourceBinding(unittest.TestCase):
 class TestValidateKitsResourcePaths(unittest.TestCase):
     """Test that run_validate_kits verifies resource paths for manifest-driven kits."""
 
+    _BOUND_TEMPLATE_KINDS = {
+        "prd": "PRD",
+        "adr": "ADR",
+        "design": "DESIGN",
+        "decomposition": "DECOMPOSITION",
+        "feature": "FEATURE",
+        "upstream_reqs": "UPSTREAM_REQS",
+        "pr_code_review": "PR-CODE-REVIEW-TEMPLATE",
+        "pr_status_report": "PR-STATUS-REPORT-TEMPLATE",
+    }
+
+    def _write_register_mode_bound_template_project(
+        self,
+        root: Path,
+        *,
+        include_artifact_bindings: bool = True,
+    ) -> tuple[object, Path]:
+        from studio.utils.context import StudioContext
+        from studio.utils import toml_utils
+
+        adapter = _bootstrap_project(root, ".cf-studio")
+        config = adapter / "config"
+        kit_root = root / "studio-kit-gears"
+        kit_root.mkdir(parents=True)
+
+        template_root = root / "docs" / "spec-templates" / "gears-sdlc"
+        artifact_bindings = {}
+        constraints_resource = {
+            "path": "../studio-kit-gears/constraints.toml",
+            "kind": "constraints",
+        }
+        if include_artifact_bindings:
+            constraints_resource["artifacts"] = artifact_bindings
+        resources = {
+            "constraints": {
+                **constraints_resource,
+            },
+        }
+        for prefix, kind in self._BOUND_TEMPLATE_KINDS.items():
+            kind_dir = template_root / kind
+            kind_dir.mkdir(parents=True, exist_ok=True)
+            template = kind_dir / "template.md"
+            if kind == "FEATURE":
+                template.write_text(
+                    "# Feature\n\nThis template intentionally omits the required flow placeholder.\n",
+                    encoding="utf-8",
+                )
+            else:
+                template.write_text(f"# {kind}\n", encoding="utf-8")
+            resources[f"{prefix}_template"] = {
+                "path": f"../docs/spec-templates/gears-sdlc/{kind}/template.md",
+            }
+            artifact_bindings[kind] = {"template": f"{prefix}_template"}
+
+        feature_examples = template_root / "FEATURE" / "examples"
+        feature_examples.mkdir(parents=True)
+        (feature_examples / "valid.md").write_text(
+            "# Feature\n\n- **ID**: `cpt-test-flow-valid`\n",
+            encoding="utf-8",
+        )
+        resources["feature_example"] = {
+            "path": "../docs/spec-templates/gears-sdlc/FEATURE/examples",
+        }
+        artifact_bindings["FEATURE"]["examples"] = "feature_example"
+        prd_example = template_root / "PRD" / "example.md"
+        prd_example.write_text("# PRD\n", encoding="utf-8")
+        resources["prd_example"] = {
+            "path": "../docs/spec-templates/gears-sdlc/PRD/example.md",
+        }
+        artifact_bindings["PRD"]["examples"] = "prd_example"
+
+        (kit_root / "constraints.toml").write_text(
+            "\n".join([
+                "[FEATURE.identifiers.flow]",
+                "required = true",
+                'template = "cpt-{system}-flow-{slug}"',
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        toml_utils.dump({
+            "version": "1.0",
+            "project_root": "..",
+            "kits": {
+                "gears": {
+                    "format": "CFS",
+                    "path": "../studio-kit-gears",
+                    "version": "1.0",
+                    "resources": resources,
+                },
+            },
+        }, config / "core.toml")
+        toml_utils.dump({
+            "version": "1.0",
+            "project_root": "..",
+            "kits": {
+                "gears": {"format": "CFS", "path": "../studio-kit-gears"},
+            },
+            "systems": [{"name": "Test", "slug": "test", "kit": "gears"}],
+        }, config / "artifacts.toml")
+
+        ctx = StudioContext.load(root)
+        self.assertIsNotNone(ctx)
+        return ctx, adapter
+
+    def test_register_mode_resource_bindings_self_check_all_templates(self):
+        """Local/register manifest kits self-check bound resources outside kit root."""
+        from studio.utils.context import set_context
+        from studio.commands.validate_kits import run_validate_kits
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "proj"
+            ctx, _adapter = self._write_register_mode_bound_template_project(root)
+            set_context(ctx)
+            try:
+                rc, result = run_validate_kits(
+                    project_root=ctx.project_root,
+                    adapter_dir=ctx.adapter_dir,
+                    verbose=True,
+                )
+            finally:
+                set_context(None)
+
+        self.assertEqual(rc, 2)
+        self.assertEqual(result.get("templates_checked"), 8)
+        self.assertEqual(len(result.get("self_check_results", [])), 8)
+
+    def test_register_mode_resource_bindings_surface_feature_template_mismatch(self):
+        """Bound FEATURE template mismatch is reported like copy-mode package layout."""
+        from studio.utils.context import set_context
+        from studio.commands.validate_kits import run_validate_kits
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "proj"
+            ctx, _adapter = self._write_register_mode_bound_template_project(root)
+            set_context(ctx)
+            try:
+                _rc, result = run_validate_kits(
+                    project_root=ctx.project_root,
+                    adapter_dir=ctx.adapter_dir,
+                    verbose=True,
+                )
+            finally:
+                set_context(None)
+
+        feature = [
+            item for item in result.get("self_check_results", [])
+            if item.get("kind") == "FEATURE"
+        ][0]
+        self.assertEqual(feature.get("status"), "FAIL")
+        messages = [err.get("message", "") for err in feature.get("errors", [])]
+        self.assertTrue(any("Template missing ID placeholder" in msg for msg in messages), messages)
+
+    def test_register_mode_without_artifact_bindings_warns_and_skips_templates(self):
+        """Manifest resources are not matched to artifact kinds by naming convention."""
+        from studio.utils.context import set_context
+        from studio.commands.validate_kits import run_validate_kits
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "proj"
+            ctx, _adapter = self._write_register_mode_bound_template_project(
+                root,
+                include_artifact_bindings=False,
+            )
+            set_context(ctx)
+            try:
+                rc, result = run_validate_kits(
+                    project_root=ctx.project_root,
+                    adapter_dir=ctx.adapter_dir,
+                    verbose=True,
+                )
+            finally:
+                set_context(None)
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(result.get("templates_checked"), 0)
+        feature = [
+            item for item in result.get("self_check_results", [])
+            if item.get("kind") == "FEATURE"
+        ][0]
+        self.assertEqual(feature.get("status"), "PASS")
+        warnings = [warn.get("message", "") for warn in feature.get("warnings", [])]
+        self.assertTrue(any("no manifest resource binding" in msg for msg in warnings), warnings)
+
     def test_missing_resource_path_produces_error(self):
         """Registered kit with resource binding pointing to missing path → FAIL."""
         from studio.utils.context import StudioContext, set_context
@@ -745,6 +930,180 @@ class TestValidateKitByPathManifest(unittest.TestCase):
             self.assertEqual(rc, 0)
             self.assertEqual(result["kits"][0]["manifest_source"], "canonical")
             self.assertEqual(result["kits"][0]["kinds"], ["DESIGN", "PRD"])
+
+    def test_canonical_constraints_artifact_bindings_survive_model_load(self):
+        """Canonical constraints resources carry explicit artifact-kind bindings."""
+        from studio.utils.kit_model import kit_model_to_toml_data, load_kit_model
+
+        with TemporaryDirectory() as td:
+            kit_dir = Path(td) / "mykit"
+            kit_dir.mkdir()
+            (kit_dir / "constraints.toml").write_text(
+                "[FEATURE.identifiers.flow]\nrequired = true\n",
+                encoding="utf-8",
+            )
+            (kit_dir / "feature-template.md").write_text("# Feature\n", encoding="utf-8")
+            (kit_dir / "feature-examples").mkdir()
+            (kit_dir / "feature-examples" / "valid.md").write_text("# Feature\n", encoding="utf-8")
+            (kit_dir / ".cf-studio-kit.toml").write_text(
+                "\n".join([
+                    'manifest_version = "1.0"',
+                    "",
+                    "[[kits]]",
+                    'slug = "mykit"',
+                    'version = "1.0"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "ruleset"',
+                    'kind = "constraints"',
+                    'source = "constraints.toml"',
+                    'type = "file"',
+                    "",
+                    "[kits.resources.artifacts.FEATURE]",
+                    'template = "feature-template"',
+                    'examples = "feature-examples"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "feature-template"',
+                    'kind = "template"',
+                    'source = "feature-template.md"',
+                    'type = "file"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "feature-examples"',
+                    'kind = "directory"',
+                    'source = "feature-examples"',
+                    'type = "directory"',
+                ]) + "\n",
+                encoding="utf-8",
+            )
+
+            model = load_kit_model(kit_dir)
+
+        constraints_resource = [res for res in model.resources if res.id == "ruleset"][0]
+        self.assertEqual(
+            constraints_resource.artifact_bindings,
+            {"FEATURE": {"template": "feature-template", "examples": "feature-examples"}},
+        )
+        rendered = kit_model_to_toml_data(model)
+        rendered_constraints = [
+            res for res in rendered["kits"][0]["resources"]
+            if res["id"] == "ruleset"
+        ][0]
+        self.assertEqual(
+            rendered_constraints["artifacts"],
+            {"FEATURE": {"template": "feature-template", "examples": "feature-examples"}},
+        )
+
+    def test_canonical_constraints_artifact_bindings_reject_invalid_shapes(self):
+        """Canonical artifact bindings fail closed on malformed explicit maps."""
+        from studio.utils.kit_model import load_kit_model
+
+        cases = [
+            ("artifacts = []", "must be a table"),
+            ('[kits.resources.artifacts.""]\ntemplate = "feature-template"', "empty artifact kind"),
+            ('[kits.resources.artifacts]\nFEATURE = "feature-template"', "FEATURE' must be a table"),
+            ('[kits.resources.artifacts.FEATURE]\nunknown = "feature-template"', "unsupported"),
+            ('[kits.resources.artifacts.FEATURE]\ntemplate = ""', "non-empty string"),
+        ]
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            for idx, (artifacts_toml, message) in enumerate(cases):
+                with self.subTest(message=message):
+                    kit_dir = base / f"case-{idx}"
+                    kit_dir.mkdir()
+                    (kit_dir / "constraints.toml").write_text("[artifacts]\n", encoding="utf-8")
+                    (kit_dir / "feature-template.md").write_text("# Feature\n", encoding="utf-8")
+                    (kit_dir / ".cf-studio-kit.toml").write_text(
+                        "\n".join([
+                            'manifest_version = "1.0"',
+                            "",
+                            "[[kits]]",
+                            'slug = "mykit"',
+                            'version = "1.0"',
+                            "",
+                            "[[kits.resources]]",
+                            'id = "ruleset"',
+                            'kind = "constraints"',
+                            'source = "constraints.toml"',
+                            'type = "file"',
+                            artifacts_toml,
+                        ]) + "\n",
+                        encoding="utf-8",
+                    )
+
+                    with self.assertRaisesRegex(ValueError, message):
+                        load_kit_model(kit_dir)
+
+    def test_canonical_artifact_bindings_only_allowed_on_constraints(self):
+        """Template resources cannot declare artifact-kind self-check bindings."""
+        from studio.utils.kit_model import load_kit_model
+
+        with TemporaryDirectory() as td:
+            kit_dir = Path(td) / "mykit"
+            kit_dir.mkdir()
+            (kit_dir / "feature-template.md").write_text("# Feature\n", encoding="utf-8")
+            (kit_dir / ".cf-studio-kit.toml").write_text(
+                "\n".join([
+                    'manifest_version = "1.0"',
+                    "",
+                    "[[kits]]",
+                    'slug = "mykit"',
+                    'version = "1.0"',
+                    "",
+                    "[[kits.resources]]",
+                    'id = "feature-template"',
+                    'kind = "template"',
+                    'source = "feature-template.md"',
+                    'type = "file"',
+                    "",
+                    "[kits.resources.artifacts.FEATURE]",
+                    'template = "feature-template"',
+                ]) + "\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "only allowed for constraints"):
+                load_kit_model(kit_dir)
+
+    def test_core_resource_artifact_bindings_survive_model_load(self):
+        """Installed core.toml resource bindings carry artifact-kind maps too."""
+        from studio.utils.kit_model import load_kit_model
+
+        with TemporaryDirectory() as td:
+            studio_root = Path(td) / "adapter"
+            kit_dir = studio_root / "config" / "kits" / "mykit"
+            kit_dir.mkdir(parents=True)
+            (kit_dir / "constraints.toml").write_text("[artifacts]\n", encoding="utf-8")
+            (kit_dir / "feature-template.md").write_text("# Feature\n", encoding="utf-8")
+            _write_core_toml(studio_root / "config", {
+                "kits": {
+                    "mykit": {
+                        "path": "config/kits/mykit",
+                        "resources": {
+                            "ruleset": {
+                                "path": "config/kits/mykit/constraints.toml",
+                                "kind": "constraints",
+                                "artifacts": {
+                                    "FEATURE": {"template": "feature-template"},
+                                },
+                            },
+                            "feature-template": {
+                                "path": "config/kits/mykit/feature-template.md",
+                                "kind": "template",
+                            },
+                        },
+                    },
+                },
+            })
+
+            model = load_kit_model(kit_dir, source_hint="core")
+
+        constraints_resource = [res for res in model.resources if res.id == "ruleset"][0]
+        self.assertEqual(
+            constraints_resource.artifact_bindings,
+            {"FEATURE": {"template": "feature-template"}},
+        )
 
     def test_malformed_manifest_produces_error(self):
         """Standalone kit with malformed manifest.toml → resource error reported."""

--- a/tests/test_kit_manifest_validate.py
+++ b/tests/test_kit_manifest_validate.py
@@ -371,10 +371,12 @@ class TestValidateKitsResourcePaths(unittest.TestCase):
             finally:
                 set_context(None)
 
-        feature = [
-            item for item in result.get("self_check_results", [])
-            if item.get("kind") == "FEATURE"
-        ][0]
+        feature = next(
+            (item for item in result.get("self_check_results", []) if item.get("kind") == "FEATURE"),
+            None,
+        )
+        self.assertIsNotNone(feature)
+        assert feature is not None
         self.assertEqual(feature.get("status"), "FAIL")
         messages = [err.get("message", "") for err in feature.get("errors", [])]
         self.assertTrue(any("Template missing ID placeholder" in msg for msg in messages), messages)
@@ -401,11 +403,13 @@ class TestValidateKitsResourcePaths(unittest.TestCase):
                 set_context(None)
 
         self.assertEqual(rc, 0)
-        self.assertEqual(result.get("templates_checked"), 0)
-        feature = [
-            item for item in result.get("self_check_results", [])
-            if item.get("kind") == "FEATURE"
-        ][0]
+        self.assertEqual(result.get("templates_checked"), 1)
+        feature = next(
+            (item for item in result.get("self_check_results", []) if item.get("kind") == "FEATURE"),
+            None,
+        )
+        self.assertIsNotNone(feature)
+        assert feature is not None
         self.assertEqual(feature.get("status"), "PASS")
         warnings = [warn.get("message", "") for warn in feature.get("warnings", [])]
         self.assertTrue(any("no manifest resource binding" in msg for msg in warnings), warnings)
@@ -481,11 +485,13 @@ class TestValidateKitsResourcePaths(unittest.TestCase):
                 set_context(None)
 
         self.assertEqual(rc, 2)
-        self.assertEqual(result.get("templates_checked"), 1)
-        feature = [
-            item for item in result.get("self_check_results", [])
-            if item.get("kind") == "FEATURE"
-        ][0]
+        self.assertEqual(result.get("templates_checked"), 2)
+        feature = next(
+            (item for item in result.get("self_check_results", []) if item.get("kind") == "FEATURE"),
+            None,
+        )
+        self.assertIsNotNone(feature)
+        assert feature is not None
         messages = [err.get("message", "") for err in feature.get("errors", [])]
         self.assertTrue(any("Template missing ID placeholder" in msg for msg in messages), messages)
 
@@ -1132,10 +1138,12 @@ class TestValidateKitByPathManifest(unittest.TestCase):
 
         self.assertEqual(rc, 2)
         self.assertEqual(result.get("templates_checked"), 1)
-        feature = [
-            item for item in result.get("self_check_results", [])
-            if item.get("kind") == "FEATURE"
-        ][0]
+        feature = next(
+            (item for item in result.get("self_check_results", []) if item.get("kind") == "FEATURE"),
+            None,
+        )
+        self.assertIsNotNone(feature)
+        assert feature is not None
         messages = [err.get("message", "") for err in feature.get("errors", [])]
         self.assertTrue(any("Template missing ID placeholder" in msg for msg in messages), messages)
 
@@ -1174,11 +1182,13 @@ class TestValidateKitByPathManifest(unittest.TestCase):
             rc, result = _validate_kit_by_path(kit_dir, verbose=True)
 
         self.assertEqual(rc, 0)
-        self.assertEqual(result.get("templates_checked"), 0)
-        feature = [
-            item for item in result.get("self_check_results", [])
-            if item.get("kind") == "FEATURE"
-        ][0]
+        self.assertEqual(result.get("templates_checked"), 1)
+        feature = next(
+            (item for item in result.get("self_check_results", []) if item.get("kind") == "FEATURE"),
+            None,
+        )
+        self.assertIsNotNone(feature)
+        assert feature is not None
         warnings = [warn.get("message", "") for warn in feature.get("warnings", [])]
         self.assertTrue(any("no manifest resource binding" in msg for msg in warnings), warnings)
 

--- a/workflows/kit.md
+++ b/workflows/kit.md
@@ -242,6 +242,10 @@ WHEN:
   AND RESOURCE_CONTEXT == provided
 DO:
   RUN classify candidates from RESOURCE_CONTEXT into public skills, agents, and rules, plus supporting templates, checklists, scripts, directories, and other
+  RUN derive explicit artifact-kind bindings for every constraints resource from RESOURCE_CONTEXT evidence:
+    - template/checklist/rules/example files are bound to artifact kinds only when the kind is explicit in file metadata, constraints kind names, or an unambiguous per-kind layout such as `artifacts/<KIND>/template.md`
+    - bindings point to resource IDs, never filesystem paths
+    - ambiguous files remain unbound and are reported as ambiguities
   RUN synthesize a conservative canonical proposal using the discovered candidates and explicit local metadata only:
     - top-level `manifest_version = "1.0"` is required before any `[[kits]]` table
     - missing or unknown `manifest_version` is blocking; report that the user should update Constructor Studio with `pipx upgrade constructor-studio` and retry
@@ -253,6 +257,9 @@ DO:
     - version = explicit semantic-version-compatible metadata, else `0.1.0`
     - each `[[kits.resources]]` includes required `id`, `kind`, and `source`
     - `constraints.toml`, resource id `constraints`, and TOML files described as structural validation rules / heading outlines / ID kinds / cross-references are classified as `kind = "constraints"`; never classify them as `other`
+    - constraints resources that have known artifact kinds and known sibling resources MUST include an `artifacts` table that maps artifact kinds to resource IDs: `artifacts.<KIND>.template = "<template-resource-id>"`, `artifacts.<KIND>.examples = "<example-resource-id>"`, `artifacts.<KIND>.rules = "<rules-resource-id>"`, and `artifacts.<KIND>.checklist = "<checklist-resource-id>"` when each resource is known
+    - artifact binding values are resource IDs in the same kit namespace; never write paths in `artifacts.<KIND>.*`
+    - omit an artifact binding when the resource-kind relationship is not known; report that `validate-kits` will warn and skip template/example self-check for that artifact kind until the binding is added
     - `install_path` is included only when the path can be expressed as a normalized relative path under TARGET_DIR without symlink escape or absolute segments
     - `public = true` is used only for skills, agents, and rules; public resources become agent-facing generated skills/agents/rules, while non-public resources are installed/bound only
     - `prefix_generated_name = false` may be used only for public resources whose generated agent/skill/rule name must be exactly the resource `id`; the default is omitted/true and generates `cf-{kit-slug}-{id}`
@@ -267,6 +274,7 @@ DO:
 RULES:
   ALWAYS classify discovered candidates into the public and supporting groups before proposing a manifest
   ALWAYS classify structural validation rule files as `kind = "constraints"` when their source path, id, or evidence identifies constraints semantics
+  ALWAYS encode template/example/checklist/rules-to-artifact-kind relationships as explicit nested metadata on the constraints resource; never rely on resource ID naming conventions such as `<kind>_template`
   ALWAYS keep the proposal conservative and report ambiguity instead of guessing
   ALWAYS propose a default manifest before any write when no legacy manifest is present
   ALWAYS use top-level `manifest_version = "1.0"` plus `[[kits]]` + `[[kits.resources]]`; never emit `[kit]` or top-level `[[resources]]`
@@ -279,7 +287,7 @@ TITLE: Approve the proposed canonical manifest for this folder?
 OPTIONS:
   1 approve-default -> SET APPROVED_PREVIEW = CURRENT_PREVIEW_TOML; RUN write APPROVED_PREVIEW bytes exactly to `<target>/.cf-studio-kit.toml`; RUN verify the written file bytes equal APPROVED_PREVIEW; CONTINUE KitInitValidateWrittenManifest
   2 show-preview -> EMIT CURRENT_PREVIEW_TOML in a fenced `toml` block; EMIT CURRENT_PREVIEW_REPORT; EMIT_MENU KitInitDiscoveryApprovalMenu; WAIT user.reply; STOP_TURN
-  3 edit -> SET PENDING_EDIT_BRANCH = discovery; EMIT "Reply with edit commands such as `set metadata.name=<name>`, `add resource id=<id> kind=<kind> source=<path>`, `remove resource id=<id>`, `set resource <id>.aliases=<a,b>`, `set resource <id>.install_path=<path>`, `set resource <id>.prefix_generated_name=false`, or `exclude source=<path>`."; WAIT user.reply; STOP_TURN
+  3 edit -> SET PENDING_EDIT_BRANCH = discovery; EMIT "Reply with edit commands such as `set metadata.name=<name>`, `add resource id=<id> kind=<kind> source=<path>`, `remove resource id=<id>`, `set resource <id>.aliases=<a,b>`, `set resource <id>.install_path=<path>`, `set resource <id>.prefix_generated_name=false`, `bind artifact <KIND>.template=<resource-id>`, `bind artifact <KIND>.examples=<resource-id>`, or `exclude source=<path>`."; WAIT user.reply; STOP_TURN
   4 rerun-discovery -> CONTINUE KitInitDiscoveryRun
   5 cancel -> STOP_TURN
   INVALID -> EMIT "Reply 1-5." and EMIT_MENU KitInitDiscoveryApprovalMenu
@@ -292,7 +300,8 @@ WHEN:
   REQUIRE PENDING_MANUAL_GUIDANCE == true
 DO:
   RUN parse the user reply as manual candidate resources, optional multiple kit declarations, resource kinds, metadata defaults, aliases, install paths, generated targets, and exclusions
-  RUN reject guidance that references sources outside TARGET_DIR, uses unsupported resource kinds, creates duplicate IDs, proposes an unsupported `manifest_version`, or omits every candidate resource
+  RUN parse optional artifact binding guidance such as `bind artifact <KIND>.template=<resource-id>`, `bind artifact <KIND>.examples=<resource-id>`, `bind artifact <KIND>.rules=<resource-id>`, and `bind artifact <KIND>.checklist=<resource-id>`
+  RUN reject guidance that references sources outside TARGET_DIR, uses unsupported resource kinds, creates duplicate IDs, proposes an unsupported `manifest_version`, binds an artifact role to an unknown resource ID, binds artifact metadata outside a constraints resource, or omits every candidate resource
   EMIT rejected guidance with reasons and EMIT_MENU KitInitManualGuidanceRetryMenu WHEN guidance is invalid
   WAIT user.reply WHEN guidance is invalid
   STOP_TURN WHEN guidance is invalid
@@ -306,6 +315,7 @@ DO:
   STOP_TURN
 RULES:
   ALWAYS produce a fresh proposal from manual guidance before entering the approval menu
+  ALWAYS preserve user-provided artifact bindings as constraints-resource `artifacts.<KIND>.*` resource-ID references
   NEVER treat manual guidance as edits to a missing preview
   NEVER write from manual guidance directly
 MENU KitInitManualGuidanceRetryMenu
@@ -323,8 +333,8 @@ PURPOSE: Apply user-supplied manifest edits, re-render the preview, and return t
 WHEN:
   REQUIRE PENDING_EDIT_BRANCH != unset
 DO:
-  RUN parse the user reply as requested manifest edits: metadata changes, kit additions/removals for multi-kit manifests, resource additions/removals, kind changes, aliases, install paths, generated targets, and fields to preserve
-  RUN reject edits that would reference sources outside TARGET_DIR, introduce duplicate kit slugs, introduce duplicate resource IDs within the same kit, use unsupported resource kinds, set `prefix_generated_name = false` on a non-public resource, remove required `manifest_version = "1.0"`, set an unsupported `manifest_version`, or contradict canonical manifest shape
+  RUN parse the user reply as requested manifest edits: metadata changes, kit additions/removals for multi-kit manifests, resource additions/removals, kind changes, aliases, install paths, generated targets, artifact bindings, and fields to preserve
+  RUN reject edits that would reference sources outside TARGET_DIR, introduce duplicate kit slugs, introduce duplicate resource IDs within the same kit, use unsupported resource kinds, set `prefix_generated_name = false` on a non-public resource, bind an artifact role to an unknown resource ID, put artifact bindings on a non-constraints resource, remove required `manifest_version = "1.0"`, set an unsupported `manifest_version`, or contradict canonical manifest shape
   EMIT the rejected edits with reasons and EMIT_MENU KitInitEditRetryMenu WHEN any requested edit is invalid
   WAIT user.reply WHEN any requested edit is invalid
   STOP_TURN WHEN any requested edit is invalid
@@ -341,6 +351,7 @@ DO:
 RULES:
   ALWAYS return edited manifests to a preview approval menu before any write
   ALWAYS preserve top-level `manifest_version = "1.0"` after applying edits
+  ALWAYS preserve artifact bindings as resource-ID references under the constraints resource, not as paths or naming-derived links
   ALWAYS recompute and show the public generated-name preview after applying edits and before returning to approval
   ALWAYS reject unsafe or unsupported edits instead of guessing
   NEVER write from an edit reply directly
@@ -360,6 +371,7 @@ WHEN:
   REQUIRE TARGET_SOURCE == legacy_manifest OR TARGET_SOURCE == discovery
 DO:
   RUN `{cfs_cmd} kit normalize <target> --dry-run`
+  RUN inspect the normalized manifest report for constraints resources with artifact kinds but no explicit template/example bindings; report these as actionable warnings because `validate-kits` will skip self-check for unknown relationships
   EMIT the validation report, manifest summary, and any warnings WHEN the dry-run passes
   EMIT the validation findings and the path that needs revision WHEN the dry-run reports fail or error
   STOP_TURN


### PR DESCRIPTION
Refactor artifact handling to support multiple artifact types in constraints resources. Introduce validation for artifact bindings and ensure comprehensive tests are in place. Update documentation to clarify expectations for these bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifests can carry explicit artifact bindings on constraints resources; validation and kit workflows use these bindings for template/example/rules/checklist mapping.

* **Bug Fixes**
  * Legacy filename/layout inferences are skipped when bindings exist; ambiguous bindings now emit warnings and avoid incorrect assumptions. Update flow preserves/merges manifest artifact bindings.

* **Documentation**
  * Kit Management spec and workflow docs updated with new binding rules and user-facing binding commands.

* **Tests**
  * Expanded tests for manifest bindings, validation paths, migration/update fast-paths, and install/sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->