### PR TITLE
Remove SKILL.md references and update documentation

### DIFF
--- a/architecture/ADR/0010-cpt-studio-adr-skill-md-entry-point-v1.md
+++ b/architecture/ADR/0010-cpt-studio-adr-skill-md-entry-point-v1.md
@@ -49,14 +49,14 @@ Chosen: **SKILL.md as the canonical agent entry point**, with generated per-agen
 ### Consequences
 
 Architecture:
-- `{cf-studio-path}/.gen/SKILL.md` — composed from core + kit SKILL.md extensions
+- Superseded: the generated skill aggregate is no longer generated or loaded; generated skills and workflows are emitted through agent integration files.
 - `{cf-studio-path}/config/AGENTS.md` — WHEN rules for conditional loading (system prompts, kit rules)
-- Per-agent entry points (`.windsurf/workflows/`, `.cursor/rules/`, etc.) — generated shims that point to SKILL.md
+- Per-agent entry points (`.windsurf/workflows/`, `.cursor/rules/`, etc.) — generated shims that point to canonical Studio skill/workflow sources
 
 SKILL.md contains: command reference, workflow routing, execution protocol, and variable definitions. It is the single document an agent needs to operate Studio.
 
 * Good, because one source of truth — change SKILL.md, all agents get the update
-* Good, because kits extend SKILL.md through composition (kit SKILL.md → `.gen/SKILL.md`)
+* Superseded: kits now expose public skill/workflow entrypoints through generated agent integration files instead of generated skill aggregate composition
 * Good, because agent shims are auto-generated and fully overwritten on each `cfs agents` invocation
 * Bad, because SKILL.md can become large — mitigated by AGENTS.md WHEN rules for conditional loading
 * Bad, because agent-specific format quirks require per-agent template maintenance

--- a/architecture/DESIGN.md
+++ b/architecture/DESIGN.md
@@ -214,7 +214,7 @@ Version output distinguishes package metadata from installed state. `--version` 
 
 - [ ] `p1` - `cpt-studio-fr-core-layout-migration`
 
-**Design Response**: The Layout Migrator is a component in the Kit Manager that detects the old directory layout and performs automatic restructuring (generated outputs from `.gen/kits/` to `config/kits/`). This is an internal v3 restructuring, not a version bump. Detection: if `{cf-studio-path}/.gen/kits/{slug}/` exists → old layout. Migration steps: (1) backup affected directories, (2) move `.gen/kits/{slug}/` → `config/kits/{slug}/` (generated outputs), (3) remove old `kits/{slug}/` reference copies if present, (4) remove `.gen/kits/` directory (preserve `.gen/AGENTS.md`, `.gen/SKILL.md`, `.gen/README.md`), (5) update `core.toml` kit registrations. Rollback: if any step fails, restore from backup and report error. Runs automatically during `cfs update`.
+**Design Response**: The Layout Migrator is a component in the Kit Manager that detects the old directory layout and performs automatic restructuring (generated outputs from `.gen/kits/` to `config/kits/`). This is an internal v3 restructuring, not a version bump. Detection: if `{cf-studio-path}/.gen/kits/{slug}/` exists → old layout. Migration steps: (1) backup affected directories, (2) move `.gen/kits/{slug}/` → `config/kits/{slug}/` (generated outputs), (3) remove old `kits/{slug}/` reference copies if present, (4) remove `.gen/kits/` directory (preserve `.gen/AGENTS.md` and `.gen/README.md`), (5) update `core.toml` kit registrations. Rollback: if any step fails, restore from backup and report error. Runs automatically during `cfs update`.
 
 ##### Remaining SDLC Requirements (EXTRACTED — External Package)
 
@@ -722,7 +722,7 @@ Manages the kit lifecycle — installing, registering, and updating kits. Enable
 
 ##### Responsibility scope
 
-- Kit installation from GitHub or local directories: download kit from a GitHub source (`cfs kit install <owner/repo[@version]>`) or install from a local directory (`cfs kit install --path <dir>`), copy all kit files from source into `{cf-studio-path}/config/kits/{slug}/`, register in `core.toml` with source and version metadata plus kit tracking policy, regenerate `.gen/AGENTS.md` and `.gen/SKILL.md` to include the new kit's navigation and skill routing. In tracked mode, files in the kit's config directory are user-editable and preserved across updates via interactive diff; in ignored mode, they are generated/ephemeral and overwriteable
+- Kit installation from GitHub or local directories: download kit from a GitHub source (`cfs kit install <owner/repo[@version]>`) or install from a local directory (`cfs kit install --path <dir>`), copy all kit files from source into `{cf-studio-path}/config/kits/{slug}/`, register in `core.toml` with source and version metadata plus kit tracking policy, regenerate `.gen/AGENTS.md` for public rules, and generate skill/workflow entrypoints through agent integration files. In tracked mode, files in the kit's config directory are user-editable and preserved across updates via interactive diff; in ignored mode, they are generated/ephemeral and overwriteable
 - Manifest-driven installation (see `cpt-studio-fr-core-kit-manifest`): the Kit Manager loads kit sources through a normalized `KitModel`. New kits use canonical `.cf-studio-kit.toml`; legacy `manifest.toml` v1/v2, ADR-0019 component manifests, and `conf.toml + layout` kits remain compatibility inputs. The Kit Manager validates the normalized model, reads all declared resources, prompts for effective destinations or local copy/register mode when required, copies or registers each resource, resolves template variables (`{identifier}`) from effective resource bindings, and registers resolved paths, install mode, hashes, provenance, and warnings in `core.toml` under `[kits.{slug}.resources]`. If no manifest-style input is present, it falls back to legacy predefined content directories and files.
 - Kit registration: add kit entry to `{cf-studio-path}/config/core.toml` with config output path, source provenance (`github`, `local_path`, or other explicit source type), requested source, effective source after mirror/fork override, version/ref, content identity, verification state, and resolved resource paths (`resources` map)
 - Version tracking: for GitHub-backed kits, resolve versions through the effective GitHub source's releases/tags; for local/path kits, record local provenance and content identity without GitHub update semantics. Kit source, version/ref, identity, and verification state are tracked in `core.toml`; kit-local metadata may also be stored in `{cf-studio-path}/config/kits/{slug}/conf.toml`
