### PR TITLE
Enhance _load_kit_layers for project root resolution and add tests

### DIFF
--- a/skills/studio/scripts/studio/utils/layer_discovery.py
+++ b/skills/studio/scripts/studio/utils/layer_discovery.py
@@ -104,7 +104,7 @@ def _load_repo_layer(studio_root: Path) -> Optional[ManifestLayer]:
 
 
 # @cpt-begin:cpt-studio-algo-project-extensibility-walk-up-discovery:p1:inst-load-kit-layers
-def _load_kit_layers(studio_root: Path) -> List[ManifestLayer]:
+def _load_kit_layers(studio_root: Path, project_root: Optional[Path] = None) -> List[ManifestLayer]:
     """Load kit manifest layers from kit registrations in ``core.toml``.
 
     Reads ``{studio_root}/config/core.toml``, iterates over ``[kits]``
@@ -114,6 +114,7 @@ def _load_kit_layers(studio_root: Path) -> List[ManifestLayer]:
     Kits with a parse error return a ``PARSE_ERROR`` state layer.
     """
     core_toml = studio_root / "config" / "core.toml"
+    trusted_root = (project_root or studio_root).resolve()
     if not core_toml.is_file():
         return []
 
@@ -135,18 +136,22 @@ def _load_kit_layers(studio_root: Path) -> List[ManifestLayer]:
         if not kit_path_raw:
             continue
 
-        kit_path = Path(str(kit_path_raw))
-        # Resolve relative paths against studio_root
-        if not kit_path.is_absolute():
-            kit_path = (studio_root / kit_path).resolve()
+        kit_path_raw_obj = Path(str(kit_path_raw))
+        # Resolve relative paths using registered-kit semantics: adapter
+        # relative first, with a project-root fallback for register-mode kits.
+        if not kit_path_raw_obj.is_absolute():
+            kit_path = (studio_root / kit_path_raw_obj).resolve()
+            project_relative_path = (trusted_root / kit_path_raw_obj).resolve()
+            if not kit_path.is_dir() and project_relative_path.is_dir():
+                kit_path = project_relative_path
         else:
-            kit_path = kit_path.resolve()
+            kit_path = kit_path_raw_obj.resolve()
 
-        # Post-resolve containment check (only for relative paths that could
-        # escape via '..' or symlinks; absolute paths are explicitly authored)
-        if not Path(str(kit_path_raw)).is_absolute() and not kit_path.is_relative_to(studio_root.resolve()):
+        # Post-resolve containment check for relative paths. Absolute paths are
+        # explicitly authored; relative paths must stay inside the project.
+        if not kit_path_raw_obj.is_absolute() and not kit_path.is_relative_to(trusted_root):
             logger.warning(
-                "Kit path '%s' resolves outside studio root, skipping",
+                "Kit path '%s' resolves outside project root, skipping",
                 kit_path_raw,
             )
             continue
@@ -241,7 +246,7 @@ def discover_layers(repo_root: Path, studio_root: Path) -> List[ManifestLayer]:
     # Step 1: Load kit layers from core.toml
     # @cpt-begin:cpt-studio-algo-project-extensibility-walk-up-discovery:p1:step-1-kit-layers
     layers: List[ManifestLayer] = []
-    kit_layers = _load_kit_layers(studio_root)
+    kit_layers = _load_kit_layers(studio_root, repo_root)
     layers.extend(kit_layers)
     # @cpt-end:cpt-studio-algo-project-extensibility-walk-up-discovery:p1:step-1-kit-layers
 

--- a/tests/test_layer_discovery.py
+++ b/tests/test_layer_discovery.py
@@ -347,6 +347,58 @@ version = "1.0.0"
             assert result[0].scope == "kit"
             assert result[0].state == ManifestLayerState.LOADED
 
+    def test_resolves_registered_sibling_kit_inside_project_root(self):
+        """Register-mode sibling kit paths may leave the Studio adapter but stay in the project."""
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "project"
+            cypilot_root = project_root / ".cf-studio"
+            kit_dir = project_root / "studio-kit-gears"
+            kit_dir.mkdir(parents=True)
+            (cypilot_root / "config").mkdir(parents=True)
+            _write(kit_dir / "manifest.toml", _VALID_V2_MANIFEST)
+
+            core_content = """\
+version = "1.0"
+
+[kits]
+[kits.gears]
+path = "../studio-kit-gears"
+format = "CFS"
+version = "1.0.0"
+"""
+            (cypilot_root / "config" / "core.toml").write_text(core_content)
+
+            result = _load_kit_layers(cypilot_root, project_root)
+            assert len(result) == 1
+            assert result[0].scope == "kit"
+            assert result[0].path == (kit_dir / "manifest.toml").resolve()
+
+    def test_project_relative_registered_kit_path_fallback(self):
+        """Project-relative kit paths are supported when adapter-relative path is absent."""
+        with TemporaryDirectory() as tmp:
+            project_root = Path(tmp) / "project"
+            cypilot_root = project_root / ".cf-studio"
+            kit_dir = project_root / "studio-kit-gears"
+            kit_dir.mkdir(parents=True)
+            (cypilot_root / "config").mkdir(parents=True)
+            _write(kit_dir / "manifest.toml", _VALID_V2_MANIFEST)
+
+            core_content = """\
+version = "1.0"
+
+[kits]
+[kits.gears]
+path = "studio-kit-gears"
+format = "CFS"
+version = "1.0.0"
+"""
+            (cypilot_root / "config" / "core.toml").write_text(core_content)
+
+            result = _load_kit_layers(cypilot_root, project_root)
+            assert len(result) == 1
+            assert result[0].scope == "kit"
+            assert result[0].path == (kit_dir / "manifest.toml").resolve()
+
 
 # ---------------------------------------------------------------------------
 # _load_master_layer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced kit path resolution logic to properly handle project-relative paths and added validation to prevent path traversal outside trusted directories. Kits violating containment rules are now skipped with clarified warning messages.

* **Tests**
  * Added test coverage for kit path resolution with project-relative paths, including sibling directory resolution and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->