### PR TITLE
Add command validation for ralphex delegation and enhance skill entrypoint checks

### DIFF
--- a/architecture/researches/pdsl-vs-structured-workflow-prompting.md
+++ b/architecture/researches/pdsl-vs-structured-workflow-prompting.md
@@ -1,0 +1,84 @@
+# PDSL vs. Research Findings on Structured Workflow Prompting
+
+## Purpose
+
+This note compares the current PDSL specification against findings from research
+on finite-state prompting, structured prompting, and LLM workflow orchestration.
+The goal is to assess how closely PDSL matches the formats and control
+mechanisms that the literature suggests are effective for turning reusable
+skills into reliable workflows.
+
+## Sources
+
+Scientific sources used in this note:
+
+1. Wang et al., **FSM: A Finite State Machine Based Zero-Shot Prompting Paradigm for Multi-Hop Question Answering** (arXiv, 2024)  
+   https://arxiv.org/abs/2407.02964
+2. Sultan et al., **Structured Chain-of-Thought Prompting for Few-Shot Generation of Content-Grounded QA Conversations** (arXiv, 2024)  
+   https://arxiv.org/abs/2402.11770
+3. Fan et al., **WorkflowLLM: Enhancing Workflow Orchestration Capability of Large Language Models** (arXiv, 2024)  
+   https://arxiv.org/abs/2411.05451
+4. White et al., **A Prompt Pattern Catalog to Enhance Prompt Engineering with ChatGPT** (arXiv, 2023)  
+   https://arxiv.org/abs/2302.11382
+5. Lu et al., **Learning to Generate Structured Output with Schema Reinforcement Learning** (arXiv, 2025)  
+   https://arxiv.org/abs/2502.18878
+
+## Comparison Table
+
+| Criterion | What research suggests | What PDSL provides | Assessment |
+| --- | --- | --- | --- |
+| Explicit decomposition of complex tasks | Break complex work into local steps or states instead of one large prompt. Supported by FSM prompting and structured CoT work. | `UNIT`, `WHEN`, `DO`, `RUN`, `CONTINUE` provide explicit decomposition into smaller executable units. | Strong alignment |
+| FSM-like control flow | Effective prompting for complex tasks benefits from explicit states, branches, continuation logic, and stop points. | `STATE`, `WHEN`, `WAIT`, `STOP_TURN`, `CONTINUE`, and `MENU` provide explicit control flow. | Strong alignment |
+| Localized instructions per state | Each state should have its own focused instructions and resources. | Each `UNIT` acts as a local handler with its own conditions, actions, and rules. | Strong alignment |
+| Explicit interaction states | User-facing branches should be part of the workflow model, not hidden in prose. | `MENU`, `OPTIONS`, `INVALID`, `WAIT`, and `STOP_TURN` make interaction states first-class. | Strong alignment |
+| Declarative workflow expression | Structured, declarative workflow descriptions are easier to follow and orchestrate than narrative prompts. | PDSL is a compact declarative notation for workflow behavior. | Strong alignment |
+| Reusable prompting patterns | Reusable prompt patterns improve consistency and reduce ambiguity. | PDSL promotes reusable `UNIT`s, shared runtime modules, and `PATTERNS`. | Good alignment |
+| Workflow orchestration readiness | Orchestration benefits from explicit handoffs, phases, and execution ownership. | `RUN`, `DISPATCH`, `RETURN`, bootstrap units, and workflow modules support orchestration. | Good alignment |
+| Error handling and recovery | Complex workflows benefit from explicit recovery paths and controlled iteration. | `ON_ERROR` exists and allows explicit recovery routing. | Good alignment |
+| Explicit transition contract | Research directions imply value in clear `current state -> condition -> next state` representations. | Transitions exist, but are distributed across `WHEN`, `DO`, and `CONTINUE`; there is no dedicated transition construct. | Partial gap |
+| Typed state model | More formal workflow systems benefit from clearly typed and constrained state/data models. | `STATE` can declare allowed values and defaults, but remains mostly textual and lightweight. | Partial gap |
+| Strict output contract | Reliable workflow execution increasingly depends on machine-checkable outputs, often schema-bound. | `RETURN` describes a handoff, but PDSL does not define a strict structured output contract. | Significant gap |
+| Schema-bound execution results | Structured output research shows reliability improves when outputs must satisfy explicit schemas. | PDSL does not embed JSON-schema-like result validation for state decisions or returns. | Significant gap |
+| Semantic validation | Strong workflow DSLs validate references, state usage, transitions, and constraints semantically, not just syntactically. | Current PDSL validation is mainly structural. | Significant gap |
+| Enforced authoring limits | If compactness rules are part of the spec, validators should enforce them. | The spec defines limits such as max `DO` actions and max `RULES`, but current validation does not appear to enforce them. | Spec/implementation gap |
+| Shared pattern registry enforcement | Reusable pattern registries should be recognized by validators. | The spec allows local and canonical pattern registries, but current validation appears focused on local definitions. | Spec/implementation gap |
+| Deterministic control interpretation | Execution semantics should be explicit enough that controllers interpret the workflow consistently. | PDSL defines runtime semantics and a shared execution card for controllers. | Good alignment |
+| Separation of behavior from prose | Effective prompting benefits from separating executable behavior from explanatory narrative. | PDSL explicitly reserves prose for rationale and PDSL for behavior. | Strong alignment |
+
+## Summary
+
+PDSL aligns well with the strongest recurring research finding: workflow-like
+prompting works better when behavior is decomposed into explicit states,
+branches, local instructions, and stop boundaries rather than embedded in long
+free-form prose.
+
+Its strongest matches to the literature are:
+
+- explicit stateful decomposition
+- clear branching and continuation semantics
+- reusable local workflow units
+- first-class interaction states
+- declarative control flow instead of narrative prompting
+
+Its main gaps relative to stricter workflow-oriented approaches are:
+
+- no first-class transition object
+- no built-in schema-bound output contract
+- limited semantic validation
+- partial mismatch between the written spec and validator behavior
+
+## Practical Conclusion
+
+PDSL is already close to a strong **structured workflow prompting DSL** for
+LLM-controlled skills and workflows. It is much closer to research-backed
+best practice than ordinary prose prompts.
+
+However, it is not yet a fully strict workflow contract language. To move
+closer to the strongest reliability-oriented findings in the literature, the
+next improvements would be:
+
+1. add an explicit transition/result contract such as `next_state`, `action`,
+   `arguments`, and `done`
+2. support schema-bound outputs for unit decisions and returns
+3. extend validation from structural checks to semantic checks over state,
+   references, transitions, and registry-backed patterns

