### PR TITLE
Add support for registered public skill resources without a manifest

### DIFF
--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -2131,6 +2131,7 @@ def _list_public_component_skills(
     return components, manifest_backed_kits
 
 
+# @cpt-begin:cpt-studio-algo-kit-public-component-generation:p1:inst-public-explicit-install
 def _list_registered_public_resource_skills(
     studio_root: Path,
     project_root: Optional[Path],
@@ -2182,6 +2183,7 @@ def _list_registered_public_resource_skills(
             out.append((source_path.name, source_path, kit_slug, None))
             kit_slugs.add(kit_slug)
     return out, kit_slugs
+# @cpt-end:cpt-studio-algo-kit-public-component-generation:p1:inst-public-explicit-install
 
 # ---------------------------------------------------------------------------
 # Kit workflow → skill generation for skill-native tools

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -4566,8 +4566,49 @@ def cmd_generate_agents(argv: List[str]) -> int:
         return 0
 
     # Step 2: Show preview and ask for confirmation (interactive)
+    preview_has_fatal_errors = any(
+        r.get("status") in {"PARTIAL", "CONFIG_ERROR"} and _result_has_fatal_errors(r)
+        for r in preview_results.values()
+    )
+    if preview_has_fatal_errors:
+        agents_result = _build_result(
+            preview_results,
+            agents_to_process,
+            project_root,
+            studio_root,
+            cfg_path,
+            copy_report,
+            dry_run=False,
+        )
+        ui.result(
+            agents_result,
+            human_fn=lambda d: _human_generate_agents_ok(
+                d, agents_to_process, preview_results, dry_run=False,
+            ),
+        )
+        return 1
+
     if total_create == 0 and total_update == 0 and total_delete == 0:
-        ui.info("No changes needed — agent files are up to date.")
+        from ..utils.ui import is_json_mode
+        if is_json_mode():
+            agents_result = _build_result(
+                preview_results,
+                agents_to_process,
+                project_root,
+                studio_root,
+                cfg_path,
+                copy_report,
+                dry_run=False,
+            )
+            ui.result(
+                agents_result,
+                human_fn=lambda d: _human_generate_agents_ok(
+                    d, agents_to_process, preview_results, dry_run=False,
+                ),
+            )
+        else:
+            ui.info("No changes needed — agent files are up to date.")
+        return 0
     else:
         from ..utils.ui import is_json_mode
         if not is_json_mode():

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -2164,11 +2164,17 @@ def _list_registered_public_resource_skills(
             if not source_path.is_absolute():
                 source_path = studio_root / source_path
             source_path = source_path.resolve()
-            try:
-                source_path.relative_to(studio_root.resolve())
-            except ValueError:
+            allowed = False
+            for root in (studio_root, project_root):
+                try:
+                    source_path.relative_to(root.resolve())
+                    allowed = True
+                    break
+                except ValueError:
+                    pass
+            if not allowed:
                 sys.stderr.write(
-                    f"WARNING: kit {kit_slug!r} public skill source escapes studio root: {source_path}, skipping\n"
+                    f"WARNING: kit {kit_slug!r} public skill source escapes project/studio root: {source_path}, skipping\n"
                 )
                 continue
             if not source_path.is_file():

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -4566,6 +4566,7 @@ def cmd_generate_agents(argv: List[str]) -> int:
         return 0
 
     # Step 2: Show preview and ask for confirmation (interactive)
+    # @cpt-begin:cpt-studio-flow-agent-integration-generate:p1:inst-return-report
     preview_has_fatal_errors = any(
         r.get("status") in {"PARTIAL", "CONFIG_ERROR"} and _result_has_fatal_errors(r)
         for r in preview_results.values()
@@ -4609,6 +4610,7 @@ def cmd_generate_agents(argv: List[str]) -> int:
         else:
             ui.info("No changes needed — agent files are up to date.")
         return 0
+    # @cpt-end:cpt-studio-flow-agent-integration-generate:p1:inst-return-report
     else:
         from ..utils.ui import is_json_mode
         if not is_json_mode():
@@ -4662,6 +4664,7 @@ def cmd_generate_agents(argv: List[str]) -> int:
     # @cpt-end:cpt-studio-flow-agent-integration-generate:p1:inst-return-exit-code
 
 
+# @cpt-begin:cpt-studio-flow-agent-integration-generate:p1:inst-return-exit-code
 _OUTSIDE_SCOPE_MARKER = "resolves outside project_root and studio_root"
 
 
@@ -4693,6 +4696,7 @@ def _result_has_fatal_errors(result: Dict[str, Any]) -> bool:
         # Any other error (including non-string structured errors) is fatal.
         return True
     return False
+# @cpt-end:cpt-studio-flow-agent-integration-generate:p1:inst-return-exit-code
 
 
 # @cpt-begin:cpt-studio-algo-agent-integration-generate-shims:p1:inst-format-output

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -2117,7 +2117,58 @@ def _list_public_component_skills(
         if getattr(component, "kind", "") == "skill":
             generated_name = str(getattr(component, "generated_name", "")).strip()
             components.append((source_path.name, source_path, kit_slug, generated_name))
+    registered_skills, registered_skill_kits = _list_registered_public_resource_skills(
+        studio_root,
+        project_root,
+    )
+    seen_paths = {entry[1].resolve().as_posix() for entry in components}
+    for entry in registered_skills:
+        if entry[1].resolve().as_posix() in seen_paths:
+            continue
+        components.append(entry)
+        seen_paths.add(entry[1].resolve().as_posix())
+    manifest_backed_kits.update(registered_skill_kits)
     return components, manifest_backed_kits
+
+
+def _list_registered_public_resource_skills(
+    studio_root: Path,
+    project_root: Optional[Path],
+) -> Tuple[List[KitWorkflowSkill], Set[str]]:
+    """Return public skill resources declared in core.toml kit registrations."""
+    if project_root is None:
+        return [], set()
+    cfg = load_project_config(project_root)
+    kits = cfg.get("kits") if isinstance(cfg, dict) else None
+    if not isinstance(kits, dict):
+        return [], set()
+
+    out: List[KitWorkflowSkill] = []
+    kit_slugs: Set[str] = set()
+    for slug, kit_entry in sorted(kits.items()):
+        if not isinstance(kit_entry, dict):
+            continue
+        resources = kit_entry.get("resources")
+        if not isinstance(resources, dict):
+            continue
+        kit_slug = str(slug)
+        for resource in resources.values():
+            if not isinstance(resource, dict):
+                continue
+            if resource.get("kind") != "skill" or resource.get("public") is not True:
+                continue
+            raw_path = resource.get("path")
+            if not isinstance(raw_path, str) or not raw_path.strip():
+                continue
+            source_path = Path(raw_path)
+            if not source_path.is_absolute():
+                source_path = studio_root / source_path
+            source_path = source_path.resolve()
+            if not source_path.is_file():
+                continue
+            out.append((source_path.name, source_path, kit_slug, None))
+            kit_slugs.add(kit_slug)
+    return out, kit_slugs
 
 # ---------------------------------------------------------------------------
 # Kit workflow → skill generation for skill-native tools

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -2164,6 +2164,13 @@ def _list_registered_public_resource_skills(
             if not source_path.is_absolute():
                 source_path = studio_root / source_path
             source_path = source_path.resolve()
+            try:
+                source_path.relative_to(studio_root.resolve())
+            except ValueError:
+                sys.stderr.write(
+                    f"WARNING: kit {kit_slug!r} public skill source escapes studio root: {source_path}, skipping\n"
+                )
+                continue
             if not source_path.is_file():
                 continue
             out.append((source_path.name, source_path, kit_slug, None))

--- a/skills/studio/scripts/studio/commands/kit.py
+++ b/skills/studio/scripts/studio/commands/kit.py
@@ -800,6 +800,25 @@ def _resolve_installed_kit_root(
     return kit_dir, kit_rel_path, kit_entry, isinstance(registered_path, str) and bool(registered_path.strip())
 
 
+def _registered_slug_for_local_kit_path(
+    config_dir: Path,
+    studio_dir: Path,
+    kit_source: Path,
+) -> str:
+    kit_source_resolved = kit_source.resolve()
+    matches: List[str] = []
+    for kit_slug, kit_entry in _read_kits_from_core_toml(config_dir).items():
+        if not isinstance(kit_entry, dict):
+            continue
+        registered_path = kit_entry.get("path")
+        if not isinstance(registered_path, str) or not registered_path.strip():
+            continue
+        registered_dir = _resolve_registered_kit_dir(studio_dir, registered_path)
+        if registered_dir is not None and registered_dir.resolve() == kit_source_resolved:
+            matches.append(kit_slug)
+    return matches[0] if len(matches) == 1 else ""
+
+
 def _collect_kit_metadata(
     config_kit_dir: Optional[Path],
     kit_slug: str,
@@ -3118,7 +3137,12 @@ def cmd_kit_update(argv: List[str]) -> int:
             })
             return 2
         # @cpt-begin:cpt-studio-flow-kit-update-cli:p1:inst-read-slug
-        kit_slug = args.slug or _read_kit_slug(kit_source) or kit_source.name
+        kit_slug = (
+            args.slug
+            or _registered_slug_for_local_kit_path(config_dir, studio_dir, kit_source)
+            or _read_kit_slug(kit_source)
+            or kit_source.name
+        )
         # @cpt-end:cpt-studio-flow-kit-update-cli:p1:inst-read-slug
         update_targets.append((kit_slug, kit_source, "", None, None))
     else:

--- a/tests/test_agents_coverage.py
+++ b/tests/test_agents_coverage.py
@@ -2378,6 +2378,59 @@ class TestKitWorkflowSharedSkills(unittest.TestCase):
             self.assertIn("{cf-studio-path}/config/kits/pub/SKILL.md", content)
             self.assertFalse((root / ".agents" / "skills" / "cf-pub-legacy" / "SKILL.md").exists())
 
+    def test_registered_public_skill_resource_generates_without_manifest(self):
+        """Registered public skill resources are authoritative even when the kit has no manifest."""
+        from studio.commands.agents import _process_single_agent, _default_agents_config
+
+        with TemporaryDirectory() as td:
+            root, cpt = self._make_project(td)
+            kit_dir = root / "studio-kit-gears"
+            workflow_dir = kit_dir / "workflows"
+            workflow_dir.mkdir(parents=True)
+            (workflow_dir / "pr-review.md").write_text(
+                "---\n"
+                "cf: true\n"
+                "type: workflow\n"
+                "name: cf-gears-pr-review\n"
+                "description: Review PRs\n"
+                "---\n"
+                "# PR Review\n",
+                encoding="utf-8",
+            )
+            (cpt / "config" / "core.toml").write_text(
+                "\n".join([
+                    'version = "1.0"',
+                    'project_root = ".."',
+                    "",
+                    "[kits.gears]",
+                    'format = "CFS"',
+                    'path = "../studio-kit-gears"',
+                    'version = "1.0"',
+                    "",
+                    "[kits.gears.resources.workflow_pr_review]",
+                    'path = "../studio-kit-gears/workflows/pr-review.md"',
+                    'kind = "skill"',
+                    "public = true",
+                ]) + "\n",
+                encoding="utf-8",
+            )
+
+            result = _process_single_agent(
+                "cursor",
+                root,
+                cpt,
+                _default_agents_config(),
+                None,
+                dry_run=False,
+            )
+
+            self.assertEqual(result["status"], "PASS")
+            public_skill = root / ".agents" / "skills" / "cf-gears-pr-review" / "SKILL.md"
+            self.assertTrue(public_skill.exists())
+            content = public_skill.read_text(encoding="utf-8")
+            self.assertIn("name: cf-gears-pr-review", content)
+            self.assertIn("@/studio-kit-gears/workflows/pr-review.md", content)
+
     def test_legacy_manifest_workflow_renders_as_skill_without_alias_artifact(self):
         """Legacy manifest workflows render as public skills from KitModel."""
         from studio.commands.agents import _process_single_agent, _default_agents_config

--- a/tests/test_agents_coverage.py
+++ b/tests/test_agents_coverage.py
@@ -324,7 +324,7 @@ class TestCanonicalKitPublicComponentGeneration(unittest.TestCase):
             self.assertNotIn(outside_skill.resolve(), paths)
             self.assertEqual(kit_slugs, set())
             stderr.write.assert_any_call(
-                f"WARNING: kit 'pubkit' public skill source escapes studio root: {outside_skill.resolve()}, skipping\n"
+                f"WARNING: kit 'pubkit' public skill source escapes project/studio root: {outside_skill.resolve()}, skipping\n"
             )
 
     def test_list_public_components_skips_unresolvable_source(self):

--- a/tests/test_agents_coverage.py
+++ b/tests/test_agents_coverage.py
@@ -298,6 +298,35 @@ class TestCanonicalKitPublicComponentGeneration(unittest.TestCase):
             self.assertIn("Bound nested behavior.", nested_content)
             self.assertNotIn("Audit nested behavior.", nested_content)
 
+    def test_registered_public_skill_resource_outside_studio_root_is_skipped(self):
+        from studio.commands.agents import _list_registered_public_resource_skills
+
+        with TemporaryDirectory() as td:
+            root, studio_root = self._make_project(td)
+            outside_dir = Path(td) / "outside"
+            outside_dir.mkdir()
+            outside_skill = outside_dir / "escape.md"
+            outside_skill.write_text("# Escape\nDo not load this.\n", encoding="utf-8")
+            core_toml = studio_root / "config" / "core.toml"
+            core_toml.write_text(
+                core_toml.read_text(encoding="utf-8")
+                + "\n[kits.pubkit.resources.escape]\n"
+                + 'kind = "skill"\n'
+                + "public = true\n"
+                + f'path = "{outside_skill.as_posix()}"\n',
+                encoding="utf-8",
+            )
+
+            with patch("sys.stderr") as stderr:
+                components, kit_slugs = _list_registered_public_resource_skills(studio_root, root)
+
+            paths = [entry[1] for entry in components]
+            self.assertNotIn(outside_skill.resolve(), paths)
+            self.assertEqual(kit_slugs, set())
+            stderr.write.assert_any_call(
+                f"WARNING: kit 'pubkit' public skill source escapes studio root: {outside_skill.resolve()}, skipping\n"
+            )
+
     def test_list_public_components_skips_unresolvable_source(self):
         from studio.commands.agents import _list_public_components
 

--- a/tests/test_agents_coverage.py
+++ b/tests/test_agents_coverage.py
@@ -58,6 +58,73 @@ class TestStudioEndpointTarget(unittest.TestCase):
         self.assertIn("outside project root", buf.getvalue())
 
 
+class TestGenerateAgentsNoChangePreview(unittest.TestCase):
+    """Regression coverage for preview/apply control flow."""
+
+    def test_no_change_preview_does_not_run_apply(self):
+        from studio.commands.agents import cmd_generate_agents
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "project"
+            studio_root = root / ".cf-studio"
+            studio_root.mkdir(parents=True)
+            args = SimpleNamespace(
+                dry_run=False,
+                remove_cypilot="no",
+                discover=False,
+                show_layers=False,
+                yes=True,
+            )
+            cfg = {"agents": {"cursor": {"workflows": {}, "skills": {}}}}
+            empty_result = {
+                "status": "PASS",
+                "agent": "cursor",
+                "workflows": {
+                    "created": [],
+                    "updated": [],
+                    "unchanged": [],
+                    "renamed": [],
+                    "deleted": [],
+                    "errors": [],
+                },
+                "skills": {
+                    "created": [],
+                    "updated": [],
+                    "deleted": [],
+                    "skipped": [],
+                    "outputs": [],
+                },
+                "subagents": {
+                    "created": [],
+                    "updated": [],
+                    "deleted": [],
+                    "skipped": False,
+                    "skip_reason": "",
+                    "outputs": [],
+                },
+                "rules": {"created": [], "updated": [], "deleted": [], "outputs": []},
+                "errors": None,
+            }
+
+            def fake_process(*_args, **kwargs):
+                self.assertTrue(kwargs.get("dry_run"))
+                return empty_result
+
+            with (
+                patch(
+                    "studio.commands.agents._resolve_agents_context",
+                    return_value=(args, ["cursor"], root, studio_root, {}, None, cfg),
+                ),
+                patch("studio.commands.agents._discover_layers", return_value=[]),
+                patch("studio.commands.agents._layers_have_v2_manifests", return_value=False),
+                patch("studio.commands.agents._process_single_agent", side_effect=fake_process) as process,
+            ):
+                rc = cmd_generate_agents([])
+
+            self.assertEqual(rc, 0)
+            self.assertEqual(process.call_count, 1)
+
+
 class TestCanonicalKitPublicComponentGeneration(unittest.TestCase):
     """Canonical kit public components drive generated skills and agents."""
 

--- a/tests/test_kit.py
+++ b/tests/test_kit.py
@@ -5953,6 +5953,50 @@ class TestCmdKitUpdateCli(unittest.TestCase):
             finally:
                 os.chdir(cwd)
 
+    def test_update_local_path_uses_registered_slug_for_matching_path(self):
+        from studio.commands.kit import cmd_kit_update
+        from studio.utils import toml_utils
+
+        with TemporaryDirectory() as td:
+            root = Path(td) / "proj"
+            adapter = _bootstrap_project(root)
+            kit_src = root / "studio-kit-gears"
+            kit_src.mkdir(parents=True)
+            (kit_src / "AGENTS.md").write_text("# Kit agents\n", encoding="utf-8")
+            toml_utils.dump({
+                "version": "1.0",
+                "project_root": "..",
+                "kits": {
+                    "gears": {
+                        "format": "CFS",
+                        "path": "../studio-kit-gears",
+                        "version": "1",
+                    }
+                },
+            }, adapter / "config" / "core.toml")
+
+            wrong_fallback = adapter / "config" / "kits" / "studio-kit-gears"
+            wrong_fallback.mkdir(parents=True)
+            (wrong_fallback / "obsolete.md").write_text("stale\n", encoding="utf-8")
+
+            cwd = os.getcwd()
+            try:
+                os.chdir(kit_src)
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    rc = cmd_kit_update([
+                        "--path", ".",
+                        "--project-root", str(root),
+                        "--force",
+                        "-y",
+                    ])
+                self.assertEqual(rc, 0)
+                out = json.loads(buf.getvalue())
+                self.assertEqual(out["results"][0]["kit"], "gears")
+                self.assertTrue((wrong_fallback / "obsolete.md").is_file())
+            finally:
+                os.chdir(cwd)
+
     def test_update_local_path_not_found(self):
         from studio.commands.kit import cmd_kit_update
         with TemporaryDirectory() as td:


### PR DESCRIPTION
Enhance the system to recognize and process registered public skill resources even when a manifest is not present, along with corresponding tests to validate this functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public skill discovery now includes registered skill resources declared in project kit configuration.
  * Generate public kit skills even when a kit lacks a manifest.

* **Bug Fixes**
  * Agent preview flow: fatal preview errors now render and cause a non‑zero exit; no‑change output is conditional (JSON vs interactive).

* **Tests**
  * Added regression tests for public-skill generation and local-kit update slug resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->