### PR TITLE
Refactor skill and workflow generation with required bootstrap

### DIFF
--- a/architecture/features/agent-integration.md
+++ b/architecture/features/agent-integration.md
@@ -221,6 +221,7 @@ Without this feature, users would need to manually create and maintain agent-spe
 1. - `p1` - Discover public core and kit skill/workflow entrypoints from registered sources - `inst-read-kit-skills`
 2. - `p1` - Assemble per-agent skill entrypoint files that follow the canonical Studio workflow or skill source - `inst-assemble-sections`
 3. - `p1` - Write skill entrypoints into agent integration paths, never into `.gen/` aggregates - `inst-write-skill`
+4. - `p1` - Generated skill/workflow entrypoints MUST prepend a local bootstrap unit that loads and runs `{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md` before transferring control to the target skill/workflow; the required bootstrap MUST activate PDSL execution semantics, Studio instruction memory, command resolution, template-variable resolution support, content-memory rules, and resource-context memory rules - `inst-required-bootstrap-unit`
 
 ### List Workflow Files
 
@@ -267,6 +268,7 @@ Without this feature, users would need to manually create and maintain agent-spe
 - [x] - `p1` - No generated skill or workflow entrypoint is written to a generated aggregate under `.gen/`
 - [x] - `p1` - Root skill metadata advertises all chat-facing route families
   rather than only plan/generate/analyze/workspace shortcuts
+- [x] - `p1` - Generated skill/workflow entrypoints keep the canonical controlling-protocol target in the generated bootstrap unit for ownership/detection compatibility while executing `required-bootstrap.md` first; legacy `ALWAYS open and follow` remains recognized as a fallback
 
 ### Workflow Discovery
 

--- a/architecture/specs/PDSL.md
+++ b/architecture/specs/PDSL.md
@@ -158,6 +158,9 @@ controller or sub-agent interpreting PDSL applies these rules:
 - `NEVER` is an absolute prohibition in the current scope.
 - `LOAD` makes a referenced prompt asset or context slice available before
   later actions depend on it.
+- `LOAD and RUN <target> as controlling protocol` loads the referenced
+  protocol and immediately transfers execution to it as the active
+  controlling protocol.
 - `RUN` executes a named local unit, probe, check, or workflow step.
 - `WAIT` plus `STOP_TURN` is a hard assistant-turn boundary.
 - `CONTINUE <unit-or-phase>` transfers control to that target; it is not