--- a/skills/studio/scripts/studio/ralphex_export.py
+++ b/skills/studio/scripts/studio/ralphex_export.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 # Rules subsections to include as bounded guidance
 _GUIDANCE_SUBSECTIONS = {"Engineering", "Quality"}
+_RALPHEX_ALLOWED_FLAGS = {"--review", "--tasks-only", "--worktree", "--serve"}
 
 
 def compile_delegation_plan(plan_dir: str) -> str:
@@ -496,6 +497,39 @@ def build_delegation_command(
         cmd.append("--serve")
 
     return cmd
+
+
+def _validate_delegation_command(command: list[str]) -> Optional[str]:
+    """Validate command arguments before invoking the external ralphex binary."""
+    if not command or not isinstance(command[0], str) or not command[0].strip():
+        return "Invalid delegation command: missing executable path"
+
+    executable = Path(command[0])
+    if not executable.is_absolute():
+        return f"Invalid delegation command: executable path must be absolute: {command[0]}"
+
+    seen_plan_file = False
+    for arg in command[1:]:
+        if not isinstance(arg, str) or not arg.strip():
+            return "Invalid delegation command: empty argument"
+        if arg.startswith("--"):
+            if arg not in _RALPHEX_ALLOWED_FLAGS:
+                return f"Invalid delegation command: unsupported flag {arg}"
+            continue
+        if seen_plan_file:
+            return f"Invalid delegation command: unexpected positional argument {arg}"
+        plan_file = Path(arg)
+        if not plan_file.is_absolute():
+            return f"Invalid delegation command: plan file path must be absolute: {arg}"
+        try:
+            plan_file = plan_file.resolve(strict=True)
+        except OSError as exc:
+            return f"Invalid delegation command: plan file is not accessible: {arg} ({exc})"
+        if not plan_file.is_file():
+            return f"Invalid delegation command: plan file is not a regular file: {plan_file}"
+        seen_plan_file = True
+
+    return None
 
 
 def check_review_precondition(default_branch: str = "main", repo_root: str | None = None) -> dict:
@@ -1025,6 +1059,10 @@ def run_delegation(
         ralphex_path, plan_file, mode, worktree=worktree, serve=serve,
     )
     result["command"] = command
+    command_error = _validate_delegation_command(command)
+    if command_error:
+        result["error"] = command_error
+        return result
     if serve and mode != "review":
         port = os.environ.get("RALPHEX_PORT", "8080").strip() or "8080"
         result["dashboard_url"] = f"http://localhost:{port}"

--- a/src/studio_proxy/update_check.py
+++ b/src/studio_proxy/update_check.py
@@ -17,6 +17,7 @@ from urllib.request import Request, urlopen
 
 
 _DEFAULT_TTL_SECONDS = 6 * 60 * 60
+_ALLOWED_SKILL_ENTRYPOINTS = {"studio.py", "cypilot.py"}
 # @cpt-end:cpt-studio-flow-core-infra-cli-invocation:p1:inst-cli-proxy-helpers
 
 
@@ -165,6 +166,10 @@ def check_kits(skill_path: Optional[Path], project_root: str = "") -> Dict[str, 
     if skill_path is None:
         result["message"] = "Skill engine not found"
         return result
+    validation_error = _validate_skill_entrypoint(skill_path)
+    if validation_error:
+        result["message"] = validation_error
+        return result
 
     args = [sys.executable, str(skill_path), "--json", "kit", "check-updates"]
     if project_root:
@@ -199,6 +204,22 @@ def check_kits(skill_path: Optional[Path], project_root: str = "") -> Dict[str, 
     })
     return result
 # @cpt-end:cpt-studio-flow-core-infra-cli-invocation:p1:inst-if-version-mismatch
+
+
+def _validate_skill_entrypoint(skill_path: Path) -> Optional[str]:
+    """Validate that a subprocess target matches the expected skill entrypoint shape."""
+    try:
+        resolved = skill_path.expanduser().resolve(strict=True)
+    except OSError as exc:
+        return f"Skill engine entry point is not accessible: {skill_path} ({exc})"
+    if not resolved.is_file():
+        return f"Skill engine entry point is not a file: {resolved}"
+    if resolved.name not in _ALLOWED_SKILL_ENTRYPOINTS:
+        return f"Skill engine entry point is not trusted: {resolved}"
+    package_dir = resolved.parent / resolved.stem
+    if not (package_dir / "__init__.py").is_file():
+        return f"Skill engine package is incomplete next to entry point: {resolved}"
+    return None
 
 
 # @cpt-begin:cpt-studio-flow-core-infra-cli-invocation:p1:inst-bg-version-check

--- a/tests/test_ralphex_delegation.py
+++ b/tests/test_ralphex_delegation.py
@@ -34,6 +34,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scr
 
 from studio.ralphex_discover import discover, validate, persist_path, INSTALL_GUIDANCE
 from studio.ralphex_export import (
+    _validate_delegation_command,
     compile_delegation_plan,
     generate_review_artifacts,
     map_phase_to_task,
@@ -929,6 +930,38 @@ class TestRunDelegation:
             assert result["returncode"] == 0
             assert "capture_output" not in invoke_kwargs
             assert "text" not in invoke_kwargs
+
+    def test_validate_delegation_command_rejects_unknown_flag(self, tmp_path):
+        """Command validation rejects unexpected ralphex flags before launch."""
+        executable = tmp_path / "ralphex"
+        executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        executable.chmod(0o755)
+
+        error = _validate_delegation_command([str(executable), "--bad-flag"])
+
+        assert "unsupported flag" in error
+
+    def test_delegation_rejects_non_absolute_executable_path(self):
+        """Delegation refuses a non-absolute ralphex executable path before subprocess launch."""
+        with TemporaryDirectory() as tmp:
+            repo_root, plan_dir = self._make_delegatable_project(tmp)
+            config = {
+                "integrations": {
+                    "ralphex": {
+                        "executable_path": "ralphex",
+                    }
+                }
+            }
+            with patch("studio.ralphex_discover.shutil.which", return_value=None):
+                result = run_delegation(
+                    config=config,
+                    plan_dir=plan_dir,
+                    repo_root=repo_root,
+                    mode="execute",
+                    dry_run=True,
+                )
+            assert result["status"] == "error"
+            assert "not installed" in result["validation"]["message"]
 
     def test_nonzero_exit_sets_failed_lifecycle(self):
         """Regression: non-zero subprocess return code transitions lifecycle to failed."""

--- a/tests/test_studio_proxy_cli.py
+++ b/tests/test_studio_proxy_cli.py
@@ -223,11 +223,19 @@ def test_check_kits_unknown_on_nonzero_subprocess(monkeypatch):
 
     monkeypatch.setattr(update_check.subprocess, "run", fake_run)
 
-    result = update_check.check_kits(Path("/tmp/studio.py"))
+    from tempfile import TemporaryDirectory
 
-    assert result["action"] == "unknown"
-    assert result["returncode"] == 1
-    assert "boom" in result["message"]
+    with TemporaryDirectory() as tmp:
+        skill_dir = Path(tmp)
+        (skill_dir / "studio").mkdir()
+        (skill_dir / "studio" / "__init__.py").write_text("__version__ = '1.0.0'\n", encoding="utf-8")
+        skill_path = skill_dir / "studio.py"
+        skill_path.write_text("print('ok')\n", encoding="utf-8")
+        result = update_check.check_kits(skill_path)
+
+        assert result["action"] == "unknown"
+        assert result["returncode"] == 1
+        assert "boom" in result["message"]
 
 
 def test_update_check_kits_parses_skill_engine_json(monkeypatch):
@@ -245,11 +253,31 @@ def test_update_check_kits_parses_skill_engine_json(monkeypatch):
 
     monkeypatch.setattr(update_check.subprocess, "run", lambda *_args, **_kwargs: Proc())
 
-    result = update_check.check_kits(Path("/tmp/studio.py"))
+    from tempfile import TemporaryDirectory
 
-    assert result["action"] == "update_available"
-    assert result["updates_available"] == 1
-    assert result["commands"] == ["cfs kit update sdlc"]
+    with TemporaryDirectory() as tmp:
+        skill_dir = Path(tmp)
+        (skill_dir / "studio").mkdir()
+        (skill_dir / "studio" / "__init__.py").write_text("__version__ = '1.0.0'\n", encoding="utf-8")
+        skill_path = skill_dir / "studio.py"
+        skill_path.write_text("print('ok')\n", encoding="utf-8")
+        result = update_check.check_kits(skill_path)
+
+        assert result["action"] == "update_available"
+        assert result["updates_available"] == 1
+        assert result["commands"] == ["cfs kit update sdlc"]
+
+
+def test_check_kits_rejects_untrusted_skill_entrypoint(tmp_path):
+    import studio_proxy.update_check as update_check
+
+    skill_path = tmp_path / "evil.py"
+    skill_path.write_text("print('bad')\n", encoding="utf-8")
+
+    result = update_check.check_kits(skill_path)
+
+    assert result["action"] == "unknown"
+    assert "not trusted" in result["message"]
 
 
 def test_download_and_cache_writes_github_provenance(monkeypatch, tmp_path):


### PR DESCRIPTION
Introduce validation for ralphex delegation commands to ensure proper executable paths and supported flags. Enhance skill entrypoint checks to validate accessibility and trustworthiness of specified entry points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of delegation commands with stricter flag and argument checks to prevent invalid operations.
  * Added security validation for skill entrypoints during kit update checks to ensure only trusted packages are accessed.
  * Improved error messaging when validation fails.

* **Tests**
  * Expanded test coverage for command validation and entrypoint security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->