@@ -953,7 +953,7 @@ sequenceDiagram
         Config Manager->>Config Manager: write core.toml (root system, kit tracking, pinned metadata, no kits)
         Config Manager->>Config Manager: write artifacts.toml (root system, autodetect defaults)
         Config Manager->>Config Manager: write managed .gitignore block
-        Skill Engine->>Skill Engine: regenerate .gen/AGENTS.md, .gen/SKILL.md
+        Skill Engine->>Skill Engine: regenerate .gen/AGENTS.md
         Skill Engine->>Agent Generator: generate entry points
         Agent Generator->>Agent Generator: write .windsurf/, .cursor/, etc.
         Skill Engine->>Skill Engine: inject root AGENTS.md entry
@@ -977,8 +977,8 @@ sequenceDiagram
                 Kit Manager->>Kit Manager: copy files to config/kits/sdlc/
                 Kit Manager->>Config Manager: register kit in core.toml with source + version
             end
-            Kit Manager->>Kit Manager: compose SKILL.md and AGENTS.md extensions
-            Skill Engine->>Skill Engine: regenerate .gen/AGENTS.md, .gen/SKILL.md
+            Kit Manager->>Kit Manager: collect AGENTS.md extensions and public entrypoints
+            Skill Engine->>Skill Engine: regenerate .gen/AGENTS.md
             Skill Engine->>Agent Generator: regenerate entry points (include kit workflows)
             Skill Engine-->>User: "Studio initialized with SDLC kit"
         else user declines
@@ -1153,7 +1153,7 @@ sequenceDiagram
     Kit Manager->>Kit Manager: add source field to kits without one
     Skill Engine->>Config Manager: persist project-pinned Studio version/source metadata
     Skill Engine->>Config Manager: rewrite managed .gitignore block
-    Skill Engine->>Skill Engine: regenerate .gen/AGENTS.md, .gen/SKILL.md
+    Skill Engine->>Skill Engine: regenerate .gen/AGENTS.md
     Skill Engine->>Agent Generator: regenerate entry points
     alt --with-kits yes|true
         Skill Engine->>Kit Manager: update kit files using tracking policy safety contract