--- a/architecture/specs/cli.md
+++ b/architecture/specs/cli.md
@@ -569,9 +569,10 @@ cfs generate-agents [--agent AGENT | --openai] [--root PATH] [--cf-studio-root P
 2. Compose the main SKILL.md from core commands + collected extensions.
 3. Generate workflow entry points in each agent's native format.
 4. Generate skill shims referencing the composed SKILL.md.
-5. Generate tool-specific subagent files where supported.
-6. Refresh the managed `.gitignore` block so all generated paths are ignored consistently.
-7. Full overwrite on each invocation (no merge with existing files).
+5. Prepend a generated bootstrap unit to every generated skill/workflow shim; that unit loads and runs `{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md` before the target skill/workflow is executed, including activation of content-memory and resource-context-memory runtime rules.
+6. Generate tool-specific subagent files where supported.
+7. Refresh the managed `.gitignore` block so all generated paths are ignored consistently.
+8. Full overwrite on each invocation (no merge with existing files).
 
 **Discover mode**:
 - `--discover` may extend or create `config/manifest.toml` from discovered layers before generating outputs.
@@ -601,6 +602,7 @@ Each agent is detected via Constructor Studio-specific generated files, not gene
 **Skill file model**:
 - **Kit workflow skills**: Generated as shared `.agents/skills/{id}/SKILL.md` for all non-Claude agents
 - **Manifest skills**: Generated to `.agents/skills/{id}/SKILL.md` with agent targeting enforced via filtering logic — when a manifest skill is scoped to specific agents (e.g. `agents=['cursor']`), it is not generated for other agents
+- **Bootstrap prelude**: Every generated skill/workflow shim contains a canonical `LOAD and RUN <target> as controlling protocol` target inside its generated bootstrap unit for detection/cleanup compatibility, while legacy `ALWAYS open and follow <target>` remains a fallback for old generated files; the bootstrap activates PDSL semantics, Studio instruction memory, command resolution, and the content/resource context memory rules required by downstream workflows
 
 All non-Claude agents read from the shared `.agents/skills/` directory, but agent-specific manifest skills are filtered at generation time. This prevents Cursor-only skills from being offered to Copilot or OpenAI.
 

--- a/skills/studio/modules/runtime/pdsl-execution-card.md
+++ b/skills/studio/modules/runtime/pdsl-execution-card.md
@@ -15,8 +15,6 @@ RULES:
     `DO`, `RULES`, `INVARIANTS`, and matching `ON_ERROR` obligations are active.
   - ALWAYS execute `DO` actions in written order unless a `CONTINUE`, `RETURN`,
     `WAIT`, or `STOP_TURN` transfers control earlier.
-  - ALWAYS read `STATE`, `WHEN`, `DO`, `RULES`, and `INVARIANTS` as list blocks;
-    every top-level item starts with that section's allowed starter keyword.
   - ALWAYS treat `REQUIRE` as a precondition. If unmet, enter matching `ON_ERROR`
     when present; otherwise stop and report the missing precondition.
   - ALWAYS treat `NEVER` as an absolute prohibition in the current scope.
@@ -31,22 +29,8 @@ RULES:
     continuation target; REQUIRED: do not reinterpret the user's reply as
     broad permission for generic autonomous execution.
   - ALWAYS while a workflow, gate, or menu remains active, treat each new user
-    message as candidate input to that active continuation or a loaded
-    session-level interrupt, not as permission for unrelated execution.
-  - ALWAYS when a new user message cannot be represented by the active
-    workflow's reachable states, prefer a visible workflow handoff or an
-    explicit workflow exit over silent protocol escape.
-  - ALWAYS treat `DISPATCH` as invoking a named sub-agent or worker contract;
-    concurrency, isolation, and join behavior come from explicit dispatch
-    options or surrounding rules, not separate dispatch keywords.
-  - ALWAYS treat an accepted plan's execution directives as binding control
-    flow, not advisory notes.
-  - ALWAYS treat `DISPATCH: <agent>` in an accepted plan as requiring
-    SubAgentDispatch before task work.
-  - NEVER reinterpret `DISPATCH` in an accepted plan as permission for inline
-    controller execution.
-  - NEVER let generic assistant editing rules override an active accepted
-    workflow plan.
+    message as input to that active continuation, not as permission for
+    unrelated execution.
   - ALWAYS treat `RETURN` as the declared terminal handoff or output shape.
   - ALWAYS treat `RULES` as mandatory constraints for the owning unit.
   - ALWAYS treat `INVARIANTS` as always active while the owning unit, workflow,
@@ -56,14 +40,9 @@ RULES:
     handles all unmatched input.
   - ALWAYS require every top-level `OPTIONS` entry to start with a decimal
     number; aliases or patterns follow the number, not replace it.
-  - ALWAYS render every `MENU` with each selectable option on its own numbered
-    line so the user can choose by replying with the number.
   - ALWAYS treat `ON_ERROR` as the named recovery path for matching failures.
   - ALWAYS treat `NOTES` as explanatory only; NOTES do not create executable
     obligations unless an active rule references them.
   - NEVER weaken `ALWAYS`, `NEVER`, `REQUIRE`, `WAIT`, `STOP_TURN`, or
     `INVARIANTS` because nearby prose sounds softer.
-  - NEVER infer hidden behavior from prose outside PDSL blocks.
-  - NEVER use text-labeled fences for PDSL instruction blocks; use
-    pdsl-labeled fences.
 ```

--- a/skills/studio/modules/runtime/required-bootstrap.md
+++ b/skills/studio/modules/runtime/required-bootstrap.md
@@ -1,0 +1,29 @@
+# Required Bootstrap
+
+Use this module when a generated skill or workflow shim must load the minimum
+shared Constructor Studio runtime before handing control to its target
+protocol.
+
+```pdsl
+UNIT RequiredBootstrap
+PURPOSE: Load the mandatory core runtime modules before any generated target skill or workflow executes.
+DO:
+  LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/pdsl-execution-card.md
+  RUN PdslExecutionSemantics
+  LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/studio-instructions-memory.md
+  RUN StudioInstructionsMemoryGate
+  LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/command-resolution.md
+  RUN CommandResolution to resolve {cfs_cmd}
+  LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/template-vars.md
+  LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/context-memory.md
+  RUN ContentMemory
+  RUN ResourceContextMemory
+RULES:
+  ALWAYS run this bootstrap before loading or executing a generated target skill/workflow
+  ALWAYS load and execute PDSL semantics before interpreting downstream PDSL blocks
+  ALWAYS load Studio instruction memory so rules from `{cf-studio-path}/.gen` and `{cf-studio-path}/config` are remembered before target work begins
+  ALWAYS resolve `{cfs_cmd}` before any downstream unit may invoke a Constructor Studio CLI command
+  ALWAYS keep template-vars and context-memory loaded so downstream protocols can resolve variables and classify remembered context deterministically
+  ALWAYS activate ContentMemory so downstream content payloads inherit the runtime lifecycle rules from bootstrap
+  ALWAYS activate ResourceContextMemory so downstream workflows can safely store and forward resource_context without reintroducing bootstrap gaps
+```

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -91,6 +91,9 @@ _TMPL_DESCRIPTION = "description: {description}"
 _AGENT_TEMPLATE_HEADER = ["---", _TMPL_NAME, _TMPL_DESCRIPTION]
 _FOLLOW_LINK_RE = re.compile(r"ALWAYS open and follow `([^`]+)`")
 _CONTROL_PROTOCOL_RE = re.compile(r"LOAD(?: and RUN)? ([^\n]+?) as controlling protocol")
+_REQUIRED_BOOTSTRAP_PATH = (
+    "{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md"
+)
 _ENDPOINT_POINTER = (
     "Constructor Studio endpoint only. Prompt source: {target_agent_path}. "
     "Final prompt is supplied by the cf controller at dispatch time."
@@ -153,7 +156,11 @@ def _is_safe_generated_id(value: str) -> bool:
 # @cpt-end:cpt-studio-algo-project-extensibility-generate-agents:p1:inst-determine-agent-path
 
 
-def _follow_protocol_lines(target_path: str) -> List[str]:
+def _follow_protocol_lines(
+    target_path: str,
+    *,
+    required_bootstrap_path: str = "{required_bootstrap_path}",
+) -> List[str]:
     """Return the generated protocol block for workflow/skill shims."""
     # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-follow-protocol
     return [
@@ -180,7 +187,7 @@ def _follow_protocol_lines(target_path: str) -> List[str]:
         "UNIT GeneratedBootstrapUnit",
         "PURPOSE: Load the required shared bootstrap before handing control to the target protocol.",
         "DO:",
-        "  LOAD {required_bootstrap_path}",
+        "  LOAD " + required_bootstrap_path,
         "  RUN RequiredBootstrap",
         "  LOAD and RUN " + target_path + " as controlling protocol",
         "RULES:",
@@ -342,7 +349,11 @@ def _pure_generated_stub_matches(stripped: str) -> bool:
     if not control_target:
         return False
     expected_protocol = [
-        line.strip() for line in _follow_protocol_lines(control_target)
+        line.strip()
+        for line in _follow_protocol_lines(
+            control_target,
+            required_bootstrap_path=_REQUIRED_BOOTSTRAP_PATH,
+        )
         if line.strip()
     ]
     return nonblank == expected_protocol
@@ -2656,7 +2667,7 @@ def _workflow_output_template_context(
         "command": command,
         "workflow_name": wf_name,
         "target_workflow_path": target_rel,
-        "required_bootstrap_path": "{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
+        "required_bootstrap_path": _REQUIRED_BOOTSTRAP_PATH,
         "name": frontmatter.get("name", command),
         "description": frontmatter.get(
             "description",
@@ -2848,7 +2859,7 @@ def _render_kit_workflow_skill_content(
             "name": spec.name,
             "description": spec.description,
             "target_path": spec.target_rel,
-            "required_bootstrap_path": "{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
+            "required_bootstrap_path": _REQUIRED_BOOTSTRAP_PATH,
         },
     )
 # @cpt-end:cpt-studio-algo-agent-integration-list-workflows:p1:inst-generate-kit-workflow-skills
@@ -3963,7 +3974,7 @@ def _render_skill_output(
             "skill_name": str(ctx.skill_name),
             "target_skill_path": target_rel,
             "target_path": target_rel,
-            "required_bootstrap_path": "{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
+            "required_bootstrap_path": _REQUIRED_BOOTSTRAP_PATH,
             "name": out_name,
             "description": out_description,
             "custom_content": ctx.custom_content,

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -90,6 +90,7 @@ _TMPL_NAME = "name: {name}"
 _TMPL_DESCRIPTION = "description: {description}"
 _AGENT_TEMPLATE_HEADER = ["---", _TMPL_NAME, _TMPL_DESCRIPTION]
 _FOLLOW_LINK_RE = re.compile(r"ALWAYS open and follow `([^`]+)`")
+_CONTROL_PROTOCOL_RE = re.compile(r"LOAD(?: and RUN)? ([^\n]+?) as controlling protocol")
 _ENDPOINT_POINTER = (
     "Constructor Studio endpoint only. Prompt source: {target_agent_path}. "
     "Final prompt is supplied by the cf controller at dispatch time."
@@ -153,7 +154,7 @@ def _is_safe_generated_id(value: str) -> bool:
 
 
 def _follow_protocol_lines(target_path: str) -> List[str]:
-    """Return the generated follow-link protocol block for workflow/skill shims."""
+    """Return the generated protocol block for workflow/skill shims."""
     # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-follow-protocol
     return [
         "CF_WORKFLOW_ACTIVE:",
@@ -187,11 +188,17 @@ def _follow_protocol_lines(target_path: str) -> List[str]:
         # @cpt-end:cpt-studio-flow-agent-integration-generate:p1:inst-inject-agents
         # @cpt-end:cpt-studio-flow-agent-integration-generate:p1:inst-collect-sysprompt
         "",
-        # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-resolve-workflow
-        f"ALWAYS open and follow `{target_path}`",
-        # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-resolve-workflow
-        "",
         "```pdsl",
+        "UNIT GeneratedBootstrapUnit",
+        "PURPOSE: Load the required shared bootstrap before handing control to the target protocol.",
+        "DO:",
+        "  LOAD {required_bootstrap_path}",
+        "  RUN RequiredBootstrap",
+        "  LOAD and RUN " + target_path + " as controlling protocol",
+        "RULES:",
+        "  - ALWAYS run this bootstrap unit before any target workflow or skill work begins",
+        "  - ALWAYS preserve the canonical controlling-protocol target so generated-file ownership and cleanup remain stable",
+        "",
         "UNIT GeneratedFollowProtocol",
         "RULES:",
         "  - ALWAYS treat target as controlling protocol, not background context",
@@ -211,6 +218,29 @@ def _follow_protocol_lines(target_path: str) -> List[str]:
         "```",
     ]
     # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-follow-protocol
+
+
+def _extract_studio_control_target(content: str) -> Optional[str]:
+    """Return the canonical controlling-protocol target for a generated routing file."""
+    m = _CONTROL_PROTOCOL_RE.search(content)
+    if not m:
+        return None
+    target = m.group(1).strip()
+    for prefix in ("{cf-studio-path}/", "@/"):
+        if target.startswith(prefix):
+            return target
+    if target.startswith("/"):
+        return target
+    return None
+
+
+def _extract_studio_owned_target(content: str) -> Optional[str]:
+    """Return the best known managed target from generated content."""
+    return (
+        _extract_studio_control_target(content)
+        or _extract_studio_follow_target(content)
+        or _extract_studio_endpoint_target(content)
+    )
 
 
 # @cpt-begin:cpt-studio-algo-agent-integration-generate-shims:p1:inst-extract-studio-follow-target
@@ -242,6 +272,14 @@ def _extract_studio_follow_target(content: str) -> Optional[str]:
             return target
     return None
 # @cpt-end:cpt-studio-algo-agent-integration-generate-shims:p1:inst-extract-studio-follow-target
+
+
+def _extract_any_follow_target(content: str) -> Optional[str]:
+    """Return any raw follow-link target, including unmanaged/absolute values."""
+    m = _FOLLOW_LINK_RE.search(content)
+    if not m:
+        return None
+    return m.group(1)
 
 
 def _extract_studio_endpoint_target(content: str) -> Optional[str]:
@@ -301,15 +339,17 @@ def _pure_generated_stub_matches(stripped: str) -> bool:
     if len(nonblank) == 1:
         line = nonblank[0]
         return bool(
+            _extract_studio_control_target(line)
+            or
             _extract_studio_follow_target(line)
             or line.startswith("Constructor Studio endpoint only. Prompt source: ")
         )
 
-    follow_target = _extract_studio_follow_target(stripped)
-    if not follow_target:
+    control_target = _extract_studio_control_target(stripped) or _extract_studio_follow_target(stripped)
+    if not control_target:
         return False
     expected_protocol = [
-        line.strip() for line in _follow_protocol_lines(follow_target)
+        line.strip() for line in _follow_protocol_lines(control_target)
         if line.strip()
     ]
     return nonblank == expected_protocol
@@ -335,7 +375,11 @@ def _is_pure_studio_generated(
     When *expected_name* or *expected_description* are provided the corresponding
     frontmatter values must match exactly; a mismatch means the user edited them.
     """
-    if _GENERATED_MARKER not in content and not _extract_studio_follow_target(content):
+    if (
+        _GENERATED_MARKER not in content
+        and not _extract_studio_control_target(content)
+        and not _extract_studio_follow_target(content)
+    ):
         return False
     stripped = _strip_generated_frontmatter(
         content,
@@ -425,7 +469,7 @@ def _generated_toml_target(instructions: object) -> Optional[str]:
     if not isinstance(instructions, str):
         return None
     stripped = instructions.strip()
-    return _extract_studio_follow_target(stripped) or _extract_studio_endpoint_target(stripped)
+    return _extract_studio_owned_target(stripped)
 
 
 def _is_valid_generated_toml_shape(
@@ -646,11 +690,11 @@ def _generated_toml_description_matches(
 
 # @cpt-begin:cpt-studio-algo-agent-integration-generate-shims:p1:inst-file-has-studio-follow-link
 def _file_has_studio_follow_link(path: Path) -> bool:
-    """Return True when *path* exists and contains a Constructor Studio follow-link."""
+    """Return True when *path* exists and contains a Constructor Studio-managed target."""
     if not path.is_file():
         return False
     try:
-        return bool(_extract_studio_follow_target(path.read_text(encoding="utf-8")))
+        return bool(_extract_studio_owned_target(path.read_text(encoding="utf-8")))
     except (OSError, UnicodeDecodeError) as exc:
         _warn_agents(f"failed to inspect follow-link in {path}: {exc}")
         return False
@@ -2619,6 +2663,7 @@ def _workflow_output_template_context(
         "command": command,
         "workflow_name": wf_name,
         "target_workflow_path": target_rel,
+        "required_bootstrap_path": "{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
         "name": frontmatter.get("name", command),
         "description": frontmatter.get(
             "description",
@@ -2810,6 +2855,7 @@ def _render_kit_workflow_skill_content(
             "name": spec.name,
             "description": spec.description,
             "target_path": spec.target_rel,
+            "required_bootstrap_path": "{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
         },
     )
 # @cpt-end:cpt-studio-algo-agent-integration-list-workflows:p1:inst-generate-kit-workflow-skills
@@ -2922,7 +2968,7 @@ def _has_openai_codex_agent_signal(project_root: Path) -> bool:
         except (OSError, UnicodeDecodeError) as exc:
             _warn_agents(f"failed to inspect Codex agent file {agent_file}: {exc}")
             continue
-        if _extract_studio_follow_target(content):
+        if _extract_studio_owned_target(content):
             return True
     return False
 
@@ -3554,14 +3600,16 @@ def _rename_workflow_files(
         text = _read_existing_workflow_text(path, prefix)
         if text is None:
             continue
-        if "ALWAYS open and follow `" not in text:
-            continue
-        match = _FOLLOW_LINK_RE.search(text)
-        if not match:
+        target_path = (
+            _extract_studio_control_target(text)
+            or _extract_studio_follow_target(text)
+            or _extract_any_follow_target(text)
+        )
+        if not target_path:
             continue
         target_rel, error = _resolve_workflow_follow_target(
             path,
-            match.group(1),
+            target_path,
             project_root,
             studio_root,
         )
@@ -3669,23 +3717,25 @@ def _cleanup_stale_workflow_file(
     except OSError as exc:
         _warn_agents(f"failed to inspect workflow alias {path}: {exc}")
         return
-    match = _FOLLOW_LINK_RE.search(text)
-    if match:
-        target_rel = match.group(1)
-        if "workflows/" in target_rel or "/workflows/" in target_rel:
-            expected = _resolve_expected_workflow_target(path, target_rel, project_root, studio_root)
-            if (
-                expected is not None
-                and _workflow_target_is_supported_alias(expected, project_root, studio_root)
-                and not expected.exists()
-            ):
-                workflows_result["deleted"].append(path_str)
-                if dry_run:
-                    return
-                try:
-                    path.unlink()
-                except (PermissionError, FileNotFoundError, OSError) as exc:
-                    _warn_agents(f"failed to delete stale workflow alias {path}: {exc}")
+    target_rel = (
+        _extract_studio_control_target(text)
+        or _extract_studio_follow_target(text)
+        or _extract_any_follow_target(text)
+    )
+    if target_rel and ("workflows/" in target_rel or "/workflows/" in target_rel):
+        expected = _resolve_expected_workflow_target(path, target_rel, project_root, studio_root)
+        if (
+            expected is not None
+            and _workflow_target_is_supported_alias(expected, project_root, studio_root)
+            and not expected.exists()
+        ):
+            workflows_result["deleted"].append(path_str)
+            if dry_run:
+                return
+            try:
+                path.unlink()
+            except (PermissionError, FileNotFoundError, OSError) as exc:
+                _warn_agents(f"failed to delete stale workflow alias {path}: {exc}")
 
 
 def _cleanup_stale_workflow_files(
@@ -3920,6 +3970,7 @@ def _render_skill_output(
             "skill_name": str(ctx.skill_name),
             "target_skill_path": target_rel,
             "target_path": target_rel,
+            "required_bootstrap_path": "{cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
             "name": out_name,
             "description": out_description,
             "custom_content": ctx.custom_content,
@@ -4916,8 +4967,7 @@ def _classify_generated_output_owner(rel: str, content: str) -> Optional[str]:
     if rel.endswith(".toml"):
         return "agent" if _is_studio_managed_toml_output(content) else None
     if not (
-        _extract_studio_follow_target(content)
-        or _extract_studio_endpoint_target(content)
+        _extract_studio_owned_target(content)
         or _is_pure_studio_generated(content)
     ):
         return None
@@ -5049,7 +5099,7 @@ def _cleanup_claude_workflow_command(
     except OSError as exc:
         _warn_agents(f"failed to inspect legacy workflow file {legacy_file}: {exc}")
         return
-    follow_target = _extract_studio_follow_target(content)
+    follow_target = _extract_studio_owned_target(content)
     if not follow_target or "workflows/" not in follow_target:
         return
     if Path(follow_target).name != wf_filename:

--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -158,23 +158,11 @@ def _follow_protocol_lines(target_path: str) -> List[str]:
     # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-follow-protocol
     return [
         "CF_WORKFLOW_ACTIVE:",
-        # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-clarify-full-route-family
         "- workflow = executable_control_flow",
         "- no_substantive_work_until = workflow_explicit_permission",
         "MANDATORY RULE: USER INTENT IS SKILL INPUT, NOT EXECUTION AUTHORITY",
         "- hard_stop = WAIT | STOP_TURN | menu | gate | opener | approval | dispatch_gate | terminal_shape",
         "- precedence = constructor_studio_workflow > generic_assistant",
-        "- active_workflow_law = current_state_transition | visible_companion_handoff | explicit_free_mode_exit",
-        # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-clarify-full-route-family
-        # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-cf-intent-clarify-after-menu
-        # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-companion-multi-select
-        # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-companion-multiselect
-        "- pre_emit_check = response_shape in workflow_allowed_shapes",
-        "- if_check_fails = emit_only(workflow_allowed_gate_menu_opener_refusal)",
-        "- protocol_violation > incomplete_answer",
-        # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-companion-multiselect
-        # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-companion-multi-select
-        # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-cf-intent-clarify-after-menu
         "",
         # @cpt-begin:cpt-studio-flow-agent-integration-generate:p1:inst-collect-sysprompt
         # @cpt-begin:cpt-studio-flow-agent-integration-generate:p1:inst-inject-agents
@@ -197,24 +185,29 @@ def _follow_protocol_lines(target_path: str) -> List[str]:
         "  LOAD and RUN " + target_path + " as controlling protocol",
         "RULES:",
         "  - ALWAYS run this bootstrap unit before any target workflow or skill work begins",
-        "  - ALWAYS preserve the canonical controlling-protocol target so generated-file ownership and cleanup remain stable",
+        (
+            "  - ALWAYS preserve the canonical controlling-protocol target so "
+            "generated-file ownership and cleanup remain stable"
+        ),
         "",
         "UNIT GeneratedFollowProtocol",
         "RULES:",
         "  - ALWAYS treat target as controlling protocol, not background context",
         "  - ALWAYS traverse declared steps/units in order",
-        "  - ALWAYS load every required unconditional LOAD/CONTINUE before task work",
-        # @cpt-begin:cpt-studio-flow-agent-integration-workflow:p1:inst-cf-conditional-module-loading
-        "  - ALWAYS evaluate conditional gates and load every active branch",
-        # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-cf-conditional-module-loading
         (
-            "  - ALWAYS while the workflow is active, map each new user message to "
-            "a current workflow state, a visible companion-skill handoff, or an "
-            "explicit free-mode exit."
+            "  - ALWAYS load every required unconditional LOAD/CONTINUE before "
+            "task work"
         ),
-        "  - NEVER treat a follow-up user prompt as permission to bypass the workflow state machine silently.",
-        "  - NEVER skip, summarize, or defer required instructions",
-        "  - ALWAYS stop if any required fragment or rule cannot be followed",
+        "  - ALWAYS evaluate conditional gates and load every active branch",
+        (
+            "  - ALWAYS while the workflow is active, treat each new user message "
+            "as input to the current workflow state, not as permission for "
+            "unrelated execution."
+        ),
+        (
+            "  - ALWAYS stop if any required fragment or rule cannot be "
+            "followed"
+        ),
         "```",
     ]
     # @cpt-end:cpt-studio-flow-agent-integration-workflow:p1:inst-follow-protocol

--- a/tests/test_agents_coverage.py
+++ b/tests/test_agents_coverage.py
@@ -2812,7 +2812,7 @@ class TestCypilotRalphexRegistration(unittest.TestCase):
             found_skill_ref = False
             for fpath in skill_files:
                 content = Path(fpath).read_text(encoding="utf-8")
-                if "ALWAYS open and follow" in content and "SKILL.md" in content:
+                if "LOAD and RUN" in content and "SKILL.md" in content:
                     found_skill_ref = True
                     break
             self.assertTrue(found_skill_ref, "Windsurf skill must reference canonical SKILL.md")
@@ -3675,7 +3675,7 @@ class TestIsPureCypilotGenerated(unittest.TestCase):
 
         content = (
             "---\nname: cypilot\ndescription: Cypilot skill\n---\n\n"
-            "ALWAYS open and follow `{cf-studio-path}/.core/workflows/generate.md`\n"
+            "LOAD and RUN {cf-studio-path}/.core/workflows/generate.md as controlling protocol\n"
         )
         self.assertTrue(_is_pure_studio_generated(content))
 
@@ -3684,7 +3684,7 @@ class TestIsPureCypilotGenerated(unittest.TestCase):
 
         content = (
             "---\nname: cypilot\ndescription: Cypilot skill\n---\n\n"
-            "ALWAYS open and follow `{cf-studio-path}/.core/workflows/generate.md`\n\n"
+            "LOAD and RUN {cf-studio-path}/.core/workflows/generate.md as controlling protocol\n\n"
             "## My custom notes\nSome user-authored content here.\n"
         )
         self.assertFalse(_is_pure_studio_generated(content))
@@ -3843,8 +3843,8 @@ class TestCopilotCustomContent(unittest.TestCase):
             content = skill_proxy.read_text(encoding="utf-8")
             self.assertIn("## Custom Copilot Instructions", content,
                 "custom_content must appear in the /cf skill proxy")
-            self.assertIn("ALWAYS open and follow", content,
-                "skill proxy must contain follow-link directive")
+            self.assertIn("LOAD and RUN", content,
+                "skill proxy must contain controlling-protocol directive")
 
 
 class TestManifestSkillAgentFiltering(unittest.TestCase):
@@ -4262,6 +4262,24 @@ class TestExtractCypilotFollowTarget(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestExtractStudioControlTarget(unittest.TestCase):
+    """Cover _extract_studio_control_target utility."""
+
+    def test_extracts_control_target(self):
+        from studio.commands.agents import _extract_studio_control_target
+
+        content = "LOAD and RUN {cf-studio-path}/test.md as controlling protocol\n"
+        result = _extract_studio_control_target(content)
+        self.assertEqual(result, "{cf-studio-path}/test.md")
+
+    def test_rejects_unmanaged_control_target(self):
+        from studio.commands.agents import _extract_studio_control_target
+
+        content = "LOAD and RUN relative/test.md as controlling protocol\n"
+        result = _extract_studio_control_target(content)
+        self.assertIsNone(result)
+
+
 class TestIsPureCypilotGeneratedV2(unittest.TestCase):
     """Cover _is_pure_studio_generated checks."""
 
@@ -4269,7 +4287,7 @@ class TestIsPureCypilotGeneratedV2(unittest.TestCase):
         from studio.commands.agents import _is_pure_studio_generated
 
         # Canonical frontmatter (only name + description) → pure
-        content = "---\nname: test\ndescription: A skill\n---\nALWAYS open and follow `{cf-studio-path}/test.md`\n"
+        content = "---\nname: test\ndescription: A skill\n---\nLOAD and RUN {cf-studio-path}/test.md as controlling protocol\n"
         result = _is_pure_studio_generated(content)
         self.assertTrue(result)
 
@@ -4277,14 +4295,14 @@ class TestIsPureCypilotGeneratedV2(unittest.TestCase):
         from studio.commands.agents import _is_pure_studio_generated
 
         # Non-canonical key (type) means user-customised frontmatter → not pure
-        content = "---\ntype: command\n---\nALWAYS open and follow `{cf-studio-path}/test.md`\n"
+        content = "---\ntype: command\n---\nLOAD and RUN {cf-studio-path}/test.md as controlling protocol\n"
         result = _is_pure_studio_generated(content)
         self.assertFalse(result)
 
     def test_with_user_content_not_pure(self):
         from studio.commands.agents import _is_pure_studio_generated
 
-        content = "---\nname: test\ndescription: A skill\n---\nALWAYS open and follow `{cf-studio-path}/test.md`\n\nUser added content here\n"
+        content = "---\nname: test\ndescription: A skill\n---\nLOAD and RUN {cf-studio-path}/test.md as controlling protocol\n\nUser added content here\n"
         result = _is_pure_studio_generated(content)
         self.assertFalse(result)
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -884,6 +884,15 @@ class TestCLIAgentsCommand(unittest.TestCase):
                     skill_file.exists(),
                     f"Expected skill file not generated: {skill_file.relative_to(root)}",
                 )
+                content = skill_file.read_text(encoding="utf-8")
+                self.assertIn("UNIT GeneratedBootstrapUnit", content)
+                self.assertIn(
+                    "LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
+                    content,
+                )
+                self.assertIn("RUN RequiredBootstrap", content)
+                self.assertIn("LOAD and RUN {cf-studio-path}/", content)
+                self.assertIn("as controlling protocol", content)
 
     def test_openai_agent_skill_frontmatter_matches_codex_schema(self):
         """Issue #125: generated skill files must use Codex-compatible frontmatter."""

--- a/tests/test_ralphex_delegation.py
+++ b/tests/test_ralphex_delegation.py
@@ -1572,7 +1572,7 @@ class TestEndToEndCapabilitySurface:
             skill_files = skills.get("created", []) + skills.get("updated", [])
             assert len(skill_files) > 0, "Windsurf must produce skill output"
             found = any(
-                "ALWAYS open and follow" in Path(f).read_text(encoding="utf-8")
+                "LOAD and RUN" in Path(f).read_text(encoding="utf-8")
                 and "SKILL.md" in Path(f).read_text(encoding="utf-8")
                 for f in skill_files
             )

--- a/tests/test_subagent_registration.py
+++ b/tests/test_subagent_registration.py
@@ -700,11 +700,10 @@ class TestLegacyStubClassification(unittest.TestCase):
         )
         self.assertIn("- no_substantive_work_until = workflow_explicit_permission", block)
         self.assertIn("- precedence = constructor_studio_workflow > generic_assistant", block)
-        self.assertIn("- pre_emit_check = response_shape in workflow_allowed_shapes", block)
         # The pipeline directive is emitted before the generated bootstrap unit.
         self.assertIn(ROOT_AGENTS_PIPELINE_INSTRUCTION, block)
         self.assertLess(
-            block.index("- protocol_violation > incomplete_answer"),
+            block.index("- precedence = constructor_studio_workflow > generic_assistant"),
             block.index(ROOT_AGENTS_PIPELINE_INSTRUCTION),
         )
         self.assertLess(
@@ -725,7 +724,8 @@ class TestLegacyStubClassification(unittest.TestCase):
         self.assertIn("ALWAYS treat target as controlling protocol", joined)
         self.assertIn("ALWAYS traverse declared steps/units in order", joined)
         self.assertIn("ALWAYS load every required unconditional LOAD/CONTINUE", joined)
-        self.assertIn("NEVER skip, summarize, or defer required instructions", joined)
+        self.assertIn("ALWAYS evaluate conditional gates and load every active branch", joined)
+        self.assertIn("ALWAYS stop if any required fragment or rule cannot be followed", joined)
         self.assertTrue(_is_pure_studio_generated(content, expected_name="cf-analyze"))
 
 

--- a/tests/test_subagent_registration.py
+++ b/tests/test_subagent_registration.py
@@ -696,13 +696,12 @@ class TestLegacyStubClassification(unittest.TestCase):
         self.assertEqual(block[0], "CF_WORKFLOW_ACTIVE:")
         self.assertLess(
             block.index("- workflow = executable_control_flow"),
-            block.index("ALWAYS open and follow `{cf-studio-path}/.core/workflows/analyze.md`"),
+            block.index("UNIT GeneratedBootstrapUnit"),
         )
         self.assertIn("- no_substantive_work_until = workflow_explicit_permission", block)
         self.assertIn("- precedence = constructor_studio_workflow > generic_assistant", block)
         self.assertIn("- pre_emit_check = response_shape in workflow_allowed_shapes", block)
-        # The pipeline directive is emitted between the mandatory-rule block and
-        # the "ALWAYS open and follow" target line.
+        # The pipeline directive is emitted before the generated bootstrap unit.
         self.assertIn(ROOT_AGENTS_PIPELINE_INSTRUCTION, block)
         self.assertLess(
             block.index("- protocol_violation > incomplete_answer"),
@@ -710,8 +709,18 @@ class TestLegacyStubClassification(unittest.TestCase):
         )
         self.assertLess(
             block.index(ROOT_AGENTS_PIPELINE_INSTRUCTION),
-            block.index("ALWAYS open and follow `{cf-studio-path}/.core/workflows/analyze.md`"),
+            block.index("UNIT GeneratedBootstrapUnit"),
         )
+        self.assertIn(
+            "  LOAD {required_bootstrap_path}",
+            block,
+        )
+        self.assertIn("  RUN RequiredBootstrap", block)
+        self.assertIn(
+            "  LOAD and RUN {cf-studio-path}/.core/workflows/analyze.md as controlling protocol",
+            block,
+        )
+        self.assertIn("UNIT GeneratedBootstrapUnit", joined)
         self.assertIn("UNIT GeneratedFollowProtocol", joined)
         self.assertIn("ALWAYS treat target as controlling protocol", joined)
         self.assertIn("ALWAYS traverse declared steps/units in order", joined)

--- a/tests/test_subagent_registration.py
+++ b/tests/test_subagent_registration.py
@@ -676,12 +676,16 @@ class TestLegacyStubClassification(unittest.TestCase):
 
     def test_generated_follow_link_protocol_requires_workflow_execution(self):
         from studio.commands.agents import (
+            _REQUIRED_BOOTSTRAP_PATH,
             _follow_protocol_lines,
             _is_pure_studio_generated,
         )
         from studio.constants import ROOT_AGENTS_PIPELINE_INSTRUCTION
 
-        block = _follow_protocol_lines("{cf-studio-path}/.core/workflows/analyze.md")
+        block = _follow_protocol_lines(
+            "{cf-studio-path}/.core/workflows/analyze.md",
+            required_bootstrap_path=_REQUIRED_BOOTSTRAP_PATH,
+        )
         content = (
             "---\n"
             "name: cf-analyze\n"
@@ -711,7 +715,7 @@ class TestLegacyStubClassification(unittest.TestCase):
             block.index("UNIT GeneratedBootstrapUnit"),
         )
         self.assertIn(
-            "  LOAD {required_bootstrap_path}",
+            "  LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/required-bootstrap.md",
             block,
         )
         self.assertIn("  RUN RequiredBootstrap", block)

--- a/tests/test_workflow_subagents_dispatch.py
+++ b/tests/test_workflow_subagents_dispatch.py
@@ -2506,6 +2506,18 @@ def test_workflow_prep_recommends_skip_when_resource_context_exists() -> None:
     ) in workflow_prep
 
 
+def test_required_bootstrap_activates_content_and_resource_context_memory() -> None:
+    """Generated-skill bootstrap must activate the content/resource memory runtime rules."""
+    repo_root = Path(__file__).resolve().parents[1]
+    required_bootstrap = (
+        repo_root / "skills" / "studio" / "modules" / "runtime" / "required-bootstrap.md"
+    ).read_text(encoding="utf-8")
+
+    assert "LOAD {cf-studio-path}/.core/skills/studio/modules/runtime/context-memory.md" in required_bootstrap
+    assert "RUN ContentMemory" in required_bootstrap
+    assert "RUN ResourceContextMemory" in required_bootstrap
+
+
 def test_studio_instruction_memory_runs_in_concrete_workflows() -> None:
     """Concrete workflows load generated/project Studio instructions before work."""
     repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
Implement a required bootstrap unit for generated skills and workflows to ensure proper execution of runtime rules and enhance PDSL handling. This change streamlines the execution process and improves protocol management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated agent/workflow shims now prepend a standard bootstrap unit before transferring control to the target.
  * Shims and routing now support the newer **`LOAD and RUN ... as controlling protocol`** flow, with the legacy follow-based format retained as a fallback.
* **Bug Fixes**
  * Improved ownership detection and stale-artifact cleanup for generated agent/workflow files.
* **Documentation**
  * Updated PDSL execution semantics and CLI/generation contracts; added/expanded required bootstrap documentation.
* **Tests**
  * Expanded assertions to validate bootstrap/control-protocol markers and runtime memory activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->