--- a/architecture/features/agent-integration.md
+++ b/architecture/features/agent-integration.md
@@ -14,13 +14,13 @@
 - [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
   - [Discover Supported Agents](#discover-supported-agents)
   - [Generate Agent Shims](#generate-agent-shims)
-  - [Compose SKILL.md](#compose-skillmd)
+  - [Generate Skill Entrypoints](#generate-skill-entrypoints)
   - [List Workflow Files](#list-workflow-files)
 - [4. States (CDSL)](#4-states-cdsl)
   - [Agent Entry Point State](#agent-entry-point-state)
 - [5. Definitions of Done](#5-definitions-of-done)
   - [Agent Entry Point Generation](#agent-entry-point-generation)
-  - [SKILL.md Composition](#skillmd-composition)
+  - [Skill Entrypoint Generation](#skill-entrypoint-generation)
   - [Workflow Discovery](#workflow-discovery)
 - [6. Implementation Modules](#6-implementation-modules)
 - [7. Acceptance Criteria](#7-acceptance-criteria)
@@ -191,13 +191,13 @@ Without this feature, users would need to manually create and maintain agent-spe
 - [x] - `p1` - Codex `reasoning_effort` → `model_reasoning_effort` value map (max → xhigh) - `inst-codex-effort-map`
 - [x] - `p1` - HTML comment helper for `reasoning_effort`/`context_window` on tools that ignore these fields - `inst-unsupported-field-comment`
 
-### Compose SKILL.md
+### Generate Skill Entrypoints
 
 - [x] `p1` - **ID**: `cpt-studio-algo-agent-integration-compose-skill`
 
-1. - `p1` - Read all `.gen/kits/*/SKILL.md` files - `inst-read-kit-skills`
-2. - `p1` - Assemble core commands section + per-kit skill sections - `inst-assemble-sections`
-3. - `p1` - Write composed SKILL.md to `.gen/SKILL.md` - `inst-write-skill`
+1. - `p1` - Discover public core and kit skill/workflow entrypoints from registered sources - `inst-read-kit-skills`
+2. - `p1` - Assemble per-agent skill entrypoint files that follow the canonical Studio workflow or skill source - `inst-assemble-sections`
+3. - `p1` - Write skill entrypoints into agent integration paths, never into `.gen/` aggregates - `inst-write-skill`
 
 ### List Workflow Files
 
@@ -235,13 +235,13 @@ Without this feature, users would need to manually create and maintain agent-spe
 - [x] - `p1` - Full overwrite on each invocation (no merge)
 - [x] - `p1` - `--dry-run` flag shows what would be generated without writing
 
-### SKILL.md Composition
+### Skill Entrypoint Generation
 
 - [x] `p1` - **ID**: `cpt-studio-dod-agent-integration-skill-composition`
 
-- [x] - `p1` - Composed SKILL.md includes core commands section
-- [x] - `p1` - Composed SKILL.md includes all `@cpt:skill` sections from installed kits
-- [x] - `p1` - Composed SKILL.md written to `.gen/SKILL.md`
+- [x] - `p1` - Agent integration files include core skill/workflow entrypoints
+- [x] - `p1` - Agent integration files include public skill/workflow entrypoints from installed kits
+- [x] - `p1` - No generated skill or workflow entrypoint is written to a generated aggregate under `.gen/`
 - [x] - `p1` - Root skill metadata advertises all chat-facing route families
   rather than only plan/generate/analyze/workspace shortcuts
 

--- a/architecture/features/kit-management.md
+++ b/architecture/features/kit-management.md
@@ -256,15 +256,14 @@ Enables users to install, update, and validate kit packages with interactive fil
 
 **Input**: Studio adapter directory
 
-**Output**: Updated `.gen/AGENTS.md`, `.gen/SKILL.md`, `.gen/README.md`
+**Output**: Updated `.gen/AGENTS.md`, `.gen/README.md`
 
 **Steps**:
 1. [x] - `p1` - Read installed kit registrations from `config/core.toml`; unregistered `config/kits/*` directories never contribute generated aggregate output - `inst-scan-kits`
-2. [x] - `p1` - Collect metadata (skill_nav, agents_content) from each registered kit - `inst-collect-all-metadata`
+2. [x] - `p1` - Collect agent-rule metadata from each registered kit - `inst-collect-all-metadata`
 3. [x] - `p1` - Read project name from `config/artifacts.toml [[systems]][0].name` (per `cpt-studio-adr-remove-system-from-core-toml`) - `inst-read-project-name`
 4. [x] - `p1` - Compose and write `.gen/AGENTS.md` with navigation rules and kit agent content - `inst-write-gen-agents`
-5. [x] - `p1` - Compose and write `.gen/SKILL.md` with per-kit skill navigation pointers - `inst-write-gen-skill`
-6. [x] - `p1` - Write `.gen/README.md` using `_gen_readme()` - `inst-write-gen-readme`
+5. [x] - `p1` - Write `.gen/README.md` using `_gen_readme()` - `inst-write-gen-readme`
 
 **Supporting**:
 - [x] - `p1` - Top-level `regenerate_gen_aggregates` function orchestrating all gen steps - `inst-regen-fn`
@@ -717,7 +716,7 @@ Enables users to install, update, and validate kit packages with interactive fil
    4. [x] - `p1` - **IF** register mode: leave files in place and bind the resource to its source path after containment validation - `inst-manifest-register-resource-in-place`
 5. [x] - `p1` - Preserve `{identifier}` template variables in copied kit source files; expose effective bindings for read-time resolution by consumers - `inst-manifest-resolve-vars`
 6. [x] - `p1` - Register effective resource paths, install mode, hashes, generated names, provenance, and warnings in `core.toml`; prefer paths relative to `{cf-studio-path}` or project root when deterministic, and fail the operation when registration cannot be persisted - `inst-manifest-register-bindings`
-7. [x] - `p1` - Collect public component metadata for `.gen/` aggregation from registered manifest resources only: public `skill` resources route through `.gen/SKILL.md`, public `rule` resources are injected into `.gen/AGENTS.md`, and undeclared root `AGENTS.md`/`SKILL.md` files are ignored - `inst-manifest-collect-meta`
+7. [x] - `p1` - Collect public component metadata for `.gen/` aggregation from registered manifest resources only: public `rule` resources are injected into `.gen/AGENTS.md`, public `skill` resources are emitted only through agent integration files, and undeclared root `AGENTS.md`/`SKILL.md` files are ignored - `inst-manifest-collect-meta`
 8. [x] - `p1` - Generate target-specific agent integration files only for public `agent` resources and nested subagents; public `rule` resources never generate per-agent rule/config files - `inst-manifest-public-rule-gen-boundary`
 9. [x] - `p1` - **RETURN** result with status, install_mode, resource_bindings, files_copied, files_registered, generated_names, warnings, and risk fingerprint - `inst-manifest-return`
 
@@ -899,8 +898,8 @@ Enables users to install, update, and validate kit packages with interactive fil
 - [x] `p1` - `cfs kit update` with canonical or legacy manifest on legacy install: auto-populates resource bindings from existing kit root + manifest defaults
 - [x] `p1` - `cfs kit update` with resource bindings: updates files at their registered paths (not default `config/kits/{slug}/` paths); new resources without bindings go to default paths
 - [x] `p1` - `cfs validate-kits` validates all registered kits (constraints + templates); for manifest kits, verifies registered resource paths exist
-- [x] `p1` - `.gen/AGENTS.md` and `.gen/SKILL.md` are regenerated after install/update
-- [x] `p1` - `cfs generate-agents` consumes `KitModel.public_components` and emits skills/subagents/rules, not workflow directory scans, for manifest-backed kits
+- [x] `p1` - `.gen/AGENTS.md` is regenerated after install/update; generated skill/workflow entry points are emitted through agent integration files
+- [x] `p1` - `cfs generate-agents` consumes `KitModel.public_components` and emits skills/subagents/rules into agent integration files, not workflow directory scans, for manifest-backed kits
 - [x] `p1` - Public skills and subagents generated from kits are named `cf-{kit-slug}-{name}` and already-prefixed names are not double-prefixed
 - [x] `p1` - Legacy `workflow` entries are surfaced as skills with `origin = "legacy-workflow"` and deprecated workflow output is derived from those skills only for compatibility
 - [x] `p1` - File-level diff correctly handles TOC stripping, conflict merging, and editor integration

--- a/architecture/features/version-config.md
+++ b/architecture/features/version-config.md
@@ -157,7 +157,7 @@ Ensures teams can upgrade Studio without losing configuration or customizations 
 1. [x] - `p1` - Backup affected directories - `inst-layout-backup`
 2. [x] - `p1` - Move generated outputs: `.gen/kits/{slug}/` → `config/kits/{slug}/` - `inst-layout-move-gen`
 3. [x] - `p1` - Remove old `kits/{slug}/` reference copies if present - `inst-layout-remove-refs`
-4. [x] - `p1` - Remove `.gen/kits/` directory (preserve `.gen/AGENTS.md`, `.gen/SKILL.md`, `.gen/README.md`) - `inst-layout-clean-gen`
+4. [x] - `p1` - Remove `.gen/kits/` directory (preserve `.gen/AGENTS.md` and `.gen/README.md`) - `inst-layout-clean-gen`
 5. [x] - `p1` - Update `core.toml` kit registrations with new paths (`config/kits/{slug}`) - `inst-layout-update-core`
 6. [x] - `p1` - **IF** any step fails, restore from backup and report error - `inst-layout-rollback`
 

--- a/architecture/specs/cli.md
+++ b/architecture/specs/cli.md
@@ -236,7 +236,7 @@ cfs update [--project-root P] [--dry-run] [--no-interactive] [-y/--yes]
 1. Resolve project root and Constructor Studio directory.
 2. Replace `.core/` from cache (always force-overwrite).
 3. For each kit in cache: compare kit version (skip same, file-level diff if newer, copy on first install), update kit files in `config/kits/{slug}/` via interactive diff prompts.
-4. Write aggregate `.gen/AGENTS.md` and `.gen/SKILL.md` from collected kit parts.
+4. Write aggregate `.gen/AGENTS.md` from collected kit rule parts.
 5. Ensure `config/` scaffold files exist (create only if missing).
 6. Re-inject root `AGENTS.md` and `CLAUDE.md` managed blocks.
 7. Auto-regenerate agent integration files if real changes happened.
@@ -254,7 +254,7 @@ cfs update [--project-root P] [--dry-run] [--no-interactive] [-y/--yes]
     "core_update": {"architecture": "updated", "skills": "updated", "...": "..."},
     "kits": {"sdlc": {"kit": "sdlc", "version": {"status": "current"}, "gen": {"files_written": 25}}},
     "gen_agents": "updated",
-    "gen_skill": "updated"
+    "gen_readme": "updated"
   },
   "self_check": {"status": "PASS", "kits_checked": 1, "templates_checked": 9}
 }

--- a/architecture/specs/kit/kit.md
+++ b/architecture/specs/kit/kit.md
@@ -89,7 +89,7 @@ Top-level `.gen/` retains only aggregate files: `AGENTS.md`, `SKILL.md`, `README
    - **If `manifest.toml` present**: validate manifest, prompt user for `user_modifiable` resource paths (offering defaults), copy each resource to its resolved path, resolve `{identifier}` template variables in kit files, register all resource bindings in `core.toml` under `[kits.{slug}.resources]`
    - **If no `manifest.toml`**: copy all kit files from source to `{cf-studio-path}/config/kits/{slug}/` (legacy behavior)
    - Register kit in `core.toml`
-2. Regenerate `.gen/AGENTS.md` and `.gen/SKILL.md` to include the new kit's navigation and skill routing
+2. Regenerate `.gen/AGENTS.md` to include public kit rules; generate skill/workflow entrypoints through agent integration files
 3. Users may freely edit any kit file at any time
 4. On kit update, the system compares new files against user's installed copies via file-level diff (using registered resource paths for manifest-driven kits), then regenerates `.gen/` aggregate files. New resources in the updated manifest trigger a path prompt; removed resources produce a warning
 

--- a/skills/studio/SKILL.md
+++ b/skills/studio/SKILL.md
@@ -20,20 +20,19 @@ DO:
   REQUIRE {cf-studio-path} is resolved before CommandResolution and before any LOAD below, since CommandResolution's fallback path depends on {cf-studio-path}
   RUN CommandResolution to resolve {cfs_cmd}
   LOAD and REMEMBER rules from {cf-studio-path}/.gen/AGENTS.md
-  LOAD and REMEMBER rules from {cf-studio-path}/.gen/SKILL.md
   LOAD and REMEMBER rules from {cf-studio-path}/config/AGENTS.md WHEN that file exists; SKIP it without error WHEN it is absent
   LOAD and REMEMBER rules from {cf-studio-path}/config/SKILL.md WHEN that file exists; SKIP it without error WHEN it is absent
   LOAD and REMEMBER rules from {cf-studio-path}/.core/requirements/pdsl-execution-card.md
   LOAD and REMEMBER all UNIT rules defined in this file
   SET CFS_INIT = true
   RUN CliCapabilities to discover and remember the available {cfs_cmd} commands
-  EMIT a load report that names each loaded rule source ({cf-studio-path}/.gen/AGENTS.md, {cf-studio-path}/.gen/SKILL.md, {cf-studio-path}/config/AGENTS.md and {cf-studio-path}/config/SKILL.md when present, {cf-studio-path}/.core/requirements/pdsl-execution-card.md, and the UNIT rules in this file) and confirms cf is ready to follow them
+  EMIT a load report that names each loaded rule source ({cf-studio-path}/.gen/AGENTS.md, {cf-studio-path}/config/AGENTS.md and {cf-studio-path}/config/SKILL.md when present, {cf-studio-path}/.core/requirements/pdsl-execution-card.md, and the UNIT rules in this file) and confirms cf is ready to follow them
   CONTINUE IntentRouting
 RULES:
   ALWAYS treat cf and cf-studio as the same skill, where cf-studio is a proxy alias to cf
   ALWAYS limit cf/cf-studio to initiating the session and loading core rules
   ALWAYS run CommandResolution then CliCapabilities on every cf/cf-studio activation, before routing
-  ALWAYS load the {cf-studio-path}/.gen/AGENTS.md and {cf-studio-path}/.gen/SKILL.md rule sources as mandatory
+  ALWAYS load the {cf-studio-path}/.gen/AGENTS.md rule source as mandatory
   ALWAYS treat the {cf-studio-path}/config/AGENTS.md and {cf-studio-path}/config/SKILL.md rule sources as optional, loading each when it exists and skipping it without error when it is absent
   ALWAYS report the loaded rule sources and confirm readiness to follow them before routing
 NOTES:

--- a/skills/studio/scripts/studio/commands/init.py
+++ b/skills/studio/scripts/studio/commands/init.py
@@ -1029,7 +1029,7 @@ def _repair_existing_install(
                 config_skill_path.write_text(
                     "# Custom Skill Extensions\n\n"
                     "Add your project-specific skill instructions here.\n"
-                    "These are loaded alongside the generated skills in `{cf-studio-path}/.gen/SKILL.md`.\n",
+                    "Agent-facing skills and workflows are generated into agent integration files.\n",
                     encoding="utf-8",
                 )
                 actions["config_skill"] = "created"
@@ -1519,7 +1519,7 @@ def cmd_init(argv: List[str]) -> int:
                 "# Custom Skill Extensions\n"
                 "\n"
                 "Add your project-specific skill instructions here.\n"
-                "These are loaded alongside the generated skills in `{cf-studio-path}/.gen/SKILL.md`.\n",
+                "Agent-facing skills and workflows are generated into agent integration files.\n",
                 encoding="utf-8",
             )
             actions["config_skill"] = "created"

--- a/skills/studio/scripts/studio/commands/kit.py
+++ b/skills/studio/scripts/studio/commands/kit.py
@@ -808,25 +808,11 @@ def _collect_kit_metadata(
     """Read installed kit files and return metadata for .gen/ aggregation.
 
     Returns dict with:
-        skill_nav      — navigation line for ``.gen/SKILL.md``
         agents_content — raw content of kit's AGENTS.md for ``.gen/AGENTS.md``
     """
     # @cpt-begin:cpt-studio-algo-kit-content-mgmt:p1:inst-collect-metadata
     result: Dict[str, str] = {"skill_nav": "", "agents_content": ""}
     kit_rel_path = _normalize_registered_kit_path(registered_kit_path, kit_slug)
-
-    skill_path = config_kit_dir / _KIT_SKILL_FILE if config_kit_dir is not None else None
-    if (
-        (skill_path is not None and skill_path.is_file())
-        or (config_kit_dir is None and _is_registered_kit_path_absolute(kit_rel_path))
-    ):
-        if not kit_rel_path:
-            skill_target = f"{{cf-studio-path}}/{_KIT_SKILL_FILE}"
-        elif _is_registered_kit_path_absolute(kit_rel_path):
-            skill_target = f"{kit_rel_path}/{_KIT_SKILL_FILE}"
-        else:
-            skill_target = f"{{cf-studio-path}}/{kit_rel_path}/{_KIT_SKILL_FILE}"
-        result["skill_nav"] = f"ALWAYS invoke `{skill_target}` FIRST"
 
     agents_path = config_kit_dir / _KIT_AGENTS_FILE if config_kit_dir is not None else None
     if agents_path is not None and agents_path.is_file():
@@ -872,7 +858,6 @@ def _collect_registered_kit_metadata(
 
     result: Dict[str, str] = {"skill_nav": "", "agents_content": ""}
     agents_parts: List[str] = []
-    skill_nav_parts: List[str] = []
     for _res_id, raw_binding in sorted(resources.items()):
         if not isinstance(raw_binding, dict):
             raw_binding = {"path": raw_binding} if isinstance(raw_binding, str) else {}
@@ -894,15 +879,12 @@ def _collect_registered_kit_metadata(
         if binding_abs is None or not binding_abs.is_file():
             continue
         if kind == "skill":
-            skill_nav_parts.append(
-                f"ALWAYS invoke `{_registered_metadata_target(binding_path)}` FIRST",
-            )
+            continue
         elif kind == "rule":
             try:
                 agents_parts.append(binding_abs.read_text(encoding="utf-8"))
             except OSError:
                 pass
-    result["skill_nav"] = "\n\n".join(skill_nav_parts)
     result["agents_content"] = "\n\n".join(part for part in agents_parts if part)
     return result
 
@@ -914,16 +896,16 @@ def _collect_registered_kit_metadata(
 # @cpt-algo:cpt-studio-algo-kit-regen-gen:p1
 # @cpt-begin:cpt-studio-algo-kit-regen-gen:p1:inst-regen-fn
 def regenerate_gen_aggregates(studio_dir: Path) -> Dict[str, Any]:
-    """Regenerate .gen/AGENTS.md, .gen/SKILL.md, .gen/README.md from all installed kits.
+    """Regenerate .gen/AGENTS.md and .gen/README.md from all installed kits.
 
-    Reads registered kits from core.toml, collects metadata (skill_nav,
-    agents_content) from each registered kit, and writes the aggregate files
-    into .gen/.
+    Reads registered kits from core.toml, collects AGENTS.md metadata from each
+    registered kit, and writes the aggregate files into .gen/.
 
     This is the canonical function — called by cmd_kit_install, cmd_kit_update,
     cmd_init, and cmd_update.
 
-    Returns dict with keys: gen_agents, gen_skill, gen_readme (action strings).
+    Returns dict with keys: gen_agents and gen_readme (action strings), and
+    gen_skill when a legacy generated skill aggregate is removed.
     """
     config_dir = studio_dir / "config"
     gen_dir = studio_dir / ".gen"
@@ -933,14 +915,11 @@ def regenerate_gen_aggregates(studio_dir: Path) -> Dict[str, Any]:
 
     # @cpt-begin:cpt-studio-algo-kit-regen-gen:p1:inst-scan-kits
     # Collect metadata from all installed kits
-    gen_skill_nav_parts: List[str] = []
     gen_agents_parts: List[str] = []
     kits_map = _read_kits_from_core_toml(config_dir)
     for kit_slug in sorted(kits_map):
         # @cpt-begin:cpt-studio-algo-kit-regen-gen:p1:inst-collect-all-metadata
         meta = _collect_registered_kit_metadata(studio_dir, kit_slug, kits_map.get(kit_slug, {}))
-        if meta["skill_nav"]:
-            gen_skill_nav_parts.append(meta["skill_nav"])
         if meta["agents_content"]:
             gen_agents_parts.append(meta["agents_content"])
         # @cpt-end:cpt-studio-algo-kit-regen-gen:p1:inst-collect-all-metadata
@@ -972,17 +951,10 @@ def regenerate_gen_aggregates(studio_dir: Path) -> Dict[str, Any]:
     result["gen_agents"] = "updated"
     # @cpt-end:cpt-studio-algo-kit-regen-gen:p1:inst-write-gen-agents
 
-    # @cpt-begin:cpt-studio-algo-kit-regen-gen:p1:inst-write-gen-skill
-    # Write .gen/SKILL.md
-    nav_rules = "\n\n".join(gen_skill_nav_parts) if gen_skill_nav_parts else ""
-    (gen_dir / _KIT_SKILL_FILE).write_text(
-        "# Studio Generated Skills\n\n"
-        "This file routes to per-kit skill instructions.\n\n"
-        + (nav_rules + "\n" if nav_rules else ""),
-        encoding="utf-8",
-    )
-    result["gen_skill"] = "updated"
-    # @cpt-end:cpt-studio-algo-kit-regen-gen:p1:inst-write-gen-skill
+    legacy_gen_skill = gen_dir / _KIT_SKILL_FILE
+    if legacy_gen_skill.exists():
+        legacy_gen_skill.unlink()
+        result["gen_skill"] = "deleted"
 
     # @cpt-begin:cpt-studio-algo-kit-regen-gen:p1:inst-write-gen-readme
     # Write .gen/README.md

--- a/skills/studio/scripts/studio/commands/kit.py
+++ b/skills/studio/scripts/studio/commands/kit.py
@@ -811,8 +811,8 @@ def _collect_kit_metadata(
         agents_content — raw content of kit's AGENTS.md for ``.gen/AGENTS.md``
     """
     # @cpt-begin:cpt-studio-algo-kit-content-mgmt:p1:inst-collect-metadata
+    del kit_slug, registered_kit_path
     result: Dict[str, str] = {"skill_nav": "", "agents_content": ""}
-    kit_rel_path = _normalize_registered_kit_path(registered_kit_path, kit_slug)
 
     agents_path = config_kit_dir / _KIT_AGENTS_FILE if config_kit_dir is not None else None
     if agents_path is not None and agents_path.is_file():
@@ -833,12 +833,6 @@ def _binding_is_public_metadata_resource(binding: Dict[str, Any], kind: str) -> 
     if isinstance(public_value, str):
         return public_value.strip().lower() in {"1", "true", "yes", "on"}
     return kind in {"skill", "rule"}
-
-
-def _registered_metadata_target(binding_path: str) -> str:
-    if _is_registered_kit_path_absolute(binding_path):
-        return binding_path
-    return f"{{cf-studio-path}}/{binding_path}"
 
 
 def _collect_registered_kit_metadata(

--- a/skills/studio/scripts/studio/commands/update.py
+++ b/skills/studio/scripts/studio/commands/update.py
@@ -653,7 +653,7 @@ def cmd_update(argv: List[str]) -> int:
             config_dir / "SKILL.md",
             "# Custom Skill Extensions\n\n"
             "Add your project-specific skill instructions here.\n"
-            "These are loaded alongside the generated skills in `{cf-studio-path}/.gen/SKILL.md`.\n",
+            "Agent-facing skills and workflows are generated into agent integration files.\n",
             actions, "config_skill",
         )
 

--- a/tests/test_kit.py
+++ b/tests/test_kit.py
@@ -4991,53 +4991,41 @@ class TestCollectKitMetadataOsError(unittest.TestCase):
             meta = _collect_kit_metadata(kit_dir, "sdlc")
             self.assertEqual(meta["agents_content"], "")
 
-    def test_skill_nav_uses_registered_custom_path(self):
+    def test_skill_nav_ignores_registered_custom_path(self):
         from studio.commands.kit import _collect_kit_metadata
         with TemporaryDirectory() as td:
             kit_dir = Path(td) / "custom-kits" / "sdlc"
             kit_dir.mkdir(parents=True)
             (kit_dir / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
             meta = _collect_kit_metadata(kit_dir, "sdlc", "custom-kits/sdlc")
-            self.assertEqual(
-                meta["skill_nav"],
-                "ALWAYS invoke `{cf-studio-path}/custom-kits/sdlc/SKILL.md` FIRST",
-            )
+            self.assertEqual(meta["skill_nav"], "")
 
-    def test_skill_nav_uses_absolute_registered_custom_path(self):
+    def test_skill_nav_ignores_absolute_registered_custom_path(self):
         from studio.commands.kit import _collect_kit_metadata
         with TemporaryDirectory() as td:
             kit_dir = Path(td) / "custom-kits" / "sdlc"
             kit_dir.mkdir(parents=True)
             (kit_dir / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
             meta = _collect_kit_metadata(kit_dir, "sdlc", kit_dir.as_posix())
-            self.assertEqual(
-                meta["skill_nav"],
-                f"ALWAYS invoke `{kit_dir.as_posix()}/SKILL.md` FIRST",
-            )
+            self.assertEqual(meta["skill_nav"], "")
 
-    def test_skill_nav_uses_windows_drive_registered_custom_path(self):
+    def test_skill_nav_ignores_windows_drive_registered_custom_path(self):
         from studio.commands.kit import _collect_kit_metadata
         with TemporaryDirectory() as td:
             kit_dir = Path(td) / "custom-kits" / "sdlc"
             kit_dir.mkdir(parents=True)
             (kit_dir / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
             meta = _collect_kit_metadata(kit_dir, "sdlc", "C:/external-kits/sdlc")
-            self.assertEqual(
-                meta["skill_nav"],
-                "ALWAYS invoke `C:/external-kits/sdlc/SKILL.md` FIRST",
-            )
+            self.assertEqual(meta["skill_nav"], "")
 
-    def test_skill_nav_uses_windows_backslash_registered_custom_path(self):
+    def test_skill_nav_ignores_windows_backslash_registered_custom_path(self):
         from studio.commands.kit import _collect_kit_metadata
         with TemporaryDirectory() as td:
             kit_dir = Path(td) / "custom-kits" / "sdlc"
             kit_dir.mkdir(parents=True)
             (kit_dir / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
             meta = _collect_kit_metadata(kit_dir, "sdlc", r"C:\external-kits\sdlc")
-            self.assertEqual(
-                meta["skill_nav"],
-                "ALWAYS invoke `C:/external-kits/sdlc/SKILL.md` FIRST",
-            )
+            self.assertEqual(meta["skill_nav"], "")
 
     def test_registered_resource_metadata_uses_public_bindings_only(self):
         from studio.commands.kit import _collect_registered_kit_metadata
@@ -5066,10 +5054,7 @@ class TestCollectKitMetadataOsError(unittest.TestCase):
                 },
             )
 
-        self.assertEqual(
-            meta["skill_nav"],
-            "ALWAYS invoke `{cf-studio-path}/custom/SKILL.md` FIRST",
-        )
+        self.assertEqual(meta["skill_nav"], "")
         self.assertEqual(meta["agents_content"], "PUBLIC RULE\n")
         self.assertNotIn("PRIVATE RULE", meta["agents_content"])
 
@@ -5094,7 +5079,7 @@ class TestCollectKitMetadataOsError(unittest.TestCase):
                 },
             )
 
-        self.assertIn("{cf-studio-path}/external/SKILL.md", meta["skill_nav"])
+        self.assertEqual(meta["skill_nav"], "")
         self.assertEqual(meta["agents_content"], "LEGACY RULE\n")
 
     def test_prompt_manifest_install_plan_allows_root_and_resource_overrides(self):
@@ -5648,10 +5633,8 @@ class TestRegenerateGenAggregates(unittest.TestCase):
 
             regenerate_gen_aggregates(adapter)
 
-            gen_skill = (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8")
             gen_agents = (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertNotIn("Loose Skill", gen_skill)
-            self.assertNotIn("loose", gen_skill)
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
             self.assertNotIn("# Loose Agents", gen_agents)
 
     def test_uses_default_installed_kit_path_when_path_not_explicitly_registered(self):
@@ -5680,12 +5663,8 @@ class TestRegenerateGenAggregates(unittest.TestCase):
 
             regenerate_gen_aggregates(adapter)
 
-            gen_skill = (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8")
             gen_agents = (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertIn(
-                "ALWAYS invoke `{cf-studio-path}/config/kits/sdlc/SKILL.md` FIRST",
-                gen_skill,
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
             self.assertIn("# Default Agents", gen_agents)
 
     def test_uses_registered_custom_kit_path(self):
@@ -5715,12 +5694,8 @@ class TestRegenerateGenAggregates(unittest.TestCase):
 
             regenerate_gen_aggregates(adapter)
 
-            gen_skill = (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8")
             gen_agents = (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertIn(
-                "ALWAYS invoke `{cf-studio-path}/custom-kits/sdlc/SKILL.md` FIRST",
-                gen_skill,
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
             self.assertIn("# Custom Agents", gen_agents)
 
     def test_uses_registered_absolute_custom_kit_path(self):
@@ -5750,12 +5725,8 @@ class TestRegenerateGenAggregates(unittest.TestCase):
 
             regenerate_gen_aggregates(adapter)
 
-            gen_skill = (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8")
             gen_agents = (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertIn(
-                f"ALWAYS invoke `{custom_kit.as_posix()}/SKILL.md` FIRST",
-                gen_skill,
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
             self.assertIn("# Custom Agents", gen_agents)
 
     def test_uses_registered_windows_drive_custom_kit_path(self):
@@ -5787,12 +5758,8 @@ class TestRegenerateGenAggregates(unittest.TestCase):
 
             regenerate_gen_aggregates(adapter)
 
-            gen_skill = (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8")
             gen_agents = (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertIn(
-                "ALWAYS invoke `C:/external-kits/sdlc/SKILL.md` FIRST",
-                gen_skill,
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
             self.assertNotIn("# Fake Project Relative Agents", gen_agents)
 
     def test_uses_registered_windows_backslash_custom_kit_path(self):
@@ -5824,12 +5791,8 @@ class TestRegenerateGenAggregates(unittest.TestCase):
 
             regenerate_gen_aggregates(adapter)
 
-            gen_skill = (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8")
             gen_agents = (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8")
-            self.assertIn(
-                "ALWAYS invoke `C:/external-kits/sdlc/SKILL.md` FIRST",
-                gen_skill,
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
             self.assertNotIn("# Fake Project Relative Agents", gen_agents)
 
 

--- a/tests/test_kit.py
+++ b/tests/test_kit.py
@@ -384,10 +384,7 @@ class TestManifestKitStrictResourceAuthority(unittest.TestCase):
                 "UNDECLARED ROOT AGENTS",
                 (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8"),
             )
-            self.assertNotIn(
-                "UNDECLARED ROOT SKILL",
-                (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8"),
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
 
     def test_legacy_manifest_install_ignores_undeclared_root_metadata_files(self):
         from studio.commands.kit import install_kit, regenerate_gen_aggregates
@@ -410,10 +407,7 @@ class TestManifestKitStrictResourceAuthority(unittest.TestCase):
                 "UNDECLARED ROOT AGENTS",
                 (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8"),
             )
-            self.assertNotIn(
-                "UNDECLARED ROOT SKILL",
-                (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8"),
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
 
     def test_manifest_update_filters_undeclared_root_metadata_files(self):
         from studio.commands.kit import install_kit, update_kit
@@ -489,10 +483,7 @@ class TestManifestKitStrictResourceAuthority(unittest.TestCase):
                 "PUBLIC RULE SENTINEL",
                 (adapter / ".gen" / "AGENTS.md").read_text(encoding="utf-8"),
             )
-            self.assertNotIn(
-                "PUBLIC RULE SENTINEL",
-                (adapter / ".gen" / "SKILL.md").read_text(encoding="utf-8"),
-            )
+            self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
 
 
 class TestKitUpdateCheckCoverage(unittest.TestCase):
@@ -5667,6 +5658,28 @@ class TestRegenerateGenAggregates(unittest.TestCase):
             self.assertFalse((adapter / ".gen" / "SKILL.md").exists())
             self.assertIn("# Default Agents", gen_agents)
 
+    def test_deletes_legacy_generated_skill_aggregate(self):
+        from studio.commands.kit import regenerate_gen_aggregates
+        from studio.utils import toml_utils
+        with TemporaryDirectory() as td:
+            root = Path(td) / "proj"
+            adapter = _bootstrap_project(root)
+            config = adapter / "config"
+            gen_dir = adapter / ".gen"
+            gen_dir.mkdir(parents=True, exist_ok=True)
+            legacy_skill = gen_dir / "SKILL.md"
+            legacy_skill.write_text("# Studio Generated Skills\n", encoding="utf-8")
+            toml_utils.dump({
+                "version": "1.0",
+                "project_root": "..",
+                "kits": {},
+            }, config / "core.toml")
+
+            result = regenerate_gen_aggregates(adapter)
+
+            self.assertEqual(result["gen_skill"], "deleted")
+            self.assertFalse(legacy_skill.exists())
+
     def test_uses_registered_custom_kit_path(self):
         from studio.commands.kit import regenerate_gen_aggregates
         from studio.utils import toml_utils
@@ -6155,7 +6168,7 @@ class TestUpdateKitVersionPaths(unittest.TestCase):
             # Source has version=1 via conf.toml
             r = update_kit("tk", src, cyp, force=False)
             self.assertEqual(r["version"]["status"], "current")
-            self.assertIn("skill_nav", r)
+            self.assertNotIn("skill_nav", r)
 
     def test_manifest_invalid_binding_returns_failed_without_writing(self):
         from studio.commands.kit import update_kit

--- a/tests/test_kit_manifest_install.py
+++ b/tests/test_kit_manifest_install.py
@@ -824,7 +824,7 @@ class TestInstallKitWithManifest(unittest.TestCase):
             )
 
             self.assertIn("skill_nav", result)
-            self.assertIn("mykit", result["skill_nav"])
+            self.assertEqual(result["skill_nav"], "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pdsl_keywords.py
+++ b/tests/test_pdsl_keywords.py
@@ -113,7 +113,7 @@ def _cf_reference_has_existing_static_prefix(ref: str) -> bool:
         # namespace is canonical even when a concrete file is materialized only
         # after init/update.
         return True
-    if ref in {".gen/AGENTS.md", ".gen/SKILL.md"}:
+    if ref == ".gen/AGENTS.md":
         return True
     if ref.startswith(".gen/kits/") and any(token in ref for token in ("{", "}", "<", ">")):
         return True

--- a/tests/test_ui_human_mode.py
+++ b/tests/test_ui_human_mode.py
@@ -1566,7 +1566,7 @@ class TestHumanUpdateDetailed(_HumanModeBase):
                 "cypilot_dir": "/tmp/project/cypilot",
                 "actions": {
                     "gen_agents": "created",
-                    "gen_skill": "updated",
+                    "gen_readme": "updated",
                     "config_readme": "unchanged",
                     "core_update": {
                         "architecture": "updated",


### PR DESCRIPTION
Eliminate all references to SKILL.md in the codebase and update related documentation to reflect the changes in skill handling. This improves clarity and aligns the documentation with the current functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that skills/workflows are generated into agent integration files; updated architecture, design, and CLI docs to reflect layout and .gen regeneration scope.

* **Refactor**
  * Initialization now conditionally loads optional config files, always includes core requirements, emits explicit load reports, and no longer generates a legacy aggregated SKILL file (legacy SKILL aggregates are removed if present); agent entrypoints are used instead.
  * CLI output example field renamed from gen_skill to gen_readme.

* **Tests**
  * Updated tests to expect AGENTS-only aggregation, empty kit navigation, deleted legacy SKILL aggregates, and the CLI field rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->