### PR TITLE
Add PM-facing capability overview, user journeys, and CLI reference

### DIFF
--- a/docs/research/cli-reference.md
+++ b/docs/research/cli-reference.md
@@ -1,0 +1,236 @@
+# Constructor Studio v1.5.9 — CLI Reference
+
+Constructor Studio ships a command-line tool called `cfs`. You invoke every feature as `cfs <command>`, optionally followed by flags. This reference covers all 30 commands available in v1.5.9, organized by the workflow stage they serve. The audience is product managers who need to understand what the tool can do, not how to implement it.
+
+---
+
+## Command Categories
+
+| # | Category | Commands | Purpose |
+|---|---|---|---|
+| 1 | Setup & Configuration | `init`, `update`, `info`, `resolve-vars` | Bootstrap and maintain a Studio-enabled project |
+| 2 | Agent Integrations | `agents`, `generate-agents` | Connect Studio to AI coding assistants (Claude, Cursor, Copilot, etc.) |
+| 3 | Validation | `validate`, `validate-kits`, `validate-toc`, `spec-coverage`, `check-language` | Ensure structure, traceability, and content quality |
+| 4 | Traceability Navigation | `list-ids`, `list-id-kinds`, `get-content`, `where-defined`, `where-used` | Explore and query CPT traceability IDs across a project |
+| 5 | Kit Management | `kit install`, `kit update`, `kit normalize`, `kit check-updates` | Manage reusable skill/rule packages (kits) |
+| 6 | Document Utilities | `toc`, `pdsl`, `chunk-input` | Author and process structured documents |
+| 7 | Visualization | `map` | Build interactive dependency maps |
+| 8 | Workspace Management | `workspace-init`, `workspace-add`, `workspace-info`, `workspace-sync` | Coordinate multi-repo workspaces |
+| 9 | Delegation & Diagnostics | `delegate`, `doctor` | Remote execution and environment health |
+
+---
+
+## Command Reference
+
+```cdsl
+COMMAND_GROUP Setup & Configuration
+  PURPOSE: Bootstrap a new Studio project, keep it current, and inspect its active configuration.
+  COMMANDS:
+    COMMAND init
+      USER_ACTION: Run once when adopting Studio in a repository; re-run with --force to reset. Preserves existing configuration fragments when re-running on an already-initialized project (use --force to replace).
+      PRODUCES: Studio config directory scaffold (default: .cf-studio/; configurable via cf-studio-path in CLAUDE.md), core config files, gitignore entries; optionally migrates a legacy CyPilot project.
+      OPTIONS: [--force (overwrite existing), --migrate-yes (auto-accept CyPilot migration), --from-dir <path> (seed from another directory)]
+
+    COMMAND update
+      USER_ACTION: Run after upgrading the Studio version or when .core/ assets need refreshing.
+      PRODUCES: Replaces .core/ content from the local cache, regenerates .gen/ aggregate files; optionally refreshes installed kits.
+      OPTIONS: [--with-kits yes (also update all kits), --dry-run (preview without writing)]
+
+    COMMAND info
+      USER_ACTION: Run to audit the current Studio setup or share config details in a support request.
+      PRODUCES: Human-readable report of project root, studio directory, registered kits, and registry status.
+      OPTIONS: [--json (machine-readable output)]
+
+    COMMAND resolve-vars
+      USER_ACTION: Run when a workflow needs guaranteed absolute file paths for template variable substitution.
+      PRODUCES: Resolved paths printed to stdout; used internally by other workflows to avoid relative-path ambiguity.
+      OPTIONS: []
+```
+
+```cdsl
+COMMAND_GROUP Agent Integrations
+  PURPOSE: Generate and inspect integration files that let AI coding assistants (Claude, Cursor, Windsurf, Copilot, OpenAI) work with Studio conventions.
+  COMMANDS:
+    COMMAND agents
+      USER_ACTION: Run to check which agent integration files exist and whether they are up to date.
+      PRODUCES: Status report listing each supported agent (Windsurf, Cursor, Claude, Copilot, OpenAI) and the state of its integration file; read-only, no files are changed.
+      OPTIONS: []
+
+    COMMAND generate-agents
+      USER_ACTION: Run after init or when onboarding a new AI assistant to the project.
+      PRODUCES: Creates or updates IDE/agent integration files so each assistant can discover Studio rules and skills.
+      OPTIONS: [--yes (skip confirmation prompts), --dry-run (preview changes without writing)]
+```
+
+```cdsl
+COMMAND_GROUP Validation
+  PURPOSE: Verify that kit structures, artifact cross-references, CDSL markers, table of contents, and content language all meet project standards.
+  COMMANDS:
+    COMMAND validate
+      USER_ACTION: Run as a CI gate or before a release to confirm the full traceability pipeline is healthy.
+      PRODUCES: Sequenced report covering kit structure, artifact structure, cross-references, CDSL marker scan, coverage check, and optional language check; exits non-zero on failure.
+      OPTIONS: [--artifact <id> (scope to one artifact), --source <path> (restrict source scope), --output <file> (write report to file), --local-only (skip remote lookups)]
+
+    COMMAND validate-kits
+      USER_ACTION: Run when a kit has been modified to confirm its internal structure is intact before sharing it.
+      PRODUCES: Pass/fail report for each kit covering directory layout, conf.toml, constraints.toml, and manifest bindings.
+      OPTIONS: [aliases: validate-rules, self-check]
+
+    COMMAND validate-toc
+      USER_ACTION: Run after editing Markdown documents to confirm the Table of Contents is still accurate.
+      PRODUCES: Report listing any TOC entries whose anchors do not match headings, are missing, or are stale.
+      OPTIONS: [--warn-only (non-zero exit only on errors, not warnings), --verbose (show all checked files)]
+
+    COMMAND spec-coverage
+      USER_ACTION: Run to measure how thoroughly the codebase is annotated with CDSL markers.
+      PRODUCES: Per-file and aggregate coverage percentages plus granularity score; can enforce a minimum threshold.
+      OPTIONS: [--min-coverage <0-100> (fail below threshold), --output <file> (write JSON report)]
+
+    COMMAND check-language
+      USER_ACTION: Run to detect characters from unexpected scripts in Markdown content (e.g., stray Cyrillic in an English document).
+      PRODUCES: List of files and line numbers containing characters outside the allowed Unicode script set.
+      OPTIONS: [--languages <list> (allowed script codes), --ignore <glob> (exclude paths), --quiet (suppress passing files)]
+```
+
+```cdsl
+COMMAND_GROUP Traceability Navigation
+  PURPOSE: Explore, query, and retrieve content associated with CPT (Constructor Part Traceability) IDs throughout a project.
+  COMMANDS:
+    COMMAND list-ids
+      USER_ACTION: Run to get a full inventory of traceability IDs, or to find all IDs of a particular kind.
+      PRODUCES: Grouped list of CPT IDs discovered across all artifact and code files.
+      OPTIONS: [--kind <token> (filter by ID kind), --pattern <regex> (filter by pattern), --dedup (suppress duplicates)]
+
+    COMMAND list-id-kinds
+      USER_ACTION: Run to understand which ID taxonomies are in use in the project.
+      PRODUCES: Table of all ID kind tokens with occurrence counts.
+      OPTIONS: []
+
+    COMMAND get-content
+      USER_ACTION: Run to read the exact text block associated with a known Studio ID without opening the file manually.
+      PRODUCES: Extracted text block for the requested ID from the relevant artifact or code file.
+      OPTIONS: [--code (retrieve from source code rather than artifact), --inst (retrieve instruction variant)]
+
+    COMMAND where-defined
+      USER_ACTION: Run to locate where a specific Studio ID is declared.
+      PRODUCES: File path(s) and line number(s) that contain the definition of the given ID.
+      OPTIONS: []
+
+    COMMAND where-used
+      USER_ACTION: Run to understand the impact of changing a specific Studio ID — who references it.
+      PRODUCES: List of all files and locations that reference the given ID.
+      OPTIONS: []
+```
+
+```cdsl
+COMMAND_GROUP Kit Management
+  PURPOSE: Install, update, and inspect reusable skill and rule packages (kits) within a Studio project.
+  COMMANDS:
+    COMMAND kit install
+      USER_ACTION: Run to add a new kit to the project from a local path, a GitHub repository, or any Git URL.
+      PRODUCES: Kit files placed under the project's kit directory; registered in Studio config. Supports copy mode (files inlined) or register mode (reference only).
+      OPTIONS: [<source> (local path, GitHub slug, or Git URL), --mode copy|register]
+
+    COMMAND kit update
+      USER_ACTION: Run when an upstream kit has new changes and you want to selectively adopt them.
+      PRODUCES: Interactive diff session per changed file; user accepts, declines, or modifies each change before it is written.
+      OPTIONS: []
+
+    COMMAND kit normalize
+      USER_ACTION: Run after manually adding or rearranging files in a kit to keep manifest.toml consistent.
+      PRODUCES: Generated or updated manifest.toml that reflects the current kit file layout.
+      OPTIONS: [--dry-run (preview manifest without writing)]
+
+    COMMAND kit check-updates
+      USER_ACTION: Run to find out whether any installed kits have newer upstream versions available.
+      PRODUCES: Comparison report of installed vs upstream kit versions for each registered kit.
+      OPTIONS: []
+```
+
+```cdsl
+COMMAND_GROUP Document Utilities
+  PURPOSE: Author structured documents, validate prompt contracts, and split large inputs for AI-assisted processing.
+  COMMANDS:
+    COMMAND toc
+      USER_ACTION: Run after adding or renaming headings in a Markdown file to regenerate its Table of Contents.
+      PRODUCES: Inserts or replaces the TOC block in the target Markdown file with anchor links derived from current headings.
+      OPTIONS: [--dry-run (print TOC without writing), --max-level <n> (deepest heading level to include), --indent-size <n> (spaces per indent level)]
+
+    COMMAND pdsl
+      USER_ACTION: Run to verify that a skill or workflow file's PDSL prompt blocks satisfy their declared contracts.
+      PRODUCES: Validation report indicating which PDSL blocks pass or fail their contract constraints; accepts a file path or stdin.
+      OPTIONS: [<file> (path to skill/workflow file), --stdin (read from stdin), --verbose (show passing blocks)]
+
+    COMMAND chunk-input
+      USER_ACTION: Run before feeding a large Markdown document into an AI workflow that has context-length limits.
+      PRODUCES: A manifest file and a set of numbered chunk files that together represent the original input split at safe boundaries.
+      OPTIONS: [--stdin (read from stdin), --dry-run (preview chunk boundaries without writing)]
+```
+
+```cdsl
+COMMAND_GROUP Visualization
+  PURPOSE: Produce an interactive visual map of how Studio artifacts and IDs depend on each other.
+  COMMANDS:
+    COMMAND map
+      USER_ACTION: Run to generate a shareable dependency map for review, onboarding, or architecture documentation.
+      PRODUCES: HTML page (or JSON data file) showing nodes for CPT IDs and edges for cross-references; highlights dangling references; supports multi-repo workspace federation.
+      OPTIONS: [--inline-data (embed JSON into HTML for single-file sharing), --output <file> (path for HTML or JSON), --json (output raw JSON instead of HTML)]
+```
+
+```cdsl
+COMMAND_GROUP Workspace Management
+  PURPOSE: Initialize and maintain a federated multi-repo workspace so Studio commands can span multiple repositories.
+  COMMANDS:
+    COMMAND workspace-init
+      USER_ACTION: Run once at the root of a mono-repo or workspace directory to register all Studio-enabled sub-projects.
+      PRODUCES: .cf-workspace.toml listing all discovered Studio project sources.
+      OPTIONS: [--inline (embed source configs directly), --output <path> (custom output path), --force (overwrite existing), --max-depth <n> (scan depth), --dry-run]
+
+    COMMAND workspace-add
+      USER_ACTION: Run to register an additional project (local path or Git URL) into an existing workspace.
+      PRODUCES: Updated .cf-workspace.toml with the new source entry appended.
+      OPTIONS: [--force (overwrite if already present), --inline (embed config inline)]
+
+    COMMAND workspace-info
+      USER_ACTION: Run to audit which sources are registered and whether they are currently reachable.
+      PRODUCES: Table of workspace sources with reachability status (online/offline/missing).
+      OPTIONS: []
+
+    COMMAND workspace-sync
+      USER_ACTION: Run to pull or update Git worktrees for any URL-based sources in the workspace.
+      PRODUCES: Local worktree directories synchronized to the declared Git refs for each URL source.
+      OPTIONS: [--source <name> (sync one source only), --dry-run, --force (reset diverged worktrees)]
+```
+
+```cdsl
+COMMAND_GROUP Delegation & Diagnostics
+  PURPOSE: Delegate Studio plans to remote execution and verify that the local environment meets all prerequisites.
+  COMMANDS:
+    COMMAND delegate
+      USER_ACTION: Run to compile a plan.toml into the ralphex (remote execution layer) format and send it for execution.
+      PRODUCES: Compiled execution plan dispatched to ralphex; in tasks-only mode prints the task list; in review mode shows the plan without executing.
+      OPTIONS: [--mode execute|tasks-only|review, --dry-run (compile without dispatching), --json (output plan as JSON)]
+
+    COMMAND doctor
+      USER_ACTION: Run to diagnose environment setup issues before using Studio features that depend on external tools.
+      PRODUCES: Health check report with PASS / WARN / FAIL status for each checked component (e.g., ralphex availability, required binaries).
+      OPTIONS: []
+```
+
+---
+
+## Notes
+
+**CPT** — Constructor Part Traceability ID. A structured identifier (e.g., `CPT-FEAT-001`) embedded in source code and artifact files to create a bidirectional traceability link. Commands in the Traceability Navigation category operate on these IDs.
+
+**PDSL** — Prompt Domain Specification Language. A contract syntax used inside skill and workflow Markdown files to declare what an AI prompt block expects as input and produces as output. The `pdsl` command validates these contracts.
+
+**CDSL** — Constructor Domain Specification Language — used both as structured document notation (CAPABILITY, ALGORITHM, COMMAND_GROUP blocks in research and spec documents) and as inline code markers (@cpt-*) scanned by cfs validate and cfs spec-coverage for traceability.
+
+**Kits** — Reusable packages of Studio skills, rules, and configuration. A kit is a directory with a `conf.toml`, `constraints.toml`, and `manifest.toml`. The `kit` subcommands manage their lifecycle.
+
+**ralphex** — The remote execution layer that Studio's `delegate` command targets. It accepts compiled plans and runs them outside the local environment.
+
+**--json flag** — Several commands (`info`, `spec-coverage`, `map`, `delegate`) accept `--json` to produce machine-readable output suitable for scripting or CI pipelines.
+
+**Command aliases** — `validate-kits` also responds to `validate-rules` and `self-check`. All three are equivalent.

--- a/docs/research/cli-reference.md
+++ b/docs/research/cli-reference.md
@@ -94,7 +94,7 @@ COMMAND_GROUP Validation
 
 ```cdsl
 COMMAND_GROUP Traceability Navigation
-  PURPOSE: Explore, query, and retrieve content associated with CPT (Constructor Part Traceability) IDs throughout a project.
+  PURPOSE: Explore, query, and retrieve content associated with CPT (Canonical Provenance Trace) IDs throughout a project.
   COMMANDS:
     COMMAND list-ids
       USER_ACTION: Run to get a full inventory of traceability IDs, or to find all IDs of a particular kind.
@@ -221,7 +221,7 @@ COMMAND_GROUP Delegation & Diagnostics
 
 ## Notes
 
-**CPT** — Constructor Part Traceability ID. A structured identifier (e.g., `CPT-FEAT-001`) embedded in source code and artifact files to create a bidirectional traceability link. Commands in the Traceability Navigation category operate on these IDs.
+**CPT** — Canonical Provenance Trace ID. A structured identifier (e.g., `CPT-FEAT-001`) embedded in source code and artifact files to create a bidirectional traceability link. Commands in the Traceability Navigation category operate on these IDs.
 
 **PDSL** — Prompt Domain Specification Language. A contract syntax used inside skill and workflow Markdown files to declare what an AI prompt block expects as input and produces as output. The `pdsl` command validates these contracts.
 

--- a/docs/research/cli-reference.md
+++ b/docs/research/cli-reference.md
@@ -22,7 +22,7 @@ Constructor Studio ships a command-line tool called `cfs`. You invoke every feat
 
 ## Command Reference
 
-```cdsl
+```text
 COMMAND_GROUP Setup & Configuration
   PURPOSE: Bootstrap a new Studio project, keep it current, and inspect its active configuration.
   COMMANDS:
@@ -47,7 +47,7 @@ COMMAND_GROUP Setup & Configuration
       OPTIONS: []
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Agent Integrations
   PURPOSE: Generate and inspect integration files that let AI coding assistants (Claude, Cursor, Windsurf, Copilot, OpenAI) work with Studio conventions.
   COMMANDS:
@@ -62,7 +62,7 @@ COMMAND_GROUP Agent Integrations
       OPTIONS: [--yes (skip confirmation prompts), --dry-run (preview changes without writing)]
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Validation
   PURPOSE: Verify that kit structures, artifact cross-references, CDSL markers, table of contents, and content language all meet project standards.
   COMMANDS:
@@ -92,7 +92,7 @@ COMMAND_GROUP Validation
       OPTIONS: [--languages <list> (allowed script codes), --ignore <glob> (exclude paths), --quiet (suppress passing files)]
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Traceability Navigation
   PURPOSE: Explore, query, and retrieve content associated with CPT (Canonical Provenance Trace) IDs throughout a project.
   COMMANDS:
@@ -122,7 +122,7 @@ COMMAND_GROUP Traceability Navigation
       OPTIONS: []
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Kit Management
   PURPOSE: Install, update, and inspect reusable skill and rule packages (kits) within a Studio project.
   COMMANDS:
@@ -147,7 +147,7 @@ COMMAND_GROUP Kit Management
       OPTIONS: []
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Document Utilities
   PURPOSE: Author structured documents, validate prompt contracts, and split large inputs for AI-assisted processing.
   COMMANDS:
@@ -167,7 +167,7 @@ COMMAND_GROUP Document Utilities
       OPTIONS: [--stdin (read from stdin), --dry-run (preview chunk boundaries without writing)]
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Visualization
   PURPOSE: Produce an interactive visual map of how Studio artifacts and IDs depend on each other.
   COMMANDS:
@@ -177,7 +177,7 @@ COMMAND_GROUP Visualization
       OPTIONS: [--inline-data (embed JSON into HTML for single-file sharing), --output <file> (path for HTML or JSON), --json (output raw JSON instead of HTML)]
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Workspace Management
   PURPOSE: Initialize and maintain a federated multi-repo workspace so Studio commands can span multiple repositories.
   COMMANDS:
@@ -202,7 +202,7 @@ COMMAND_GROUP Workspace Management
       OPTIONS: [--source <name> (sync one source only), --dry-run, --force (reset diverged worktrees)]
 ```
 
-```cdsl
+```text
 COMMAND_GROUP Delegation & Diagnostics
   PURPOSE: Delegate Studio plans to remote execution and verify that the local environment meets all prerequisites.
   COMMANDS:

--- a/docs/research/cli-reference.md
+++ b/docs/research/cli-reference.md
@@ -221,7 +221,7 @@ COMMAND_GROUP Delegation & Diagnostics
 
 ## Notes
 
-**CPT** — Canonical Provenance Trace ID. A structured identifier (e.g., `CPT-FEAT-001`) embedded in source code and artifact files to create a bidirectional traceability link. Commands in the Traceability Navigation category operate on these IDs.
+**CPT** — Canonical Provenance Trace ID. A structured identifier with the format `cpt-{system-slug}-{kind}-{slug}` (e.g., `cpt-studio-fr-session-routing`) embedded in source code and artifact files to create a bidirectional traceability link. Commands in the Traceability Navigation category operate on these IDs.
 
 **PDSL** — Prompt Domain Specification Language. A contract syntax used inside skill and workflow Markdown files to declare what an AI prompt block expects as input and produces as output. The `pdsl` command validates these contracts.
 

--- a/docs/research/studio-overview.md
+++ b/docs/research/studio-overview.md
@@ -266,6 +266,21 @@ CAPABILITY SourceCodeWork
     THEN: Studio runs the explore gate for full context, breaks the refactor
       into logical sub-steps, applies each in sequence with CI validation
       after each step, and presents a per-layer review at the end
+
+  SCENARIO CodeReviewWithMethodologyDepth
+    GIVEN: A tech lead wants a thorough review of a complex refactor beyond a quick pass
+    WHEN: They invoke cf-coding in review mode and choose per-layer granularity
+    THEN: Studio dispatches reviewers in parallel for each methodology layer
+      (code-checklist, bug-finding, consistency-checklist), aggregates deduplicated
+      findings, lets the user select which to fix, and dispatches a fix agent only
+      for the approved finding set before re-running CI
+
+  SCENARIO TestFirstWorkflow
+    GIVEN: A developer is starting a new feature and wants to write tests before code
+    WHEN: They invoke cf-coding and describe the feature behavior to test
+    THEN: Studio authors test files only (unit tests and/or e2e tests) against the
+      feature description, runs the test suite to confirm tests are red, then hands
+      off to the implementation path — ensuring tests exist before any production code
 ```
 
 ---
@@ -312,6 +327,21 @@ CAPABILITY DocumentationWork
     THEN: Studio diffs the current doc against the codebase via the explore gate,
       identifies outdated sections, proposes targeted revisions, and presents
       them as findings for the user to approve before writing
+
+  SCENARIO MultiAudienceDocumentReview
+    GIVEN: A senior engineer wants to verify that existing architecture docs are still accurate
+    WHEN: They invoke cf-write-docs in review-first mode on an existing DESIGN document
+    THEN: Studio runs a semantic review using the artifact checklist and consistency
+      methodology, presents findings categorized by severity, and gates any fixes on
+      explicit per-finding approval before applying changes
+
+  SCENARIO LanguagePolicyEnforcement
+    GIVEN: A team maintains English-only documentation but suspects a recent commit
+      introduced non-English characters
+    WHEN: They invoke cf-write-docs or cfs check-language on the affected files
+    THEN: Studio scans for characters outside the allowed Unicode script set,
+      reports violations with exact file and line references, and prompts the author
+      to resolve them before the document passes validation
 ```
 
 ---
@@ -360,6 +390,21 @@ CAPABILITY SkillAndWorkflowAuthoring
     THEN: Studio runs the consistency-checklist methodology across all files in
       parallel per-layer mode and produces a findings report without making
       any changes until the author approves each one
+
+  SCENARIO NewStudioSkillCreation
+    GIVEN: A Studio developer wants to add a new custom workflow to their project kit
+    WHEN: They invoke cf-write-skills and describe the skill's purpose and gate structure
+    THEN: Studio authors a PDSL-formatted skill file, validates it with cfs pdsl validate,
+      runs a prompt-engineering semantic review (checking routing logic, missing cases,
+      unclear gates), applies approved fixes, and re-validates PDSL after each fix cycle
+
+  SCENARIO WorkflowBugInvestigation
+    GIVEN: A workflow behaved unexpectedly — a gate fired when it should not have
+    WHEN: The developer invokes cf-debug-prompts, arms the debugger, then triggers
+      the faulty workflow
+    THEN: The debugger intercepts each PDSL instruction, shows the current location
+      (file:line:unit), displays the active state, and pauses for approval — allowing
+      the developer to step through the exact gate condition and identify the root cause
 ```
 
 ---
@@ -589,6 +634,72 @@ CAPABILITY SessionOverlays
 
 ---
 
+### 14. SDLC Artifact Pipeline
+
+```cdsl
+CAPABILITY SdlcArtifactPipeline
+  ACTOR: Product Manager, Tech Lead, Architect, Developer
+  PURPOSE: The SDLC kit adds a structured artifact pipeline on top of Constructor
+    Studio: PRD → ADR + DESIGN → DECOMPOSITION → FEATURE → CODE, with templates,
+    checklists, and traceability enforcement at every stage. Each artifact kind
+    has a dedicated authoring workflow that delegates to cf-write-docs or cf-coding
+    and enforces deterministic validation plus semantic review.
+  KEY_OPERATIONS:
+    - Author a PRD with actors, FR/NFR, use cases, and success criteria (cf-sdlc-doc-prd)
+    - Record an Architecture Decision Record — context/options/decision/consequences (cf-sdlc-doc-adr)
+    - Author a system DESIGN — components, interfaces, boundaries, architecture drivers (cf-sdlc-doc-design)
+    - Break down a DESIGN into an ordered FEATURE list with dependency links (cf-sdlc-decompose)
+    - Author a FEATURE spec with CDSL flows, algorithms, states, and test scenarios (cf-sdlc-doc-feature)
+    - Implement a FEATURE in code with @cpt-* traceability markers (cf-sdlc-implement)
+    - Analyze downstream impact of an upstream artifact change — cascade tracking or release-readiness estimation (cf-sdlc-change-impact-analysis)
+    - Review a GitHub PR against artifact checklists and code review prompts (cf-sdlc-pr-review)
+    - Generate a PR status report with severity assessment and resolved-comment audit (cf-sdlc-pr-status)
+    - Reconstruct SDLC artifacts from existing code using @cpt-* markers — marker-first strategy (cf-sdlc-reverse-engineer)
+    - Migrate OpenSpec artifacts to Studio SDLC format in 8 phases with code verification (cf-sdlc-migrate-openspec)
+  SCENARIO PrdAuthoringFromScratch
+    GIVEN: A PM has a new product idea and needs a formal requirements document
+    WHEN: They invoke cf-sdlc-doc-prd and describe their product concept
+    THEN: Studio guides them through the PRD template (actors, functional requirements
+      with cpt-IDs, non-functional requirements, use cases, success criteria), runs
+      cfs validate --artifact on the result, and performs a semantic review against
+      the PRD checklist before the document is considered done
+  SCENARIO ArchitectureDecisionRecord
+    GIVEN: A tech lead chose a specific database technology and must document why
+    WHEN: They invoke cf-sdlc-doc-adr and describe the decision context
+    THEN: Studio authors an ADR with context, considered options, the chosen option,
+      consequences, and a unique cpt-adr-* traceability ID; the ADR is validated
+      and cross-referenced into the DESIGN artifact automatically
+  SCENARIO ChangeImpactAnalysis
+    GIVEN: A product requirement (PRD FR) was updated to change behavior
+    WHEN: They invoke cf-sdlc-change-impact-analysis with the changed artifact ID
+    THEN: Studio traces the blast radius downstream (PRD → DESIGN → DECOMPOSITION
+      → FEATURE → CODE markers), flags stale @cpt-* markers in code, reports
+      coverage gaps, and — in release-readiness mode — recommends a version bump
+      based on impact severity
+  SCENARIO PrReviewWithChecklists
+    GIVEN: A developer opened a GitHub PR with code and a FEATURE implementation
+    WHEN: They invoke cf-sdlc-pr-review with the PR number
+    THEN: Studio fetches the diff from GitHub, analyzes it against the codebase
+      checklist and per-domain review prompts (code, design, ADR, PRD), and
+      produces a structured review report at .prs/{ID}/review.md with severity-rated
+      findings — without modifying any local files
+  SCENARIO ReverseEngineerFeatureFromCode
+    GIVEN: A team has legacy code with @cpt-* markers but no FEATURE spec documents
+    WHEN: They invoke cf-sdlc-reverse-engineer with the code scope
+    THEN: Studio extracts all @cpt-* markers, reconstructs FEATURE specs with
+      CDSL flows and test scenarios grounded in the actual code behavior,
+      and flags @cpt-gap markers where evidence is missing
+  SCENARIO OpenSpecMigration
+    GIVEN: A team has existing OpenSpec proposals, specs, and design documents
+    WHEN: They invoke cf-sdlc-migrate-openspec with the OpenSpec root directory
+    THEN: Studio runs an 8-phase migration (inventory → PRD → DESIGN → ADRs →
+      DECOMPOSITION → FEATURE specs → @cpt-* code markers → registration + validation),
+      verifies every claim against actual source code, and flags discrepancies where
+      the spec contradicts the implementation
+```
+
+---
+
 ## Summary Table
 
 | Capability | Primary Actor | Workflow / Command | Key CLI |
@@ -606,3 +717,4 @@ CAPABILITY SessionOverlays
 | Narrative Explanation | Developer, any team member | cf-explain | `/cf explain` |
 | Project Setup and Brownfield Onboarding | Developer, tech lead | cf-auto-config | `cfs init / update / generate-agents` |
 | Session Overlays | Any user / Studio author | cf-brave-new-world, cf-debug-prompts | (activated at session start) |
+| 14 | SDLC Artifact Pipeline | PM, Tech Lead, Architect, Developer | cf-sdlc-doc-prd, cf-sdlc-doc-adr, cf-sdlc-doc-design, cf-sdlc-decompose, cf-sdlc-doc-feature, cf-sdlc-implement, cf-sdlc-change-impact-analysis, cf-sdlc-pr-review, cf-sdlc-pr-status, cf-sdlc-reverse-engineer, cf-sdlc-migrate-openspec | cfs validate --artifact, cfs spec-coverage |

--- a/docs/research/studio-overview.md
+++ b/docs/research/studio-overview.md
@@ -18,7 +18,7 @@ The goal is to answer three questions for each capability: **what it does**, **w
 
 ### 1. Session Entry and Routing
 
-```cdsl
+```text
 CAPABILITY SessionEntryAndRouting
   ACTOR: Any team member (developer, tech writer, PM)
   PURPOSE: Provides a single activation point for all Studio capabilities. Free-text
@@ -62,7 +62,7 @@ CAPABILITY SessionEntryAndRouting
 
 ### 2. Context Discovery
 
-```cdsl
+```text
 CAPABILITY ContextDiscovery
   ACTOR: Developer, tech writer, or any contributor starting a complex task
   PURPOSE: Scans the project read-only to find every file and artifact relevant
@@ -112,7 +112,7 @@ CAPABILITY ContextDiscovery
 
 ### 3. Dependency Mapping
 
-```cdsl
+```text
 CAPABILITY DependencyMapping
   ACTOR: Tech lead, architect, or PM assessing impact of a refactor
   PURPOSE: Builds a visual and queryable map of how CPT traceability IDs connect
@@ -160,7 +160,7 @@ CAPABILITY DependencyMapping
 
 ### 4. Design Exploration
 
-```cdsl
+```text
 CAPABILITY DesignExploration
   ACTOR: Developer, architect, or PM evaluating design options before committing
   PURPOSE: Runs a structured expert panel discussion on any design topic, surfacing
@@ -201,7 +201,7 @@ CAPABILITY DesignExploration
 
 ### 5. Planning
 
-```cdsl
+```text
 CAPABILITY Planning
   ACTOR: Tech lead or senior developer breaking a large initiative into
     executable phases
@@ -243,7 +243,7 @@ CAPABILITY Planning
 
 ### 6. Source Code Work
 
-```cdsl
+```text
 CAPABILITY SourceCodeWork
   ACTOR: Developer (all seniority levels)
   PURPOSE: Handles the complete write-review-fix lifecycle for source code in
@@ -304,7 +304,7 @@ CAPABILITY SourceCodeWork
 
 ### 7. Documentation Work
 
-```cdsl
+```text
 CAPABILITY DocumentationWork
   ACTOR: Tech writer, developer authoring READMEs or ADRs, or PM authoring specs
   PURPOSE: Handles the complete write-review-fix lifecycle for all documentation
@@ -365,7 +365,7 @@ CAPABILITY DocumentationWork
 
 ### 8. Skill and Workflow Authoring
 
-```cdsl
+```text
 CAPABILITY SkillAndWorkflowAuthoring
   ACTOR: Studio author (developer or prompt engineer building or maintaining
     Studio skills, workflows, agent instructions, or system prompts)
@@ -428,7 +428,7 @@ CAPABILITY SkillAndWorkflowAuthoring
 
 ### 9. Kit Management
 
-```cdsl
+```text
 CAPABILITY KitManagement
   ACTOR: Developer or Studio administrator managing reusable behavior packages
     across projects
@@ -479,7 +479,7 @@ CAPABILITY KitManagement
 
 ### 10. Multi-Repo Workspace
 
-```cdsl
+```text
 CAPABILITY MultiRepoWorkspace
   ACTOR: Tech lead or architect managing a federation of related Git repositories
   PURPOSE: Federates multiple Git repositories under one Studio workspace so that
@@ -530,7 +530,7 @@ CAPABILITY MultiRepoWorkspace
 
 ### 11. Narrative Explanation
 
-```cdsl
+```text
 CAPABILITY NarrativeExplanation
   ACTOR: Developer onboarding to a new codebase, or any team member who needs
     to understand a complex artifact or decision
@@ -573,7 +573,7 @@ CAPABILITY NarrativeExplanation
 
 ### 12. Project Setup and Brownfield Onboarding
 
-```cdsl
+```text
 CAPABILITY ProjectSetupAndBrownfieldOnboarding
   ACTOR: Developer or tech lead initializing Studio on an existing or new project
   PURPOSE: Scans an existing codebase, generates grounded configuration and rule
@@ -639,7 +639,7 @@ CAPABILITY ProjectSetupAndBrownfieldOnboarding
 
 ### 13. Session Overlays
 
-```cdsl
+```text
 CAPABILITY SessionOverlays
   ACTOR: Any Studio user (Brave New World) or Studio author / debugger
     (Debug Prompts)
@@ -688,7 +688,7 @@ CAPABILITY SessionOverlays
 
 ### 14. SDLC Artifact Pipeline
 
-```cdsl
+```text
 CAPABILITY SdlcArtifactPipeline
   ACTOR: Product Manager, Tech Lead, Architect, Developer
   PURPOSE: The SDLC kit adds a structured artifact pipeline on top of Constructor
@@ -719,7 +719,7 @@ CAPABILITY SdlcArtifactPipeline
     GIVEN: A tech lead chose a specific database technology and must document why
     WHEN: They invoke cf-sdlc-doc-adr and describe the decision context
     THEN: Studio authors an ADR with context, considered options, the chosen option,
-      consequences, and a unique cpt-adr-* traceability ID; the ADR is validated
+      consequences, and a unique cpt-{system}-adr-* traceability ID; the ADR is validated
       and cross-referenced into the DESIGN artifact automatically
   SCENARIO ChangeImpactAnalysis
     GIVEN: A product requirement (PRD FR) was updated to change behavior
@@ -754,19 +754,19 @@ CAPABILITY SdlcArtifactPipeline
 
 ## Summary Table
 
-| Capability | Primary Actor | Workflow / Command | Key CLI |
+| Capability | Primary Actor | AI Workflow(s) | CLI Commands |
 |---|---|---|---|
-| Session Entry and Routing | Any team member | cf-studio, cf-analyze, cf-generate | `/cf` |
-| Context Discovery | Developer, tech writer, PM | cf-explore | `cfs explore` |
+| Session Entry and Routing | Any team member | cf-studio, cf-analyze, cf-generate | — |
+| Context Discovery | Developer, tech writer, PM | cf-explore | — |
 | Dependency Mapping | Tech lead, architect, PM | cf-map | `cfs map` |
-| Design Exploration | Developer, architect, PM | cf-brainstorm | `/cf brainstorm` |
-| Planning | Tech lead, senior developer | cf-plan | `/cf plan` |
-| Source Code Work | Developer | cf-coding (monolithic) | `/cf code` |
-| Documentation Work | Tech writer, developer, PM | cf-write-docs (monolithic) | `/cf docs` |
-| Skill and Workflow Authoring | Studio author, prompt engineer | cf-write-skills (monolithic) | `/cf skills` |
-| Kit Management | Developer, Studio admin | cf-kit | `cfs kit install / update / normalize` |
-| Multi-Repo Workspace | Tech lead, architect | cf-workspace | `cfs workspace-init / add / sync` |
-| Narrative Explanation | Developer, any team member | cf-explain | `/cf explain` |
-| Project Setup and Brownfield Onboarding | Developer, tech lead | cf-auto-config | `cfs init / update / generate-agents` |
-| Session Overlays | Any user / Studio author | cf-brave-new-world, cf-debug-prompts | (activated at session start) |
-| 14 | SDLC Artifact Pipeline | PM, Tech Lead, Architect, Developer | cf-sdlc-doc-prd, cf-sdlc-doc-adr, cf-sdlc-doc-design, cf-sdlc-decompose, cf-sdlc-doc-feature, cf-sdlc-implement, cf-sdlc-change-impact-analysis, cf-sdlc-pr-review, cf-sdlc-pr-status, cf-sdlc-reverse-engineer, cf-sdlc-migrate-openspec | cfs validate --artifact, cfs spec-coverage |
+| Design Exploration | Developer, architect, PM | cf-brainstorm | — |
+| Planning | Tech lead, senior developer | cf-plan | — |
+| Source Code Work | Developer | cf-coding | — |
+| Documentation Work | Tech writer, developer, PM | cf-write-docs | `cfs validate-toc`, `cfs check-language` |
+| Skill and Workflow Authoring | Studio author, prompt engineer | cf-write-skills | `cfs pdsl` |
+| Kit Management | Developer, Studio admin | cf-kit | `cfs kit install / update / normalize / check-updates` |
+| Multi-Repo Workspace | Tech lead, architect | cf-workspace | `cfs workspace-init / workspace-add / workspace-info / workspace-sync` |
+| Narrative Explanation | Developer, any team member | cf-explain | — |
+| Project Setup and Brownfield Onboarding | Developer, tech lead | cf-auto-config | `cfs init` / `cfs update` / `cfs generate-agents` |
+| Session Overlays | Any user / Studio author | cf-brave-new-world, cf-debug-prompts | — |
+| SDLC Artifact Pipeline | PM, Tech Lead, Architect, Developer | cf-sdlc-doc-prd, cf-sdlc-doc-adr, cf-sdlc-doc-design, cf-sdlc-decompose, cf-sdlc-doc-feature, cf-sdlc-implement, cf-sdlc-change-impact-analysis, cf-sdlc-pr-review, cf-sdlc-pr-status, cf-sdlc-reverse-engineer, cf-sdlc-migrate-openspec | `cfs validate --artifact`, `cfs spec-coverage` |

--- a/docs/research/studio-overview.md
+++ b/docs/research/studio-overview.md
@@ -1,0 +1,608 @@
+# Constructor Studio v1.5.9 — Capability Overview
+
+Constructor Studio is an AI-powered development companion that integrates with your existing codebase and toolchain to accelerate the full software lifecycle — from exploration and planning through code, documentation, and skill authoring. It operates through a single entry point (`/cf`) and routes each request to the right workflow automatically, handling the write-review-fix cycle within each workflow without requiring separate commands.
+
+This document covers all 13 capability domains available in v1.5.9. Each domain is presented as a structured CDSL block for quick scanning, followed by concrete scenarios that illustrate how a team member would actually use it.
+
+---
+
+## How to Read This Document
+
+Each capability is described using CDSL (Capability Description and Scenario Language) notation. A `CAPABILITY` block names the domain, identifies the primary actor, states the PM-level purpose, and lists key operations. Inside each block, `SCENARIO` entries follow a Given/When/Then pattern: the starting context, the action a user takes, and what Studio does in response.
+
+The goal is to answer three questions for each capability: **what it does**, **who uses it**, and **what the experience looks like end to end**.
+
+---
+
+## Capability Domains
+
+### 1. Session Entry and Routing
+
+```cdsl
+CAPABILITY SessionEntryAndRouting
+  ACTOR: Any team member (developer, tech writer, PM)
+  PURPOSE: Provides a single activation point for all Studio capabilities. Free-text
+    intent is matched to the right workflow automatically, so users never need to
+    remember command names.
+  KEY_OPERATIONS: [
+    "Activate Studio via /cf or cf-studio alias",
+    "Route free-text intent to the matching workflow",
+    "Route analysis intent to matching workflow (cf-analyze)",
+    "Route generation intent to matching workflow (cf-generate)",
+    "Set session mode: assistant (guided), normal, or debug",
+    "Offer companion sequences for cross-domain tasks",
+    "Apply Brave New World overlay to auto-answer safe choices"
+  ]
+  NOTE: cf-analyze and cf-generate are lightweight entry-point routers — they match the user's intent to the right concrete workflow but perform no analysis or generation themselves.
+
+  SCENARIO FirstTimeActivation
+    GIVEN: A developer opens a new project and types /cf for the first time
+    WHEN: They describe their intent in plain English ("I want to add a retry
+      mechanism to the HTTP client")
+    THEN: Studio identifies the intent as a coding task, selects cf-coding,
+      confirms the session mode, and begins the workflow
+
+  SCENARIO CrossDomainTask
+    GIVEN: A tech writer needs to both refactor a module and update its
+      documentation in one session
+    WHEN: They describe both goals at the entry prompt
+    THEN: Studio detects that two domains are involved, proposes a sequential
+      companion skill sequence (cf-coding then cf-write-docs), and walks through
+      them in order
+
+  SCENARIO DebugModeSession
+    GIVEN: A Studio author suspects a skill is misbehaving and wants to trace
+      execution step by step
+    WHEN: They activate /cf and choose debug mode at the session prompt
+    THEN: Studio attaches the debug overlay, enabling breakpoints and step-through
+      inspection for the entire session
+```
+
+---
+
+### 2. Context Discovery
+
+```cdsl
+CAPABILITY ContextDiscovery
+  ACTOR: Developer, tech writer, or any contributor starting a complex task
+  PURPOSE: Scans the project read-only to find every file and artifact relevant
+    to the current task, producing a structured resource map before any changes
+    are made.
+  KEY_OPERATIONS: [
+    "Scan project for task-relevant files and artifacts",
+    "Return a resource map with paths, summaries, and suggested slices",
+    "Run standalone or as an automatic pre-dispatch gate",
+    "Partition large codebases across parallel agents",
+    "Save context as result.json + resource-map.md + summary.md (optional, prompted after standalone runs)"
+  ]
+
+  SCENARIO PreFlightBeforeCoding
+    GIVEN: A developer is about to refactor an authentication module
+    WHEN: cf-coding invokes cf-explore automatically before generating any code
+    THEN: Studio returns a resource map (resource-map.md + summary.md) listing
+      the auth module, its tests, related config files, and any documentation
+      that references it, so the coding workflow has full context before writing
+      a single line
+
+  SCENARIO StandaloneExploration
+    GIVEN: A PM wants to understand which files are touched by a specific feature
+      area before scoping a sprint
+    WHEN: They invoke cf-explore directly with a description of the feature
+    THEN: Studio produces summary.md listing relevant paths and a plain-language
+      summary of what it found, without making any changes
+
+  SCENARIO LargeMonorepoScan
+    GIVEN: A workspace contains dozens of packages and thousands of files
+    WHEN: cf-explore is triggered on a cross-cutting concern
+    THEN: Studio partitions the scan across parallel agents, merges results into
+      a single resource map (resource-map.md + summary.md), and flags which
+      packages are most relevant
+```
+
+---
+
+### 3. Dependency Mapping
+
+```cdsl
+CAPABILITY DependencyMapping
+  ACTOR: Tech lead, architect, or PM assessing impact of a refactor
+  PURPOSE: Builds a visual and queryable map of how CPT traceability IDs connect
+    across markdown and source code, making it easy to spot broken or missing
+    links after a refactor.
+  KEY_OPERATIONS: [
+    "Scan markdown and source for CPT traceability IDs",
+    "Generate an interactive HTML dependency graph or JSON export",
+    "Detect dangling and phantom references",
+    "Support single-repo, workspace-wide, or markdown-only scope",
+    "Assist with md-map.toml category rule configuration"
+  ]
+
+  SCENARIO PostRefactorAudit
+    GIVEN: A team has just renamed several modules as part of a restructuring
+    WHEN: A tech lead runs cfs map on the repository
+    THEN: Studio produces an HTML graph and flags every CPT ID that now points
+      to a path that no longer exists (dangling references), plus any IDs
+      referenced in source but absent from documentation (phantom references)
+
+  SCENARIO CrossRepoTraceability
+    GIVEN: A workspace spans three Git repositories that share a common spec
+    WHEN: The architect runs cfs map with-workspace scope
+    THEN: Studio resolves CPT IDs across all three repos and renders a unified
+      graph showing which implementation files satisfy which spec requirements
+
+  SCENARIO CategoryRuleSetup
+    GIVEN: A new team member is configuring the project's md-map.toml for the
+      first time and is unsure which categories to define
+    WHEN: They invoke cf-map and, after generation completes, they select
+      'config-assist' from cf-map's next-steps menu
+    THEN: Studio scans existing markdown, infers likely category groupings, and
+      proposes a starter md-map.toml for the user to review and approve
+```
+
+---
+
+### 4. Design Exploration
+
+```cdsl
+CAPABILITY DesignExploration
+  ACTOR: Developer, architect, or PM evaluating design options before committing
+  PURPOSE: Runs a structured expert panel discussion on any design topic, surfacing
+    diverse perspectives and open questions so the team can make informed decisions
+    before writing code or specs.
+  KEY_OPERATIONS: [
+    "Assemble a panel of 3–6 domain experts for a given topic",
+    "Run topic rounds followed by optional challenge rounds",
+    "Present questions one at a time at the user's pace",
+    "Run in inline, single-agent, or fan-out parallel mode",
+    "Produce a decisions block and open-questions block; hand off to the next workflow"
+  ]
+
+  SCENARIO ApiDesignReview
+    GIVEN: A team is debating two approaches for a public API versioning strategy
+    WHEN: A developer invokes cf-brainstorm with the versioning topic and their
+      two candidate designs
+    THEN: Studio assembles a panel (e.g., API designer, security reviewer, DevEx
+      lead), walks through topic rounds, presents each question in turn, and
+      produces a summary of the panel's consensus and unresolved questions
+
+  SCENARIO ArchitecturePreliminary
+    GIVEN: A PM wants to pressure-test a proposed microservices split before it
+      enters planning
+    WHEN: They start a brainstorm session in fan-out parallel mode
+    THEN: Multiple expert agents respond simultaneously, their outputs are
+      merged, and Studio surfaces the strongest objections and agreements in a
+      single decisions block
+
+  SCENARIO HandoffToPlan
+    GIVEN: A brainstorm session has concluded with a preferred design approach
+    WHEN: The user signals they are ready to move to planning
+    THEN: Studio presents the option to hand off directly to cf-plan, carrying
+      the decisions block and open questions as input context
+```
+
+---
+
+### 5. Planning
+
+```cdsl
+CAPABILITY Planning
+  ACTOR: Tech lead or senior developer breaking a large initiative into
+    executable phases
+  PURPOSE: Decomposes a large task into a sequenced set of self-contained phases,
+    each with its own brief, so that execution can proceed incrementally without
+    losing scope.
+  KEY_OPERATIONS: [
+    "Phase 0: runtime discovery, explore gate, brainstorm gate",
+    "Phase 1: scope assessment and decomposition",
+    "Phase 2: generate a brief per phase",
+    "Phase 3: compile to plan.toml and individual phase files",
+    "Store plan artifacts in .cf-studio/.plans/ (directory name is configurable via cf-studio-path; default shown) for execution handoff"
+  ]
+
+  SCENARIO LargeFeaturePlanning
+    GIVEN: A tech lead needs to ship a new billing integration across three
+      services, estimated at several weeks of work
+    WHEN: They invoke cf-plan and describe the feature goal
+    THEN: Studio runs the explore gate to understand the codebase, decomposes
+      the work into numbered phases, generates a brief for each, and writes
+      plan.toml plus individual phase files to .cf-studio/.plans/
+
+  SCENARIO PlanWithPriorBrainstorm
+    GIVEN: A brainstorm session has already produced a decisions block for the
+      same initiative
+    WHEN: cf-plan detects the prior brainstorm output in the handoff context
+    THEN: Studio skips the brainstorm gate (already satisfied) and proceeds
+      directly to scope assessment, using the decisions block to inform phase
+      boundaries
+
+  SCENARIO IncrementalExecution
+    GIVEN: A plan has been compiled and the team is ready to start execution
+    WHEN: A developer picks up Phase 2 from plan.toml
+    THEN: Studio reads the Phase 2 brief as the input context for cf-coding,
+      providing bounded, well-defined scope without re-running discovery
+```
+
+---
+
+### 6. Source Code Work
+
+```cdsl
+CAPABILITY SourceCodeWork
+  ACTOR: Developer (all seniority levels)
+  PURPOSE: Handles the complete write-review-fix lifecycle for source code in
+    a single workflow — authoring new code, refactoring existing code, reviewing
+    for bugs and consistency, and applying approved fixes.
+  KEY_OPERATIONS: [
+    "Explore gate (automatic context discovery before writing)",
+    "Brainstorm gate (optional design check for complex tasks)",
+    "Author dispatch: codegen / smart / casual by task complexity",
+    "Deterministic CI: tests, lint, typecheck, build",
+    "Semantic review: code-checklist, bug-finding, consistency-checklist",
+    "Findings gated: user approves which findings to fix before fixes are applied",
+    "Git finalization: commit / stage / none, chosen once per session"
+  ]
+
+  SCENARIO NewFeatureFromScratch
+    GIVEN: A developer needs to implement a rate-limiter for an existing HTTP
+      client module
+    WHEN: They invoke cf-coding and describe the feature
+    THEN: Studio runs the explore gate to map relevant files, selects the smart
+      author mode for a medium-complexity task, writes the implementation,
+      runs CI (tests, lint, typecheck, build), performs a full semantic review,
+      presents findings, waits for the user to approve which to fix, applies
+      fixes, and offers to stage or commit the result
+
+  SCENARIO BugFixWithReview
+    GIVEN: A bug report points to a race condition in a concurrency module
+    WHEN: The developer invokes cf-coding in fix mode with the bug description
+    THEN: Studio scans the module and related tests, generates a targeted fix,
+      runs CI to confirm the fix does not break other tests, and presents any
+      secondary findings for the user to approve before applying
+
+  SCENARIO LegacyRefactor
+    GIVEN: A senior developer wants to refactor a 2,000-line legacy class into
+      smaller, testable units
+    WHEN: They invoke cf-coding in refactor mode
+    THEN: Studio runs the explore gate for full context, breaks the refactor
+      into logical sub-steps, applies each in sequence with CI validation
+      after each step, and presents a per-layer review at the end
+```
+
+---
+
+### 7. Documentation Work
+
+```cdsl
+CAPABILITY DocumentationWork
+  ACTOR: Tech writer, developer authoring READMEs or ADRs, or PM authoring specs
+  PURPOSE: Handles the complete write-review-fix lifecycle for all documentation
+    artifacts — guides, READMEs, specs, ADRs, and reports — in a single workflow,
+    with automatic language complexity enforcement on all output.
+  KEY_OPERATIONS: [
+    "Explore gate and brainstorm gate before authoring",
+    "Audience, narrator, and diagram dimension configuration",
+    "Language complexity enforcement on all generated text",
+    "Deterministic CI: artifact structure validation, TOC check, language policy",
+    "Semantic review: consistency-checklist and artifact-checklist",
+    "Findings gated: user approves fixes before applied"
+  ]
+
+  SCENARIO NewApiGuide
+    GIVEN: A developer has shipped a new API and needs an integration guide for
+      external partners
+    WHEN: They invoke cf-write-docs, specify the audience as external developers,
+      and point to the API source files
+    THEN: Studio runs the explore gate to read the API, configures the audience
+      and narrator dimensions, generates the guide, runs CI (structure, TOC,
+      language policy), performs a semantic review, presents findings, and applies
+      approved fixes
+
+  SCENARIO AdrAuthoring
+    GIVEN: An architect needs to document a significant architectural decision
+      with full context and consequences
+    WHEN: They invoke cf-write-docs in ADR mode with a description of the decision
+    THEN: Studio generates a structured ADR following the team's artifact template,
+      validates it against the artifact checklist, and flags any missing sections
+      before presenting the draft for review
+
+  SCENARIO ExistingDocRevision
+    GIVEN: A README has grown stale after a major refactor and contains
+      incorrect CLI examples
+    WHEN: A tech writer invokes cf-write-docs in revise mode on the file
+    THEN: Studio diffs the current doc against the codebase via the explore gate,
+      identifies outdated sections, proposes targeted revisions, and presents
+      them as findings for the user to approve before writing
+```
+
+---
+
+### 8. Skill and Workflow Authoring
+
+```cdsl
+CAPABILITY SkillAndWorkflowAuthoring
+  ACTOR: Studio author (developer or prompt engineer building or maintaining
+    Studio skills, workflows, agent instructions, or system prompts)
+  PURPOSE: Handles the complete write-review-fix lifecycle for Studio's own
+    prompt and workflow artifacts, with PDSL syntax validation integrated at
+    every step to prevent prompt-level bugs from reaching production.
+  KEY_OPERATIONS: [
+    "Write, revise, or review Studio skills, workflows, and agent instructions",
+    "PDSL syntax validation via cfs pdsl validate",
+    "Semantic review: prompt-engineering, prompt-bug-finding, consistency-checklist",
+    "Review depth: single-pass / per-methodology / per-layer (parallel reviewers)",
+    "Findings gated before fixes applied",
+    "PDSL re-validated after every fix"
+  ]
+
+  SCENARIO NewSkillAuthoring
+    GIVEN: A Studio author needs to create a new skill for a domain not yet
+      covered by Studio
+    WHEN: They invoke cf-write-skills with a description of the skill's purpose
+      and target actor
+    THEN: Studio scaffolds the skill using PDSL conventions, validates syntax,
+      runs all three review methodologies, presents findings by layer, and
+      re-validates after each approved fix
+
+  SCENARIO ExistingWorkflowRevision
+    GIVEN: A prompt engineer identifies a reliability issue in an existing
+      workflow's review step
+    WHEN: They invoke cf-write-skills in revise mode pointing to the affected
+      workflow file
+    THEN: Studio reads the current workflow, applies prompt-bug-finding review,
+      surfaces the suspected issue as a finding, and applies the fix only after
+      the author approves — then re-validates PDSL to confirm no syntax
+      regressions
+
+  SCENARIO SkillConsistencyAudit
+    GIVEN: A team has authored several related skills over time and suspects
+      inconsistent terminology
+    WHEN: They invoke cf-write-skills in review-only mode across the skill set
+    THEN: Studio runs the consistency-checklist methodology across all files in
+      parallel per-layer mode and produces a findings report without making
+      any changes until the author approves each one
+```
+
+---
+
+### 9. Kit Management
+
+```cdsl
+CAPABILITY KitManagement
+  ACTOR: Developer or Studio administrator managing reusable behavior packages
+    across projects
+  PURPOSE: Provides a structured lifecycle for kits — reusable packages of rules,
+    templates, scripts, and agents — including discovery, installation, updates,
+    and manifest normalization.
+  KEY_OPERATIONS: [
+    "Initialize: detect project type, propose manifest, user approves, write and validate",
+    "Install from GitHub, generic Git URL, or local path (copy or register mode)",
+    "Interactive update: accept / decline / modify per changed file",
+    "Normalize: generate or update manifest.toml with dry-run preview",
+    "CLI: cfs kit install / update / normalize / check-updates"
+  ]
+
+  SCENARIO InstallingASharedKit
+    GIVEN: A new project needs the team's standard linting and rule kit, which
+      lives in a shared GitHub repository
+    WHEN: A developer runs cfs kit install with the GitHub URL
+    THEN: Studio clones or copies the kit into the project, registers it in the
+      manifest, and validates the installed structure before confirming success
+
+  SCENARIO InteractiveKitUpdate
+    GIVEN: The shared linting kit has released a new version with changes to
+      three rule files, one of which the local project has customized
+    WHEN: The developer runs cfs kit update
+    THEN: Studio presents each changed file one at a time, shows a diff, and
+      asks the developer to accept, decline, or modify the change — preserving
+      their local customization where they decline
+
+  SCENARIO NewKitInitialization
+    GIVEN: A team wants to package their project-specific templates and agents
+      as a reusable kit for other projects in the organization
+    WHEN: They run cfs kit normalize in the target folder
+    THEN: Studio scans the folder, detects whether it is a canonical, legacy, or
+      greenfield layout, proposes a manifest.toml with a dry-run preview, and
+      writes the manifest after user approval
+```
+
+---
+
+### 10. Multi-Repo Workspace
+
+```cdsl
+CAPABILITY MultiRepoWorkspace
+  ACTOR: Tech lead or architect managing a federation of related Git repositories
+  PURPOSE: Federates multiple Git repositories under one Studio workspace so that
+    cross-repo CPT traceability, validation, and dependency mapping work as if
+    the repos were a single project.
+  KEY_OPERATIONS: [
+    "Initialize a workspace federating multiple repos",
+    "Add sources by local path or Git URL",
+    "Inspect workspace health and sync remote repos",
+    "Resolve CPT traceability IDs across repo boundaries",
+    "Run workspace-scoped validation and map generation",
+    "CLI: cfs workspace-init / add / info / sync",
+    "Invoke Studio workflow: cf-workspace (wraps all workspace CLI operations with guided prompts and confirmations)"
+  ]
+
+  SCENARIO WorkspaceInitialization
+    GIVEN: A platform team maintains four microservice repos and a shared spec
+      repo that must all stay in sync
+    WHEN: A tech lead runs cfs workspace-init and adds all five repos
+    THEN: Studio registers each repo in the workspace manifest, verifies
+      connectivity, and makes cross-repo CPT resolution available for subsequent
+      map and validation commands
+
+  SCENARIO CrossRepoImpactAssessment
+    GIVEN: A change to the shared spec repo may affect multiple downstream
+      service repos
+    WHEN: The architect runs cfs map with-workspace scope after the spec change
+    THEN: Studio resolves CPT IDs across all registered repos and surfaces
+      every downstream reference that may be impacted by the spec change
+
+  SCENARIO RemoteRepoSync
+    GIVEN: Two of the workspace repos have received upstream commits overnight
+    WHEN: A developer runs cfs workspace sync at the start of the day
+    THEN: Studio pulls the latest commits for all remote-backed repos in the
+      workspace and reports any repos that could not be synced cleanly
+```
+
+---
+
+### 11. Narrative Explanation
+
+```cdsl
+CAPABILITY NarrativeExplanation
+  ACTOR: Developer onboarding to a new codebase, or any team member who needs
+    to understand a complex artifact or decision
+  PURPOSE: Delivers a source-grounded, portion-by-portion walkthrough of any
+    codebase area, artifact, or architectural decision, paced by the user and
+    exportable as a portable Markdown package.
+  KEY_OPERATIONS: [
+    "E0 preflight: resolve input access tier, check for prior session",
+    "E1 gates: mode, disposition, audience, and plan — set sequentially",
+    "E2 delivery: read context once, deliver portions of up to 200 words each",
+    "7-slot navigator for moving between portions",
+    "E5 wrap: optional export as Markdown package under .cache/explain/packages/ (top-level project cache directory, separate from the Studio config dir)"
+  ]
+
+  SCENARIO OnboardingWalkthrough
+    GIVEN: A new developer joins a team with a large, unfamiliar codebase and
+      needs to understand the authentication flow
+    WHEN: They invoke cf-explain pointing at the auth module
+    THEN: Studio sets up an audience-appropriate plan, walks through the module
+      portion by portion (each under 200 words), and lets the developer navigate
+      forward, back, or jump to a specific section at any time
+
+  SCENARIO AdDecisionExplanation
+    GIVEN: A PM wants to understand why a significant architectural decision was
+      made six months ago, documented in an ADR
+    WHEN: They invoke cf-explain on the ADR file in plain-language mode
+    THEN: Studio reads the ADR and any referenced source files, delivers a
+      narrative explanation in non-technical language portion by portion, and
+      answers follow-up questions grounded in the source
+
+  SCENARIO ExportForSharing
+    GIVEN: A tech lead has walked through a complex subsystem with a contractor
+      who needs to take the explanation offline
+    WHEN: The tech lead triggers the E5 export at the end of the session
+    THEN: Studio packages the full walkthrough as a self-contained Markdown
+      bundle under .cache/explain/packages/, ready to share or commit
+```
+
+---
+
+### 12. Project Setup and Brownfield Onboarding
+
+```cdsl
+CAPABILITY ProjectSetupAndBrownfieldOnboarding
+  ACTOR: Developer or tech lead initializing Studio on an existing or new project
+  PURPOSE: Scans an existing codebase, generates grounded configuration and rule
+    files, and integrates Studio with the team's preferred IDE and toolchain —
+    including migration support for legacy CyPilot projects.
+  KEY_OPERATIONS: [
+    "Precheck: verify Studio is initialized and source code exists",
+    "Scan: cf-explore discovers project structure",
+    "Detect: identify systems and topics, propose rule files",
+    "Generate: per-topic rule files grounded in file:line evidence",
+    "Integrate: write AGENTS.md and artifacts.toml",
+    "Validate: structural and quality checks",
+    "Migrate: legacy CyPilot projects via --migrate-yes flag",
+    "IDE integrations: Claude, Copilot, Cursor, OpenAI, Windsurf",
+    "CLI: cfs init / update / generate-agents"
+  ]
+
+  SCENARIO GreenFieldInit
+    GIVEN: A developer starts a new project and wants Studio configured from day
+      one
+    WHEN: They run cfs init in the project root
+    THEN: Studio scans the (mostly empty) project, generates starter rule files,
+      writes AGENTS.md with IDE integration stubs, and validates the output
+      structure before completing
+
+  SCENARIO BrownfieldOnboarding
+    GIVEN: An existing production service with 50,000 lines of code has never
+      used Studio before
+    WHEN: A tech lead runs cfs init on the repo
+    THEN: Studio runs cf-explore to discover the project structure, identifies
+      distinct system areas (e.g., API layer, data layer, background jobs),
+      generates a grounded rule file for each area with file:line citations,
+      writes AGENTS.md and artifacts.toml, and validates all outputs
+
+  SCENARIO LegacyCyPilotMigration
+    GIVEN: A team previously used CyPilot and has existing configuration files
+      they want to preserve
+    WHEN: They run cfs init --migrate-yes
+    THEN: Studio detects the legacy CyPilot layout, maps legacy configuration
+      to the current Studio format, generates updated rule files, and reports
+      any constructs that could not be migrated automatically
+```
+
+---
+
+### 13. Session Overlays
+
+```cdsl
+CAPABILITY SessionOverlays
+  ACTOR: Any Studio user (Brave New World) or Studio author / debugger
+    (Debug Prompts)
+  PURPOSE: Provides two cross-cutting session-level behaviors: Brave New World
+    accelerates throughput by auto-answering safe, reversible choices; Debug
+    Prompts gives Studio authors a full step-through debugger for tracing skill
+    and workflow execution.
+  KEY_OPERATIONS: [
+    "Brave New World: auto-answer safe reversible choices without pausing",
+    "Brave New World: announce each auto-decision as it is made",
+    "Brave New World: hard-block on destructive, git, security, or credential prompts",
+    "Debug Prompts: step / over / back / continue navigation",
+    "Debug Prompts: breakpoints by file, line, unit, or condition",
+    "Debug Prompts: run mode for uninterrupted execution",
+    "Debug Prompts: trace export to .debug-skill/ (top-level project-root directory for debug trace files)"
+  ]
+
+  SCENARIO BraveNewWorldDuringCoding
+    GIVEN: A developer is running a long cf-coding session and wants to minimize
+      interruptions for routine confirmations
+    WHEN: They activate cf-brave-new-world at the start of the session
+    THEN: Studio auto-answers every safe, reversible prompt (e.g., "should I
+      create this test file?"), announces each decision inline, and pauses only
+      when a prompt involves a destructive action, a git operation, or any
+      security or credential concern
+
+  SCENARIO DebugBreakpoint
+    GIVEN: A Studio author suspects that a specific unit in a skill is producing
+      incorrect output
+    WHEN: They set a breakpoint on that unit using the Debug Prompts overlay and
+      run the skill
+    THEN: Studio executes the skill normally until it reaches the breakpoint,
+      then pauses and presents the current state, allowing the author to inspect
+      inputs and outputs before deciding to step, continue, or back up
+
+  SCENARIO TraceExport
+    GIVEN: A Studio author has debugged a tricky skill issue and wants to share
+      the trace with a colleague for review
+    WHEN: They trigger trace export from the debug overlay
+    THEN: Studio writes the full execution trace to .debug-skill/ as a structured
+      file that the colleague can inspect without needing to reproduce the
+      session
+```
+
+---
+
+## Summary Table
+
+| Capability | Primary Actor | Workflow / Command | Key CLI |
+|---|---|---|---|
+| Session Entry and Routing | Any team member | cf-studio, cf-analyze, cf-generate | `/cf` |
+| Context Discovery | Developer, tech writer, PM | cf-explore | `cfs explore` |
+| Dependency Mapping | Tech lead, architect, PM | cf-map | `cfs map` |
+| Design Exploration | Developer, architect, PM | cf-brainstorm | `/cf brainstorm` |
+| Planning | Tech lead, senior developer | cf-plan | `/cf plan` |
+| Source Code Work | Developer | cf-coding (monolithic) | `/cf code` |
+| Documentation Work | Tech writer, developer, PM | cf-write-docs (monolithic) | `/cf docs` |
+| Skill and Workflow Authoring | Studio author, prompt engineer | cf-write-skills (monolithic) | `/cf skills` |
+| Kit Management | Developer, Studio admin | cf-kit | `cfs kit install / update / normalize` |
+| Multi-Repo Workspace | Tech lead, architect | cf-workspace | `cfs workspace-init / add / sync` |
+| Narrative Explanation | Developer, any team member | cf-explain | `/cf explain` |
+| Project Setup and Brownfield Onboarding | Developer, tech lead | cf-auto-config | `cfs init / update / generate-agents` |
+| Session Overlays | Any user / Studio author | cf-brave-new-world, cf-debug-prompts | (activated at session start) |

--- a/docs/research/studio-overview.md
+++ b/docs/research/studio-overview.md
@@ -97,6 +97,15 @@ CAPABILITY ContextDiscovery
     THEN: Studio partitions the scan across parallel agents, merges results into
       a single resource map (resource-map.md + summary.md), and flags which
       packages are most relevant
+
+  SCENARIO CrossRepoContextGathering
+    GIVEN: A developer needs to understand how a shared library is used across three
+      separate repositories in the workspace before adding a breaking API change
+    WHEN: They invoke cf-explore with the workspace sources included
+    THEN: Studio dispatches partitioned explorers across all workspace sources in parallel,
+      aggregates the resource maps into a single deduplicated context, and surfaces every
+      file, artifact, and @cpt-* marker that references the shared library — giving the
+      developer a federated impact picture before writing a single line
 ```
 
 ---
@@ -137,6 +146,14 @@ CAPABILITY DependencyMapping
       'config-assist' from cf-map's next-steps menu
     THEN: Studio scans existing markdown, infers likely category groupings, and
       proposes a starter md-map.toml for the user to review and approve
+
+  SCENARIO RefactorSafetyCheck
+    GIVEN: A developer is about to rename or split a core module that many artifacts reference
+    WHEN: They invoke cf-map before starting the refactor
+    THEN: Studio builds the full CPT dependency graph, highlights every artifact and code file
+      that references the affected module's IDs, flags any already-dangling references,
+      and exports the map as JSON so the developer can script targeted updates — giving
+      a complete blast-radius picture before a single line of code changes
 ```
 
 ---
@@ -448,6 +465,14 @@ CAPABILITY KitManagement
     THEN: Studio scans the folder, detects whether it is a canonical, legacy, or
       greenfield layout, proposes a manifest.toml with a dry-run preview, and
       writes the manifest after user approval
+
+  SCENARIO KitUpdateWithPerFileDiffReview
+    GIVEN: The SDLC kit has a new upstream version with updated workflow files
+    WHEN: The developer runs cfs kit check-updates then cfs kit update
+    THEN: Studio presents the version diff summary, then walks through each changed file
+      one at a time — showing a diff and asking accept/decline/modify per file; declined
+      files are kept as-is, modified files use the developer's merged version; at the end
+      cfs validate-kits confirms the updated kit structure is valid
 ```
 
 ---
@@ -490,6 +515,15 @@ CAPABILITY MultiRepoWorkspace
     WHEN: A developer runs cfs workspace sync at the start of the day
     THEN: Studio pulls the latest commits for all remote-backed repos in the
       workspace and reports any repos that could not be synced cleanly
+
+  SCENARIO WorkspaceSyncForDistributedTeam
+    GIVEN: A team works across three Git-hosted repositories federated in a workspace,
+      and the shared architecture repo was updated by another team member
+    WHEN: They run cfs workspace-sync (or cfs workspace-sync --source arch-repo)
+    THEN: Studio fetches and updates the Git worktree for the URL-based source,
+      reports sync results per source (updated / already-current / failed), and
+      makes the updated cross-repo CPT IDs immediately available for cfs where-used
+      and cfs validate queries — no manual git pull required
 ```
 
 ---
@@ -581,6 +615,24 @@ CAPABILITY ProjectSetupAndBrownfieldOnboarding
     THEN: Studio detects the legacy CyPilot layout, maps legacy configuration
       to the current Studio format, generates updated rule files, and reports
       any constructs that could not be migrated automatically
+
+  SCENARIO AutoConfigRefreshAfterReorg
+    GIVEN: A team reorganized their codebase into new modules six months after initial Studio onboarding
+    WHEN: They invoke cf-auto-config again on the evolved project
+    THEN: Studio detects existing rule files and offers a refresh menu (refresh all /
+      selective / report-only / cancel); in selective mode, the developer picks which
+      topics to regenerate, Studio re-scans only those areas and proposes updated rule
+      files grounded in the new file:line evidence — without touching topics that did not change
+
+  SCENARIO IdeIntegrationSetupAfterKitInstall
+    GIVEN: A team installed a new behavior kit (e.g. the SDLC kit) and wants their
+      Cursor and Windsurf IDEs to know about the new workflows
+    WHEN: They run cfs generate-agents after the kit install
+    THEN: Studio discovers the kit's public skills and agent proxies, composes an updated
+      SKILL.md from all kit @cpt:skill sections, generates proxy agent files for each
+      configured IDE target (Cursor, Windsurf, Claude, Copilot, OpenAI), updates the
+      managed gitignore block, and reports which files were written or updated — all
+      verified via cfs agents afterward
 ```
 
 ---

--- a/docs/research/user-journeys.md
+++ b/docs/research/user-journeys.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document describes the six primary cross-cutting user journeys in Constructor Studio v1.5.9 using CDSL (Constructor Domain Specification Language) algorithms. Each journey traces the full path a user takes from intent to outcome, showing how Studio's monolithic workflows chain together.
+This document describes the fifteen primary cross-cutting user journeys in Constructor Studio v1.5.9 using CDSL (Constructor Domain Specification Language) algorithms. Each journey traces the full path a user takes from intent to outcome, showing how Studio's monolithic workflows chain together.
 
 **How to read ALGORITHM blocks**
 
@@ -33,6 +33,15 @@ All workflows in v1.5.9 are monolithic. Each workflow owns its full lifecycle �
 | 4 | Review and fix existing code | Developer / Reviewer | Identify, approve, and apply fixes for code issues, then commit | `cf-explore` → `cf-coding` (review-first) | — |
 | 5 | Create and publish a behavior kit | Platform engineer | Package reusable behaviors into a validated, installable kit | `cf-kit` | `cfs kit install` → `cfs generate-agents` |
 | 6 | Generate project documentation | Technical writer / Developer | Produce audience-tuned, reviewed, committed documentation | `cf-explore` → `cf-write-docs` | — |
+| 7 | Author a Product Requirements Document (PRD) | Product Manager | Produce a validated PRD with actors, FR/NFR, use cases, success criteria, and cpt-IDs | `cf-sdlc-doc-prd` → `cf-write-docs` | `cfs validate --artifact` |
+| 8 | Record an Architecture Decision (ADR) | Architect / Tech Lead | Capture a technology or design decision with context, options, consequences, and a cpt-adr-* ID | `cf-sdlc-doc-adr` → `cf-write-docs` | `cfs validate --artifact` |
+| 9 | Author a System DESIGN Document | Architect / Tech Lead | Document system architecture: components, interfaces, boundaries, principles, constraints | `cf-sdlc-doc-design` → `cf-write-docs` | `cfs validate --artifact` |
+| 10 | Decompose DESIGN into Feature List (DECOMPOSITION) | Tech Lead / PM | Break a DESIGN into an ordered, dependency-linked FEATURE list with PRD/DESIGN coverage | `cf-sdlc-decompose` → `cf-write-docs` | `cfs validate --artifact` |
+| 11 | Author a FEATURE Specification | Tech Lead / Developer | Write a precise, implementable FEATURE spec with CDSL flows, algorithms, states, and test scenarios | `cf-sdlc-doc-feature` → `cf-write-docs` | `cfs validate --artifact` |
+| 12 | Implement a FEATURE with Traceability | Developer | Write production code implementing a FEATURE spec with @cpt-* markers linking code to FEATURE IDs | `cf-sdlc-implement` → `cf-coding` | `cfs validate --artifact` |
+| 13 | Analyze Change Impact Across the Artifact Pipeline | Tech Lead / PM / Release Manager | Understand which downstream artifacts and code markers are affected by a change to an upstream artifact | `cf-sdlc-change-impact-analysis` | `cfs where-used` → `cfs spec-coverage` |
+| 14 | Review a GitHub Pull Request | Tech Lead / Reviewer / Team Lead | Get a structured, checklist-based review of a GitHub PR against code and artifact quality standards | `cf-sdlc-pr-review` | — |
+| 15 | Reconstruct SDLC Artifacts from Existing Code | Tech Lead / Architect | Reconstruct missing PRD/DESIGN/DECOMPOSITION/FEATURE artifacts from existing code using @cpt-* markers as evidence | `cf-sdlc-reverse-engineer` → `cf-write-docs` | `cfs validate --artifact` |
 
 ---
 
@@ -570,6 +579,530 @@ ALGORITHM GenerateProjectDocumentation
       verification if significant structural changes are made
   ]
   NEXT: Documentation committed; deployment or publishing pipeline (external to Studio)
+```
+
+---
+
+### Journey 7: Author a Product Requirements Document (PRD)
+
+```cdsl
+ALGORITHM AuthorPRD
+  ACTOR: Product Manager
+  GOAL: Produce a validated PRD with actors, FR/NFR, use cases, success
+        criteria, and cpt-IDs that can gate downstream SDLC artifact authoring
+  INPUTS: [
+    Product concept or problem description,
+    Stakeholder context
+  ]
+  OUTPUTS: [
+    Validated PRD markdown file with cpt-fr-* and cpt-nfr-* IDs,
+    cfs validate --artifact PASS
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-doc-prd and describe the product or feature area.
+    2. Studio binds PRD template + rules + checklist + example from the
+       SDLC kit before any authoring begins.
+    3. DECISION: Explore context first?
+       - YES: Studio discovers existing docs or related artifacts for
+         grounding; exploration summary flows into authoring.
+       - SKIP: proceed directly to authoring with user-supplied context.
+    4. DECISION: Brainstorm requirements framing?
+       - YES: Studio explores actors and requirements framing options;
+         panel produces a structured framing summary.
+       - SKIP: proceed to authoring with stated intent.
+    5. Studio authors PRD sections via cf-write-docs engine:
+         5a. Overview — product context and problem statement.
+         5b. Actors — all user and system roles.
+         5c. Goals — business and user goals.
+         5d. Functional Requirements — each FR assigned a unique
+             cpt-{system}-fr-* ID; written in RFC 2119 MUST/SHALL language.
+         5e. Non-Functional Requirements — each NFR assigned a unique
+             cpt-{system}-nfr-* ID.
+         5f. Use Cases — actor-goal-scenario triples referencing FR IDs.
+         5g. Success Criteria — measurable acceptance conditions per FR.
+    6. Deterministic gate: run `cfs validate --artifact` on the PRD file.
+       Validation fails halt authoring; findings must be resolved.
+    7. Semantic review using PRD checklist; structured findings presented
+       to user with severity and location.
+    8. DECISION: Fix which findings?
+       - Per-finding selection: user approves or skips each finding
+         individually before fixes are applied.
+    9. Re-validate after fixes; iterate until `cfs validate --artifact`
+       returns PASS and user marks the PRD done.
+  DECISION_POINTS:
+    - ExploreContextFirst: yes (discover existing docs) / skip
+    - BrainstormRequirementsFraming: yes / skip
+    - FixWhichFindings: per-finding selection
+  GUARDS: [
+    PRD template and rules must be loaded before authoring begins,
+    cpt-IDs must be unique within the system namespace,
+    All FRs must be written in RFC 2119 MUST/SHALL/SHOULD language,
+    cfs validate --artifact must return PASS before PRD is considered complete
+  ]
+  NEXT: cf-sdlc-doc-design or cf-sdlc-doc-adr
+```
+
+---
+
+### Journey 8: Record an Architecture Decision (ADR)
+
+```cdsl
+ALGORITHM RecordADR
+  ACTOR: Architect or Tech Lead
+  GOAL: Capture a technology or design decision with context, options,
+        consequences, and a cpt-adr-* ID that can be cross-referenced
+        in the system DESIGN document
+  INPUTS: [
+    Decision description,
+    Considered alternatives,
+    DESIGN artifact (optional, for cross-reference)
+  ]
+  OUTPUTS: [
+    ADR markdown file with cpt-adr-* ID,
+    ADR ID registered and cross-referenced in DESIGN
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-doc-adr and describe the decision to capture.
+    2. Studio binds ADR template + rules + checklist + example from the
+       SDLC kit before any authoring begins.
+    3. Studio authors the ADR via cf-write-docs engine:
+         3a. Context and Problem Statement — what situation forces this
+             decision; constraints and forces in play.
+         3b. Decision Drivers — criteria used to evaluate options.
+         3c. Considered Options — at least two alternatives with
+             pros/cons analysis for each.
+         3d. Decision Outcome — chosen option with rationale.
+         3e. Consequences — positive, negative, and neutral effects;
+             risks introduced; follow-on actions.
+         3f. cpt-adr-* ID — assigned and embedded in front-matter.
+    4. Deterministic gate: run `cfs validate --artifact` on the ADR file.
+    5. Semantic review against ADR checklist; findings presented by severity.
+    6. DECISION: Fix which findings?
+       - Per-finding selection: user approves or skips each finding.
+    7. Re-validate after fixes; iterate until PASS.
+  DECISION_POINTS:
+    - FixWhichFindings: per-finding selection
+  GUARDS: [
+    Decision must have at least two considered options before authoring is complete,
+    cpt-adr-* ID must be assigned before the ADR file is written,
+    Consequences section must be non-empty,
+    cfs validate --artifact must return PASS before the ADR is considered complete
+  ]
+  NEXT: Register ADR ID in DESIGN § Architecture Drivers
+```
+
+---
+
+### Journey 9: Author a System DESIGN Document
+
+```cdsl
+ALGORITHM AuthorSystemDesign
+  ACTOR: Architect or Tech Lead
+  GOAL: Document system architecture covering components, interfaces,
+        boundaries, principles, and constraints, with IDs that downstream
+        decomposition and implementation can reference
+  INPUTS: [
+    PRD (for FRs and NFRs to satisfy),
+    ADRs (for architecture drivers),
+    High-level architecture knowledge
+  ]
+  OUTPUTS: [
+    DESIGN markdown with cpt-component-*, cpt-principle-*, and
+    cpt-constraint-* IDs,
+    cfs validate --artifact PASS
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-doc-design.
+    2. Studio binds DESIGN template + rules + checklist + example from
+       the SDLC kit before any authoring begins.
+    3. Studio authors the DESIGN via cf-write-docs engine:
+         3a. Architecture Vision — purpose, scope, and quality attributes.
+         3b. Architecture Drivers — links to ADR IDs and PRD NFR IDs.
+         3c. Principles and Constraints — each assigned a unique
+             cpt-{system}-principle-* or cpt-{system}-constraint-* ID.
+         3d. Component Model — each component assigned a unique
+             cpt-{system}-component-* ID; responsibilities and
+             boundaries described.
+         3e. Interfaces — contracts between components; input/output
+             schemas, protocols, error semantics.
+         3f. DECISION: Include sequence diagrams?
+             - YES: Studio generates Mermaid sequence diagrams for key
+               interaction flows and embeds them inline.
+             - SKIP: diagram placeholders inserted; user authors separately.
+    4. Deterministic gate: run `cfs validate --artifact` on the DESIGN file.
+    5. Semantic review against DESIGN checklist; findings presented.
+    6. DECISION: Fix which findings?
+       - Per-finding selection: user approves or skips each finding.
+    7. Re-validate after fixes; iterate until PASS.
+  DECISION_POINTS:
+    - IncludeSequenceDiagrams: yes (auto-embed Mermaid) / skip (placeholders)
+    - FixWhichFindings: per-finding selection
+  GUARDS: [
+    All cpt-component-* IDs must be unique within the system namespace,
+    DESIGN must reference existing ADR IDs for every major technology choice,
+    PRD FR coverage must be noted in the component model or interface descriptions,
+    cfs validate --artifact must return PASS before DESIGN is considered complete
+  ]
+  NEXT: cf-sdlc-decompose
+```
+
+---
+
+### Journey 10: Decompose DESIGN into Feature List (DECOMPOSITION)
+
+```cdsl
+ALGORITHM DecomposeDesign
+  ACTOR: Tech Lead or PM
+  GOAL: Break a DESIGN into an ordered, dependency-linked FEATURE list
+        with full PRD and DESIGN coverage so that implementation can
+        proceed feature by feature
+  INPUTS: [
+    DESIGN document (for components and interfaces to decompose),
+    PRD (for coverage links back to FRs)
+  ]
+  OUTPUTS: [
+    DECOMPOSITION markdown with cpt-feature-* IDs, ordering,
+    dependency graph, and coverage links,
+    cfs validate --artifact PASS
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-decompose with the DESIGN document as primary input.
+    2. Studio binds DECOMPOSITION template + rules + checklist + example
+       from the SDLC kit before any authoring begins.
+    3. Studio authors the DECOMPOSITION via cf-write-docs engine:
+         3a. Feature entries — for each deliverable unit of work:
+             - Assign a unique cpt-{system}-feature-* ID.
+             - Write a one-paragraph description of scope and boundaries.
+             - Record dependency links to other cpt-feature-* IDs.
+             - Record coverage links to PRD cpt-fr-* IDs and DESIGN
+               cpt-component-* IDs.
+             - Set initial status (planned).
+             - Define a measurable Definition of Done.
+         3b. DECISION: Ordering strategy?
+             - DEPENDENCY: features ordered by dependency graph
+               (no feature before its dependencies).
+             - RISK: high-risk or high-uncertainty features pulled forward.
+             - VALUE: highest business value features prioritized first.
+    4. Deterministic gate: run `cfs validate --artifact` on the
+       DECOMPOSITION file.
+    5. Semantic review for completeness, ordering correctness, and
+       coverage gaps; findings presented.
+    6. DECISION: Fix which findings?
+       - Per-finding selection: user approves or skips each finding.
+    7. Re-validate after fixes; iterate until PASS.
+  DECISION_POINTS:
+    - OrderingStrategy: dependency / risk / value priority
+    - FixWhichFindings: per-finding selection
+  GUARDS: [
+    Every cpt-feature-* entry must reference at least one PRD cpt-fr-* ID,
+    Dependency graph must have no cycles,
+    All features must have a non-empty Definition of Done,
+    cfs validate --artifact must return PASS before DECOMPOSITION is complete
+  ]
+  NEXT: cf-sdlc-doc-feature (per feature entry)
+```
+
+---
+
+### Journey 11: Author a FEATURE Specification
+
+```cdsl
+ALGORITHM AuthorFeatureSpec
+  ACTOR: Tech Lead or Developer
+  GOAL: Write a precise, implementable FEATURE specification with CDSL
+        flows, algorithms, state diagrams, and test scenarios that
+        developers can implement with full traceability
+  INPUTS: [
+    DECOMPOSITION entry (cpt-feature-* ID and description),
+    DESIGN (for interface contracts),
+    PRD (for acceptance criteria)
+  ]
+  OUTPUTS: [
+    FEATURE markdown with cpt-flow-*, cpt-algo-*, and cpt-state-* IDs
+    and test scenarios,
+    cfs validate --artifact PASS
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-doc-feature with the target cpt-feature-* ID.
+    2. Studio binds FEATURE template + rules + checklist + example from
+       the SDLC kit before any authoring begins.
+    3. Studio authors the FEATURE spec via cf-write-docs engine:
+         3a. Overview — feature purpose, scope, and link to DECOMPOSITION
+             entry.
+         3b. CDSL Flows — each flow assigned a unique cpt-{system}-flow-*
+             ID; written as GIVEN/WHEN/THEN scenarios covering the nominal
+             path and primary alternates.
+         3c. Algorithms — each algorithm assigned a unique
+             cpt-{system}-algo-* ID; pseudocode or CDSL ALGORITHM block.
+         3d. DECISION: Include state diagrams?
+             - YES: Studio generates Mermaid state diagrams for stateful
+               entities; each state assigned a cpt-{system}-state-* ID.
+             - SKIP: state diagram section omitted.
+         3e. Test Scenarios — at least one happy-path scenario and one
+             error/edge-case scenario per cpt-flow-* ID.
+         3f. Definition of Done — measurable, checkable criteria derived
+             from PRD acceptance conditions.
+    4. Deterministic gate: run `cfs validate --artifact` on the FEATURE file.
+    5. Semantic review against FEATURE checklist for implementability,
+       test coverage, and completeness; findings presented.
+    6. DECISION: Fix which findings?
+       - Per-finding selection: user approves or skips each finding.
+    7. Re-validate after fixes; iterate until PASS.
+  DECISION_POINTS:
+    - IncludeStateDiagrams: yes (Mermaid state diagrams) / skip
+    - FixWhichFindings: per-finding selection
+  GUARDS: [
+    Every cpt-flow-* ID must be unique within the system namespace,
+    Test scenarios must cover at least one happy-path and one error case
+      per flow,
+    Definition of Done must be measurable and checkable,
+    cfs validate --artifact must return PASS before FEATURE spec is complete
+  ]
+  NEXT: cf-sdlc-implement
+```
+
+---
+
+### Journey 12: Implement a FEATURE with Traceability
+
+```cdsl
+ALGORITHM ImplementFeatureWithTraceability
+  ACTOR: Developer
+  GOAL: Write production code that implements a FEATURE specification,
+        with @cpt-* markers in source linking every code unit back to
+        the FEATURE flow and algorithm IDs it satisfies
+  INPUTS: [
+    FEATURE spec (cpt-feature-* ID and cpt-flow-* IDs),
+    Codebase rules (codebase_rules),
+    Codebase checklist (codebase_checklist)
+  ]
+  OUTPUTS: [
+    Production code with @cpt-{kind}:{id}:p{N} markers,
+    cfs validate --artifact PASS (traceability check),
+    CI green (project tests, lint, typecheck, build)
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-implement with the source FEATURE spec.
+    2. Studio binds CODE artifact kind + codebase_rules +
+       codebase_checklist + source FEATURE before authoring begins.
+    3. cf-coding explore gate: Studio discovers relevant files, modules,
+       and interfaces in the codebase that the FEATURE will touch.
+    4. DECISION: Write tests first?
+       - YES (test-first): developer (or Studio) writes failing tests
+         for each cpt-flow-* scenario before implementation code.
+       - NO: implementation code written first; tests follow.
+    5. Author dispatch — cf-coding writes implementation with
+       @cpt-{kind}:{id}:p{N} markers on every function, class, or
+       block that satisfies a cpt-flow-* or cpt-algo-* ID per
+       codebase_rules.
+    6. Deterministic gate: run project tests + lint + typecheck + build
+       + `cfs validate --artifact` (traceability check). Any failure
+       halts and feeds back into the fix phase.
+    7. Semantic review: code-checklist + bug-finding review +
+       consistency-checklist against the FEATURE contract; findings
+       presented by severity.
+    8. DECISION: Fix which review findings?
+       - Per-finding selection: user approves or skips each finding.
+    9. Re-validate after fixes; iterate until `cfs validate --artifact`
+       returns PASS and CI is green.
+  DECISION_POINTS:
+    - TestFirstPath: yes (test-first) / no (implementation-first)
+    - FixWhichFindings: per-finding selection
+  GUARDS: [
+    @cpt-* markers must be present for all cpt-flow-* IDs declared
+      in the FEATURE spec,
+    cfs validate --artifact must return PASS before implementation is done,
+    CI (tests + lint + typecheck + build) must be green before done,
+    No @cpt-* marker may reference an ID not declared in the source FEATURE
+  ]
+  NEXT: cf-sdlc-pr-review or cf-sdlc-change-impact-analysis
+```
+
+---
+
+### Journey 13: Analyze Change Impact Across the Artifact Pipeline
+
+```cdsl
+ALGORITHM AnalyzeChangeImpact
+  ACTOR: Tech Lead, PM, or Release Manager
+  GOAL: Understand which downstream artifacts and @cpt-* code markers
+        are affected by a change to an upstream artifact, and surface
+        stale or uncovered dependencies before they reach production
+  INPUTS: [
+    Changed artifact ID (e.g. cpt-{system}-fr-login),
+    Baseline ref (prior tag or main branch HEAD),
+    Current ref (HEAD or feature branch)
+  ]
+  OUTPUTS: [
+    Impact report at .change-impact/{ID}/report.md containing:
+    cascade tree of affected artifacts, coverage gaps, stale @cpt-*
+    flags, and optional version bump recommendation
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-change-impact-analysis with the changed artifact ID,
+       baseline ref, and current ref.
+    2. DECISION: Analysis mode?
+       - CASCADE-TRACKING: Studio flags all artifacts and code markers
+         downstream of the changed ID as affected or stale; no scoring.
+       - RELEASE-READINESS-ESTIMATION: Studio additionally scores
+         completeness and produces a version bump recommendation
+         (patch / minor / major) based on the breadth and depth of impact.
+    3. Studio diffs the upstream artifact between baseline ref and current
+       ref; identifies which IDs, sections, or contracts changed.
+    4. Studio runs `cfs where-used` on the changed ID to trace all
+       downstream dependents, bounded by cascade depth rules per artifact
+       type (PRD → DESIGN → DECOMPOSITION → FEATURE → CODE).
+    5. Studio runs `cfs spec-coverage` on the affected downstream artifact
+       set to identify coverage gaps introduced by the upstream change.
+    6. Studio flags stale @cpt-* markers: any code marker referencing an
+       ID whose upstream artifact changed more recently than the code was
+       last updated (within the configured staleness threshold).
+    7. Studio aggregates findings into the impact report and emits a
+       structured summary to the user.
+  DECISION_POINTS:
+    - AnalysisMode: cascade-tracking / release-readiness-estimation
+  GUARDS: [
+    Read-only operation — Studio must never edit artifacts or code files
+      during this workflow,
+    Report must be written only under .change-impact/ and not overwrite
+      any artifact in the main docs tree,
+    cfs where-used and cfs spec-coverage must complete before the report
+      is written
+  ]
+  NEXT: Update affected downstream artifacts, or cf-sdlc-pr-review
+```
+
+---
+
+### Journey 14: Review a GitHub Pull Request
+
+```cdsl
+ALGORITHM ReviewGitHubPullRequest
+  ACTOR: Tech Lead, Reviewer, or Team Lead
+  GOAL: Obtain a structured, checklist-based review of a GitHub PR
+        against code quality, design, ADR, and PRD standards, with
+        severity-rated findings persisted for the team
+  INPUTS: [
+    GitHub PR number or URL (or "ALL" to review all open PRs),
+    Access to the GitHub repository (read-only)
+  ]
+  OUTPUTS: [
+    Structured review report at .prs/{ID}/review.md with findings
+    grouped by domain (code, design, ADR, PRD) and rated by severity
+    (critical / major / minor / info)
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-pr-review with a PR number, URL, or "ALL".
+    2. DECISION: Single PR or all open PRs?
+       - SINGLE: Studio fetches the specified PR diff and metadata.
+       - ALL: Studio fetches all open PRs in the repository and reviews
+         each in sequence, producing a report per PR.
+    3. Studio fetches PR diff and metadata fresh from GitHub; prior run
+       data is never reused.
+    4. Studio analyzes the diff against each configured review domain:
+         4a. Code review — correctness, security, performance, style per
+             codebase_rules and codebase_checklist.
+         4b. Design review — consistency with DESIGN component model,
+             interface contracts, and principles.
+         4c. ADR review — implementation choices consistent with recorded
+             ADR decisions; no silent overrides of decided options.
+         4d. PRD review — changed behavior traceable to PRD FRs; no
+             scope creep or uncovered requirements.
+    5. Studio applies severity classification to each finding:
+       critical (blocks merge) / major (should fix before merge) /
+       minor (can fix post-merge) / info (observation only).
+    6. Studio writes the structured report to .prs/{ID}/review.md.
+  DECISION_POINTS:
+    - ReviewScope: single PR / all open PRs
+  GUARDS: [
+    Read-only operation — Studio must never modify local files during
+      this workflow,
+    PR diff must always be re-fetched from GitHub; cached or prior run
+      data must not be used,
+    Report must be written only under .prs/ and must not modify any
+      artifact in the main docs or source tree
+  ]
+  NEXT: cf-sdlc-pr-status or address findings in a fix branch
+```
+
+---
+
+### Journey 15: Reconstruct SDLC Artifacts from Existing Code
+
+```cdsl
+ALGORITHM ReconstructSDLCArtifacts
+  ACTOR: Tech Lead or Architect (working with legacy or undocumented code)
+  GOAL: Reconstruct missing PRD, DESIGN, DECOMPOSITION, and FEATURE
+        artifacts from existing code, using @cpt-* markers as primary
+        evidence and flagging gaps where evidence is insufficient
+  INPUTS: [
+    Code scope (directory or file list),
+    Existing @cpt-* markers in code (or structural patterns if none exist)
+  ]
+  OUTPUTS: [
+    Reconstructed SDLC artifact files with IDs grounded in actual code
+    behavior,
+    @cpt-gap flags in artifacts where code evidence is missing or
+    ambiguous,
+    cfs validate --artifact PASS on each reconstructed artifact
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-reverse-engineer with the code scope.
+    2. DECISION: Marker strategy?
+       - MARKER-FIRST: Studio extracts existing @cpt-* markers from
+         the code scope as the primary source of artifact structure;
+         marker IDs become the skeleton of reconstructed artifacts.
+       - PATTERN-INFERENCE: Studio infers artifact structure from code
+         patterns (module boundaries, function names, test names) when
+         no @cpt-* markers exist or are insufficient.
+    3. DECISION: Execution mode?
+       - SUBAGENTS: Studio dispatches parallel sub-agents per artifact
+         kind for higher throughput.
+       - PLAN: Studio produces a reconstruction plan for user review
+         before executing.
+       - PLAN-RALPHEX: Studio produces a plan, executes it, then runs
+         a senior-reviewer pass (ralphex) to validate the reconstruction.
+    4. Studio extracts @cpt-* markers from the code scope; builds a
+       marker-to-location index.
+    5. DECISION: Target artifact kinds?
+       - FEATURE ONLY (default): reconstruct FEATURE specs only,
+         grounded directly in code behavior.
+       - FULL PIPELINE: reconstruct PRD, DESIGN, DECOMPOSITION, and
+         FEATURE artifacts in pipeline order, each grounded in the
+         artifact below it and ultimately in code.
+    6. Studio delegates artifact authoring to cf-write-docs under the
+       reverse-engineering methodology for each targeted artifact kind:
+         6a. For each artifact: Studio authors content grounded in code
+             evidence (marker locations, function signatures, test cases,
+             module interfaces).
+         6b. Where code evidence is absent or ambiguous, Studio inserts
+             a @cpt-gap flag with a description of what is missing and
+             why it could not be inferred.
+    7. Deterministic gate: run `cfs validate --artifact` on each
+       reconstructed artifact file.
+    8. Semantic review of reconstructed content for accuracy,
+       completeness, and gap coverage; findings presented.
+    9. DECISION: Fix which findings?
+       - Per-finding selection: user approves or skips each finding.
+   10. Re-validate after fixes; iterate until PASS on all artifacts.
+  DECISION_POINTS:
+    - MarkerStrategy: marker-first / pattern-inference
+    - ExecutionMode: subagents / plan / plan-ralphex
+    - TargetArtifactKinds: FEATURE only (default) / full pipeline
+      (PRD + DESIGN + DECOMPOSITION + FEATURE)
+    - FixWhichFindings: per-finding selection
+  GUARDS: [
+    Every reconstructed requirement or flow must be grounded in actual
+      code behavior observable in the code scope,
+    Discrepancies between inferred spec and actual code must be flagged
+      explicitly as @cpt-gap or a finding — never silently omitted,
+    cfs validate --artifact must return PASS on each artifact before
+      reconstruction is declared complete,
+    Studio must never delete or overwrite existing SDLC artifacts without
+      explicit user confirmation
+  ]
+  NEXT: Register reconstructed artifacts in artifacts.toml; run
+        cfs validate for full pipeline traceability check
 ```
 
 ---

--- a/docs/research/user-journeys.md
+++ b/docs/research/user-journeys.md
@@ -1,0 +1,603 @@
+# Constructor Studio v1.5.9 — User Journeys
+
+## Introduction
+
+This document describes the six primary cross-cutting user journeys in Constructor Studio v1.5.9 using CDSL (Constructor Domain Specification Language) algorithms. Each journey traces the full path a user takes from intent to outcome, showing how Studio's monolithic workflows chain together.
+
+**How to read ALGORITHM blocks**
+
+Each block follows a fixed schema:
+
+- `ACTOR` — the role that initiates the journey
+- `GOAL` — the outcome they are trying to reach
+- `INPUTS` — what must already exist before the journey begins
+- `OUTPUTS` — what is produced when the journey ends
+- `STEPS` — the ordered sequence of actions and workflow invocations
+- `DECISION_POINTS` — named forks where the user or Studio chooses a path
+- `GUARDS` — invariants that must hold throughout; violation halts the journey
+- `NEXT` — optional handoff to a downstream journey or external process
+
+**v1.5.9 architecture note**
+
+All workflows in v1.5.9 are monolithic. Each workflow owns its full lifecycle — intent capture, exploration gate, brainstorm gate, authoring, CI, review, fix, and git finalization — internally. There are no standalone sub-workflows for individual phases (e.g., no `cf-coding-gen`, `cf-coding-ci`, `cf-git-commit`). Git finalization is embedded inside each workflow that produces file artifacts.
+
+---
+
+## Journey Index
+
+| # | Journey | Actor | Goal | AI Workflows (cf-*) | CLI Commands (cfs *) |
+|---|---------|-------|------|---------------------|----------------------|
+| 1 | Plan and implement a new feature | Developer | Ship a working, reviewed, committed feature | `cf-explore` → `cf-brainstorm` → `cf-plan` → `cf-coding` | — |
+| 2 | Onboard a brownfield project to Studio | Tech lead / DevOps | Configure Studio rules and agents for an existing codebase | `cf-auto-config` | `cfs init` → `cfs generate-agents` → `cfs validate-kits` |
+| 3 | Brainstorm and write an architectural decision record | Architect / Tech lead | Produce a persisted, reviewed ADR from a structured brainstorm | `cf-brainstorm` → `cf-write-docs` | — |
+| 4 | Review and fix existing code | Developer / Reviewer | Identify, approve, and apply fixes for code issues, then commit | `cf-explore` → `cf-coding` (review-first) | — |
+| 5 | Create and publish a behavior kit | Platform engineer | Package reusable behaviors into a validated, installable kit | `cf-kit` | `cfs kit install` → `cfs generate-agents` |
+| 6 | Generate project documentation | Technical writer / Developer | Produce audience-tuned, reviewed, committed documentation | `cf-explore` → `cf-write-docs` | — |
+
+---
+
+## Journeys
+
+### Journey 1: Plan and Implement a New Feature
+
+```cdsl
+ALGORITHM PlanAndImplementFeature
+  ACTOR: Developer
+  GOAL: Deliver a working, reviewed, and committed feature implementation
+        with optional upfront exploration and design brainstorm
+  INPUTS: [
+    Studio activated in project directory,
+    Feature intent described (natural language or issue reference),
+    Codebase accessible to Studio agents
+  ]
+  OUTPUTS: [
+    Committed feature code on the target branch,
+    Review findings report (embedded in cf-coding run),
+    CI pass confirmation
+  ]
+  STEPS:
+    1. Activate Studio in the project root (Studio reads .bootstrap config,
+       loads rule files, resolves agent kit).
+    2. DECISION: Explore first?
+       - YES (target area unclear): invoke cf-explore to map relevant
+         modules, surfaces, and dependencies; receive exploration summary.
+       - NO (target known): skip to step 3.
+    3. DECISION: Brainstorm first?
+       - YES (design is ambiguous or multiple approaches exist): invoke
+         cf-brainstorm; panel of agents proposes and challenges approaches;
+         wrap produces a design summary persisted to disk or session-only.
+       - NO: skip to step 4.
+    4. DECISION: Plan first?
+       - YES (feature spans multiple files, layers, or sub-tasks): invoke
+         cf-plan; plan decomposes intent into ordered implementation tasks
+         with acceptance criteria; user reviews and confirms plan.
+       - NO (single-scope change): skip to step 5.
+    5. Invoke cf-coding with confirmed intent (and plan artifact if produced).
+       cf-coding begins its internal lifecycle:
+         5a. Intent capture — cf-coding reads user intent, prior exploration
+             summary, and plan artifact (if any).
+         5b. DECISION: Sub-agent dispatch mode?
+             - NATIVE: Studio dispatches sub-agents using native agent
+               protocol; parallel execution where tasks are independent.
+             - INLINE: Sub-agent logic runs in the primary agent thread
+               sequentially.
+         5c. DECISION: Coding classification?
+             - WRITE-FIRST: generate implementation, then run CI, then review.
+             - REVIEW-FIRST: review existing code first, collect findings,
+               then generate targeted fix implementation (see Journey 4
+               for full review-first detail).
+         5d. Author phase — agent writes or modifies files per the plan.
+         5e. CI phase — Studio runs configured linters, type-checkers, and
+             test suites internally; failures fed back into fix phase.
+         5f. Review phase — agent inspects authored output.
+             DECISION: Review granularity?
+             - SINGLE-PASS: one unified review over all changes.
+             - PER-METHODOLOGY: separate review pass per configured
+               methodology (e.g., correctness, security, style).
+             - PER-LAYER: separate review pass per architectural layer
+               (e.g., API, business logic, persistence).
+         5g. Findings browser — user sees structured findings list.
+             DECISION: Fix scope?
+             - ALL FINDINGS: apply all fixes automatically.
+             - SUBSET: user approves per-finding; selected findings applied.
+             - NONE: accept code as-is, close findings.
+         5h. Fix phase — agent applies approved fixes; re-runs CI if fixes
+             touch tested surfaces.
+         5i. Git finalization — embedded inside cf-coding.
+             DECISION: Git action?
+             - COMMIT: stage all changes and create a commit with
+               generated message.
+             - STAGE ONLY: stage changes, leave commit to user.
+             - NONE: leave working tree as-is.
+  DECISION_POINTS:
+    - ExploreFirst: skip (target known) / run cf-explore (target unclear)
+    - BrainstormFirst: skip (clear design) / run cf-brainstorm (ambiguous)
+    - PlanFirst: skip (single-scope) / run cf-plan (multi-step)
+    - SubAgentDispatch: native (parallel) / inline (sequential)
+    - CodingClassification: write-first / review-first
+    - ReviewGranularity: single-pass / per-methodology / per-layer
+    - FixScope: all findings / subset (per-finding approval) / none
+    - GitAction: commit / stage-only / none
+  GUARDS: [
+    Studio must be activated before any workflow is invoked,
+    cf-plan output must be confirmed by user before cf-coding starts,
+    CI must pass (or all failures acknowledged) before git finalization,
+    Fix phase must not introduce new CI failures without user acknowledgment
+  ]
+  NEXT: Feature branch ready for pull request or merge (external to Studio)
+```
+
+---
+
+### Journey 2: Onboard a Brownfield Project to Studio
+
+```cdsl
+ALGORITHM OnboardBrownfieldProject
+  ACTOR: Tech lead or DevOps engineer
+  GOAL: Bring an existing codebase under Studio governance by generating
+        accurate rule files, agent kits, and validated configurations
+  INPUTS: [
+    Existing source repository accessible on disk,
+    User has write access to repository root,
+    Optional: existing CyPilot project configuration
+  ]
+  OUTPUTS: [
+    .bootstrap directory populated with Studio config and rule files,
+    Generated agent kit(s) appropriate to detected stack,
+    Validation report confirming kits are consistent with codebase
+  ]
+  STEPS:
+    1. Run `cfs init` in the repository root.
+       Studio creates the .bootstrap scaffold and reads any existing
+       configuration fragments.
+    2. DECISION: Existing CyPilot project detected?
+       - YES: Studio offers migration path; user accepts to import
+         CyPilot rules as Studio rule files, or declines to start fresh.
+       - NO: proceed to step 3.
+    3. Invoke cf-auto-config. cf-auto-config runs its internal phases:
+         3a. Precheck — validate that prerequisites are met (repo root
+             found, .bootstrap scaffold present, required tools available).
+         3b. Scan — agent traverses the repository; collects language,
+             framework, toolchain, and structural signals.
+         3c. Detect — agent classifies detected stack; identifies applicable
+             rule topic areas (coding standards, testing conventions,
+             documentation conventions, security posture).
+         3d. Generate — agent produces proposed rule files per topic area.
+             DECISION: Rules exist already?
+             - REFRESH: overwrite all existing rule files with new
+               generated versions.
+             - SELECTIVE: user chooses which topic areas to regenerate;
+               others left intact.
+             - REPORT-ONLY: generate a diff report of proposed changes
+               without writing files.
+             - CANCEL: abort; leave existing rules unchanged.
+         3e. Integrate — agent writes accepted rule files into .bootstrap;
+             updates Studio manifest to reference new files.
+             DECISION: Accept proposed rule files or edit per-topic?
+             - ACCEPT ALL: all proposed files written as generated.
+             - EDIT PER-TOPIC: user reviews and edits each topic area
+               interactively before it is written.
+         3f. Validate — agent re-reads written rule files and checks
+             internal consistency; reports any contradictions or gaps.
+    4. DECISION: Which IDE integrations to enable?
+       - User selects from detected available integrations (e.g., VS Code,
+         JetBrains, Cursor); Studio writes corresponding integration
+         config files.
+       - User may skip all IDE integrations.
+    5. Run `cfs generate-agents` to instantiate agent kit(s) based on
+       the finalized rule files and detected stack profile.
+    6. Run `cfs validate-kits` to confirm that all generated agent kits
+       are internally consistent and reference only resolvable rule files
+       and workflow definitions.
+    7. User reviews validation report; any kit errors must be resolved
+       (edit rules or re-run cf-auto-config selective) before the
+       project is considered onboarded.
+  DECISION_POINTS:
+    - CyPilotMigration: accept migration offer / start fresh
+    - RulesExistPolicy: refresh / selective / report-only / cancel
+    - RuleFileAcceptance: accept all / edit per-topic
+    - IDEIntegrations: one or more integrations / skip all
+  GUARDS: [
+    `cfs init` must complete before cf-auto-config is invoked,
+    Precheck phase must pass before scan begins,
+    Rule files may not be written until user has accepted or edited proposals,
+    `cfs validate-kits` must report no errors before onboarding is declared complete
+  ]
+  NEXT: Project ready for day-to-day Studio workflows (Journeys 1, 3, 4, 5, 6)
+```
+
+---
+
+### Journey 3: Brainstorm and Write an Architectural Decision Record
+
+```cdsl
+ALGORITHM BrainstormAndWriteADR
+  ACTOR: Architect or Tech lead
+  GOAL: Produce a structured, persisted, and reviewed Architectural
+        Decision Record (ADR) grounded in a facilitated multi-agent
+        brainstorm
+  INPUTS: [
+    Studio activated in project directory,
+    ADR topic or decision question stated by the user,
+    Optional: existing ADRs or context documents for reference
+  ]
+  OUTPUTS: [
+    Persisted brainstorm session summary (disk artifact),
+    Reviewed and committed ADR document in the project docs tree,
+    Review findings report (embedded in cf-write-docs run)
+  ]
+  STEPS:
+    1. Invoke cf-brainstorm with the ADR topic as the driving question.
+       cf-brainstorm runs its internal lifecycle:
+         1a. Panel proposal — Studio proposes a panel of agent personas
+             (e.g., pragmatist, security advocate, scalability thinker,
+             domain expert).
+             DECISION: Panel size and composition?
+             - ACCEPT PROPOSED: use Studio's suggested panel as-is.
+             - EDIT: user adjusts panel size or replaces personas before
+               brainstorm begins.
+         1b. DECISION: Brainstorm execution mode?
+             - INLINE: all panel agent reasoning runs in the primary
+               thread sequentially; simpler, lower parallelism.
+             - SINGLE-AGENT: one synthesizing agent plays all panel roles
+               in sequence, producing a unified output.
+             - FAN-OUT: each panel persona runs as a parallel sub-agent;
+               outputs collected and merged by a synthesis agent.
+         1c. Topic rounds — each panel persona presents its analysis of
+             the decision question: options, trade-offs, risks, and
+             recommendations.
+         1d. DECISION: Challenge round?
+             - YES: each persona critiques the strongest proposal from
+               another persona; sharpens the recommendation.
+             - NO: skip challenge round; move directly to wrap.
+         1e. Wrap — synthesis agent aggregates panel outputs into a
+             structured session summary (decision options, trade-offs
+             matrix, recommended option with rationale).
+             DECISION: Session persistence?
+             - PERSIST TO DISK: session summary written to a brainstorm
+               artifact file in the project docs tree.
+             - SESSION-ONLY: summary held in context only; not written
+               to disk.
+    2. User reviews brainstorm summary and confirms the recommended option
+       (or selects an alternative) as the basis for the ADR.
+    3. Invoke cf-write-docs with the brainstorm summary as the primary
+       input and "ADR" as the document type.
+       cf-write-docs runs its internal lifecycle:
+         3a. Intent capture — cf-write-docs reads document type, topic,
+             brainstorm summary, and any reference ADRs.
+         3b. DECISION: Audience dimension?
+             - DEVELOPER: technical depth, implementation consequences
+               emphasized.
+             - PM: business impact, risk, timeline consequences emphasized.
+             - NEWCOMER: background context, glossary, rationale emphasized.
+             - MIXED: balanced treatment; sidebar callouts for specialist
+               content.
+         3c. Author phase — agent writes the ADR using the Studio ADR
+             template (context, decision, status, consequences).
+         3d. CI phase — Studio runs documentation validators (link check,
+             template conformance, front-matter schema) internally.
+         3e. Review phase — agent reviews the authored ADR for clarity,
+             completeness, and alignment with the brainstorm recommendation.
+         3f. Findings browser — user sees structured findings list.
+             DECISION: Fix scope — approve findings before applying?
+             - APPROVE ALL: all findings applied without per-finding review.
+             - PER-FINDING APPROVAL: user approves or rejects each finding
+               individually before the fix is applied.
+             - NONE: accept ADR as-is.
+         3g. Fix phase — agent applies approved findings; re-runs CI.
+         3h. Git finalization — embedded inside cf-write-docs.
+             DECISION: Git action?
+             - COMMIT: stage ADR and brainstorm artifact; create commit.
+             - STAGE ONLY: stage files, leave commit to user.
+             - NONE: leave working tree unchanged.
+  DECISION_POINTS:
+    - PanelComposition: accept proposed / edit personas and size
+    - BrainstormMode: inline / single-agent / fan-out
+    - ChallengeRound: yes / no
+    - SessionPersistence: persist to disk / session-only
+    - AudienceDimension: developer / PM / newcomer / mixed
+    - FixScopeApproval: approve all / per-finding approval / none
+    - GitAction: commit / stage-only / none
+  GUARDS: [
+    Brainstorm wrap must produce a session summary before cf-write-docs starts,
+    User must confirm the recommended decision option before authoring begins,
+    ADR template conformance CI check must pass before git finalization,
+    Persisted brainstorm artifact path must not conflict with existing files
+  ]
+  NEXT: ADR committed; team review via pull request (external to Studio)
+```
+
+---
+
+### Journey 4: Review and Fix Existing Code
+
+```cdsl
+ALGORITHM ReviewAndFixExistingCode
+  ACTOR: Developer or Reviewer
+  GOAL: Systematically identify issues in existing code, obtain per-finding
+        approval, apply fixes, confirm CI passes, and commit the result
+  INPUTS: [
+    Studio activated in project directory,
+    Target code scope identified (file, module, or directory),
+    Optional: specific review criteria or methodology names
+  ]
+  OUTPUTS: [
+    Structured findings report with per-finding status (applied / skipped),
+    Fixed codebase with CI-passing state,
+    Committed changes on the target branch
+  ]
+  STEPS:
+    1. Invoke cf-explore scoped to the target code area.
+       cf-explore maps the module structure, dependency graph, and surfaces
+       relevant architectural context needed to make review findings
+       actionable.
+    2. Invoke cf-coding in review-first classification mode, passing the
+       exploration summary and target scope.
+       cf-coding (review-first) runs its internal lifecycle:
+         2a. Intent capture — cf-coding reads target scope, exploration
+             summary, and any user-specified review criteria.
+         2b. DECISION: Review granularity?
+             - SINGLE-PASS: one unified review agent inspects all changes
+               or all files in scope in a single pass; produces a flat
+               findings list.
+             - PER-METHODOLOGY: a separate review pass is executed for
+               each configured methodology (e.g., correctness, security,
+               performance, style); findings tagged by methodology.
+             - PER-LAYER: a separate review pass is executed for each
+               architectural layer present in scope (e.g., API surface,
+               business logic, data access); findings tagged by layer.
+         2c. Findings browser — user sees the complete structured findings
+             list with severity, location, methodology/layer tag (if
+             applicable), and suggested fix description.
+             DECISION: Which findings to fix?
+             - ALL: all findings marked for fix application.
+             - SUBSET (per-finding approval): user reviews each finding
+               individually and marks it approved or skipped.
+             - NONE: no fixes applied; findings report saved only.
+         2d. Fix phase — agent generates and applies fixes for all
+             approved findings. Each fix is scoped to the specific
+             location identified in the finding; agent avoids touching
+             unapproved areas.
+         2e. CI phase — Studio runs configured linters, type-checkers,
+             and test suites.
+             DECISION: Re-run CI after fix?
+             - YES (default): CI runs after fix phase completes; any
+               new failures are surfaced and must be acknowledged.
+             - NO: skip post-fix CI (user accepts responsibility for
+               CI state).
+         2f. If post-fix CI introduces new failures, a secondary fix
+             loop is offered. User may approve additional targeted fixes
+             or accept the CI failures.
+         2g. Git finalization — embedded inside cf-coding.
+             DECISION: Git action?
+             - COMMIT: stage all approved-fix changes; create commit with
+               message referencing the findings count and scope.
+             - STAGE ONLY: stage changes, leave commit to user.
+             - NONE: leave working tree as-is.
+  DECISION_POINTS:
+    - ReviewGranularity: single-pass / per-methodology / per-layer
+    - FindingsFixScope: all / subset (per-finding approval) / none
+    - RerunCIAfterFix: yes / no
+    - GitAction: commit / stage-only / none
+  GUARDS: [
+    cf-explore must complete before cf-coding review-first begins,
+    Fix phase must only touch locations referenced by approved findings,
+    Per-finding approval must be recorded before any fix is applied in subset mode,
+    Secondary fix loop must not auto-approve new findings without user review
+  ]
+  NEXT: Fixed branch ready for pull request or merge (external to Studio)
+```
+
+---
+
+### Journey 5: Create and Publish a Behavior Kit
+
+```cdsl
+ALGORITHM CreateAndPublishBehaviorKit
+  ACTOR: Platform engineer
+  GOAL: Package reusable Studio behaviors into a validated, installable
+        behavior kit that downstream projects can adopt
+  INPUTS: [
+    Studio activated in the kit source directory,
+    Behavior definitions, rule files, and workflow fragments to be packaged,
+    Optional: existing kit manifest for update scenario
+  ]
+  OUTPUTS: [
+    Validated kit artifact with manifest, rule files, and workflow definitions,
+    Kit registered or installed in one or more consumer projects,
+    Consumer project agent kits regenerated to incorporate new behaviors
+  ]
+  STEPS:
+    1. Invoke cf-kit in the kit source directory.
+       cf-kit runs its internal lifecycle:
+         1a. Detect state — cf-kit inspects the directory for an existing
+             kit manifest. Reports: new kit, update to existing kit, or
+             no kit context found.
+             DECISION: Kit target path?
+             - CURRENT DIRECTORY: kit is built from and into the current
+               directory.
+             - CUSTOM PATH: user specifies an alternative directory; cf-kit
+               operates there.
+         1b. Discovery — cf-kit scans the target directory; identifies all
+             candidate behaviors, rule files, workflow definitions, and
+             skill fragments eligible for inclusion in the kit manifest.
+         1c. Manifest proposal — cf-kit generates a proposed kit manifest
+             listing all discovered components with metadata (name, version,
+             dependencies, exposed entry points).
+             DECISION: Manifest approval?
+             - APPROVE DEFAULT: accept the proposed manifest as-is.
+             - SHOW PREVIEW: display a rendered preview of the manifest
+               before approving.
+             - EDIT: user edits the manifest interactively (add, remove,
+               or annotate components) before approving.
+             - RERUN DISCOVERY: discard proposed manifest; re-run discovery
+               (useful after the user adds or removes files).
+             - CANCEL: abort cf-kit; no manifest written.
+         1d. Write phase — cf-kit writes the approved manifest and any
+             required packaging metadata to the kit target directory.
+         1e. Validate — cf-kit runs internal validation: checks manifest
+             schema, resolves all declared component references, and
+             confirms no dangling dependencies. Reports validation result.
+    2. Kit artifact is ready. User chooses the publication path.
+    3. In the consumer project, run `cfs kit install`.
+       DECISION: Install mode?
+       - COPY: kit files are copied into the consumer project's .bootstrap
+         directory; consumer owns a local copy.
+       - REGISTER: kit is registered by reference (path or URL); consumer
+         project resolves kit at runtime without copying files.
+       - GITHUB: kit is installed from a GitHub repository reference;
+         Studio fetches and caches the kit.
+    4. During install, Studio checks for conflicts with existing consumer
+       project files.
+       DECISION: Interactive update decisions per changed file?
+       - For each file that would be overwritten: user chooses overwrite /
+         keep existing / diff and decide.
+    5. Run `cfs generate-agents` in the consumer project to regenerate
+       agent kits incorporating the newly installed behavior kit's
+       behaviors, rule files, and workflow definitions.
+    6. Consumer project agents are now aware of the kit's behaviors and
+       can invoke them within Studio workflows.
+  DECISION_POINTS:
+    - KitTargetPath: current directory / custom path
+    - ManifestApproval: approve default / show preview / edit / rerun discovery / cancel
+    - InstallMode: copy / register / GitHub
+    - PerFileUpdateDecision: overwrite / keep existing / diff and decide
+  GUARDS: [
+    Discovery must complete before manifest proposal is generated,
+    Manifest must be approved (not cancelled) before write phase begins,
+    Kit validation must pass before the artifact is considered publishable,
+    `cfs generate-agents` must run after install to ensure agent coherence,
+    Consumer project must have Studio initialized before kit install
+  ]
+  NEXT: Consumer project teams begin using kit behaviors in their Studio workflows
+```
+
+---
+
+### Journey 6: Generate Project Documentation
+
+```cdsl
+ALGORITHM GenerateProjectDocumentation
+  ACTOR: Technical writer or Developer
+  GOAL: Produce audience-tuned, reviewed, and committed project documentation
+        grounded in an exploration of the actual codebase
+  INPUTS: [
+    Studio activated in project directory,
+    Documentation scope defined (module, API, architecture, onboarding, etc.),
+    Optional: existing documentation files for incremental update
+  ]
+  OUTPUTS: [
+    New or updated documentation files committed to the project docs tree,
+    TOC validation report,
+    Language complexity check report,
+    Review findings report (embedded in cf-write-docs run)
+  ]
+  STEPS:
+    1. Invoke cf-explore scoped to the target documentation area.
+       cf-explore maps modules, public APIs, architectural layers, and
+       existing documentation coverage. Exploration summary becomes the
+       factual basis for the authored documentation.
+    2. Invoke cf-write-docs with the exploration summary and documentation
+       scope as inputs.
+       cf-write-docs runs its internal lifecycle:
+         2a. Intent capture — cf-write-docs reads scope, exploration
+             summary, document type, and any existing docs for incremental
+             update.
+         2b. DECISION: Audience dimension?
+             - DEVELOPER: technical depth; code examples, API signatures,
+               and implementation details emphasized.
+             - PM: business context, feature descriptions, and impact
+               emphasized; implementation detail minimized.
+             - NEWCOMER: progressive disclosure; prerequisite concepts
+               explained, glossary included, setup steps explicit.
+             - MIXED: balanced treatment; specialist sections clearly
+               labeled; navigation aids provided.
+         2c. DECISION: Narrator dimension?
+             - FIRST-PERSON: documentation written as "we" or "I" (team
+               or author voice).
+             - THIRD-PERSON: documentation written in third person
+               (system or component as subject).
+             - NEUTRAL: passive or impersonal constructions; no personal
+               pronouns.
+         2d. DECISION: Diagram dimension?
+             - AUTO-EMBED: Studio generates and embeds diagrams (e.g.,
+               Mermaid) inline in the documentation automatically where
+               structural content is detected.
+             - SUGGEST: Studio identifies locations where diagrams would
+               help and inserts placeholder comments; user creates diagrams.
+             - SKIP: no diagrams generated or suggested.
+         2e. Author phase — agent writes documentation files per the
+             audience, narrator, and diagram settings. References
+             exploration summary for accuracy.
+         2f. Validate TOC — Studio checks that all section headings are
+             consistent with the declared table of contents; reports
+             missing or orphaned sections.
+         2g. Check language complexity — Studio runs a language complexity
+             analysis calibrated to the chosen audience dimension; flags
+             sentences or passages that exceed the target reading level.
+         2h. CI phase — Studio runs documentation validators (link check,
+             template conformance, front-matter schema) internally.
+         2i. Review phase — agent reviews authored documentation for
+             accuracy (against exploration summary), completeness,
+             and audience alignment.
+         2j. Findings browser — user sees structured findings list
+             covering accuracy issues, complexity violations, broken links,
+             and structural gaps.
+             DECISION: Fix scope approval?
+             - APPROVE ALL: all findings applied automatically.
+             - PER-FINDING APPROVAL: user reviews and approves or skips
+               each finding before it is applied.
+             - NONE: accept documentation as-is; findings recorded only.
+         2k. Fix phase — agent applies approved findings; re-runs TOC
+             validation and language complexity check.
+         2l. Git finalization — embedded inside cf-write-docs.
+             DECISION: Git action?
+             - COMMIT: stage all documentation files; create commit with
+               message referencing scope and audience.
+             - STAGE ONLY: stage files, leave commit to user.
+             - NONE: leave working tree unchanged.
+  DECISION_POINTS:
+    - AudienceDimension: developer / PM / newcomer / mixed
+    - NarratorDimension: first-person / third-person / neutral
+    - DiagramDimension: auto-embed / suggest / skip
+    - FixScopeApproval: approve all / per-finding approval / none
+    - GitAction: commit / stage-only / none
+  GUARDS: [
+    cf-explore must complete before cf-write-docs begins authoring,
+    Audience, narrator, and diagram dimensions must be set before author phase,
+    TOC validation must pass before git finalization,
+    Fix phase must not alter factual content without re-running exploration
+      verification if significant structural changes are made
+  ]
+  NEXT: Documentation committed; deployment or publishing pipeline (external to Studio)
+```
+
+---
+
+## Cross-Journey Patterns
+
+The six journeys above share a set of recurring structural patterns. Understanding these patterns helps product managers reason about how Studio workflows compose.
+
+### Explore Gate
+
+Journeys 1, 4, and 6 all begin with an optional or mandatory invocation of `cf-explore`. The explore gate exists because authoring agents (cf-coding, cf-write-docs) need grounded factual context about the codebase to produce accurate output. When the target is already known and narrow, explore can be skipped (Journey 1 decision point). When the target is a review or documentation exercise over unfamiliar territory, explore is always warranted. The exploration summary artifact flows forward as an input to the subsequent workflow.
+
+### Brainstorm Gate
+
+Journeys 1 and 3 offer a brainstorm gate before authoring begins. The brainstorm gate is triggered when design intent is ambiguous or when multiple implementation or architectural options need structured comparison. cf-brainstorm's panel-and-challenge model produces a session summary that serves as a structured design input to cf-coding or cf-write-docs. The gate is optional in Journey 1 and mandatory in Journey 3 (since the brainstorm output is the ADR's primary source material).
+
+### Plan-First Pattern
+
+Journey 1 introduces the plan-first pattern: when a feature spans multiple files, layers, or sub-tasks, cf-plan decomposes the intent into ordered tasks with acceptance criteria before cf-coding is invoked. This prevents cf-coding from making ad-hoc scope decisions during implementation. The plan artifact is explicitly confirmed by the user, making scope boundaries an explicit agreement rather than an implicit inference.
+
+### Sub-Agent Dispatch Modes
+
+Journeys 1 and 3 expose the sub-agent dispatch decision (native parallel vs. inline sequential vs. single-agent). In v1.5.9, this dispatch mode is selected at the start of the workflow that uses sub-agents (cf-coding for implementation tasks, cf-brainstorm for panel personas). The dispatch mode affects latency and observability but not the logical content of the output. Users who need full visibility into intermediate outputs should prefer inline or single-agent mode.
+
+### Review-Fix Loop
+
+Every workflow that produces file artifacts (cf-coding, cf-write-docs) embeds an internal review-fix loop. The loop always produces a findings list before any fix is applied. The fix scope decision — approve all, per-finding approval, or none — is a consistent gate that prevents unreviewed changes from being written. After fixes are applied, CI (or documentation validators) re-run to confirm the fixed state is clean. If new failures arise, a secondary fix opportunity is offered before git finalization.
+
+### Git Finalization
+
+In v1.5.9, git finalization is embedded inside each workflow that produces committed artifacts (cf-coding, cf-write-docs, cf-kit). There is no standalone `cf-git-commit` workflow. The git action decision (commit / stage-only / none) is the last decision in every such workflow. This means that users who want to batch changes across multiple workflow runs should choose stage-only on all but the final run, then commit manually or invoke a new workflow run scoped to the final commit.

--- a/docs/research/user-journeys.md
+++ b/docs/research/user-journeys.md
@@ -56,7 +56,7 @@ ALGORITHM PlanAndImplementFeature
     CI pass confirmation
   ]
   STEPS:
-    1. Activate Studio in the project root (Studio reads .bootstrap config,
+    1. Activate Studio in the project root (Studio reads Studio config,
        loads rule files, resolves agent kit).
     2. DECISION: Explore first?
        - YES (target area unclear): invoke cf-explore to map relevant
@@ -142,13 +142,13 @@ ALGORITHM OnboardBrownfieldProject
     Optional: existing CyPilot project configuration
   ]
   OUTPUTS: [
-    .bootstrap directory populated with Studio config and rule files,
+    .cf-studio/ directory (configurable via cf-studio-path) populated with Studio config and rule files,
     Generated agent kit(s) appropriate to detected stack,
     Validation report confirming kits are consistent with codebase
   ]
   STEPS:
     1. Run `cfs init` in the repository root.
-       Studio creates the .bootstrap scaffold and reads any existing
+       Studio creates the .cf-studio/ scaffold and reads any existing
        configuration fragments.
     2. DECISION: Existing CyPilot project detected?
        - YES: Studio offers migration path; user accepts to import
@@ -156,7 +156,7 @@ ALGORITHM OnboardBrownfieldProject
        - NO: proceed to step 3.
     3. Invoke cf-auto-config. cf-auto-config runs its internal phases:
          3a. Precheck — validate that prerequisites are met (repo root
-             found, .bootstrap scaffold present, required tools available).
+             found, .cf-studio/ scaffold present, required tools available).
          3b. Scan — agent traverses the repository; collects language,
              framework, toolchain, and structural signals.
          3c. Detect — agent classifies detected stack; identifies applicable
@@ -171,7 +171,7 @@ ALGORITHM OnboardBrownfieldProject
              - REPORT-ONLY: generate a diff report of proposed changes
                without writing files.
              - CANCEL: abort; leave existing rules unchanged.
-         3e. Integrate — agent writes accepted rule files into .bootstrap;
+         3e. Integrate — agent writes accepted rule files into .cf-studio/;
              updates Studio manifest to reference new files.
              DECISION: Accept proposed rule files or edit per-topic?
              - ACCEPT ALL: all proposed files written as generated.
@@ -441,7 +441,7 @@ ALGORITHM CreateAndPublishBehaviorKit
     2. Kit artifact is ready. User chooses the publication path.
     3. In the consumer project, run `cfs kit install`.
        DECISION: Install mode?
-       - COPY: kit files are copied into the consumer project's .bootstrap
+       - COPY: kit files are copied into the consumer project's .cf-studio/
          directory; consumer owns a local copy.
        - REGISTER: kit is registered by reference (path or URL); consumer
          project resolves kit at runtime without copying files.

--- a/docs/research/user-journeys.md
+++ b/docs/research/user-journeys.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document describes the fifteen primary cross-cutting user journeys in Constructor Studio v1.5.9 using CDSL (Constructor Domain Specification Language) algorithms. Each journey traces the full path a user takes from intent to outcome, showing how Studio's monolithic workflows chain together.
+This document describes the twenty-two primary cross-cutting user journeys in Constructor Studio v1.5.9 using CDSL (Constructor Domain Specification Language) algorithms. Each journey traces the full path a user takes from intent to outcome, showing how Studio's monolithic workflows chain together.
 
 **How to read ALGORITHM blocks**
 
@@ -42,6 +42,13 @@ All workflows in v1.5.9 are monolithic. Each workflow owns its full lifecycle �
 | 13 | Analyze Change Impact Across the Artifact Pipeline | Tech Lead / PM / Release Manager | Understand which downstream artifacts and code markers are affected by a change to an upstream artifact | `cf-sdlc-change-impact-analysis` | `cfs where-used` → `cfs spec-coverage` |
 | 14 | Review a GitHub Pull Request | Tech Lead / Reviewer / Team Lead | Get a structured, checklist-based review of a GitHub PR against code and artifact quality standards | `cf-sdlc-pr-review` | — |
 | 15 | Reconstruct SDLC Artifacts from Existing Code | Tech Lead / Architect | Reconstruct missing PRD/DESIGN/DECOMPOSITION/FEATURE artifacts from existing code using @cpt-* markers as evidence | `cf-sdlc-reverse-engineer` → `cf-write-docs` | `cfs validate --artifact` |
+| 16 | Full SDLC Pipeline End-to-End | Product Manager, Architect, Developer | Deliver a fully traced feature from product requirement to production code with all artifacts linked by CPT IDs | `cf-sdlc-doc-prd` → `cf-sdlc-doc-adr` → `cf-sdlc-doc-design` → `cf-sdlc-decompose` → `cf-sdlc-doc-feature` → `cf-sdlc-implement` | `cfs validate --artifact` → `cfs spec-coverage` |
+| 17 | Release Readiness Estimation | Release Manager, Tech Lead | Assess downstream impact of artifact changes and get a version bump recommendation before a release | `cf-sdlc-change-impact-analysis` | `cfs where-used` → `cfs spec-coverage` |
+| 18 | PR Status Monitoring | Team Lead, PM, Release Manager | Get a current status snapshot of one or all open GitHub PRs — CI state, open comments, severity, resolved-comment audit | `cf-sdlc-pr-status` | — |
+| 19 | Spec Coverage Gate in CI | Tech Lead, Developer, DevOps | Enforce a minimum @cpt-* marker coverage threshold as a quality gate in the CI pipeline | — | `cfs spec-coverage` |
+| 20 | Cross-Repo Traceability Navigation | Tech Lead, Architect | Trace a CPT ID from its definition in one repo to all usages across all registered workspace sources | `cf-sdlc-change-impact-analysis` | `cfs workspace-info` → `cfs list-ids` → `cfs where-defined` → `cfs where-used` → `cfs get-content` |
+| 21 | Interactive Kit Update Cycle | Developer, Tech Lead | Update an installed kit to the latest version, reviewing each changed file individually before accepting changes | — | `cfs kit check-updates` → `cfs kit update` → `cfs generate-agents` → `cfs validate-kits` |
+| 22 | CDSL ID Navigation Workflow | Developer, Architect | Enumerate CPT IDs for a feature area, find definitions and usages, read content — before making a change | `cf-sdlc-change-impact-analysis` | `cfs list-id-kinds` → `cfs list-ids` → `cfs where-defined` → `cfs where-used` → `cfs get-content` |
 
 ---
 
@@ -1103,6 +1110,342 @@ ALGORITHM ReconstructSDLCArtifacts
   ]
   NEXT: Register reconstructed artifacts in artifacts.toml; run
         cfs validate for full pipeline traceability check
+```
+
+---
+
+### Journey 16: Full SDLC Pipeline End-to-End
+
+```cdsl
+ALGORITHM FullSDLCPipelineEndToEnd
+  ACTOR: Product Manager, Architect, Developer (team)
+  GOAL: Deliver a fully traced feature from product requirement to
+        production code, with every artifact linked by CPT IDs and
+        validated at each stage
+  INPUTS: [
+    Product idea or problem statement,
+    Constructor Studio initialized with SDLC kit,
+    Codebase accessible
+  ]
+  OUTPUTS: [
+    PRD + ADR(s) + DESIGN + DECOMPOSITION + FEATURE spec(s) +
+    production code with @cpt-* markers,
+    all artifacts passing cfs validate --artifact,
+    CI green
+  ]
+  STEPS:
+    1. PM invokes cf-sdlc-doc-prd — authors PRD with cpt-fr-* and
+       cpt-nfr-* IDs; cfs validate --artifact PASS.
+    2. Architect invokes cf-sdlc-doc-adr for each major technology
+       decision — ADRs with cpt-adr-* IDs cross-referenced in DESIGN.
+    3. Architect invokes cf-sdlc-doc-design — DESIGN with
+       cpt-component-*, cpt-principle-*, cpt-constraint-* IDs;
+       cfs validate --artifact PASS.
+    4. Tech lead invokes cf-sdlc-decompose — DECOMPOSITION with ordered
+       cpt-feature-* IDs linking back to PRD FRs and DESIGN components.
+    5. For each feature: developer invokes cf-sdlc-doc-feature — FEATURE
+       spec with cpt-flow-*, cpt-algo-*, cpt-state-* IDs and test
+       scenarios.
+    6. Developer invokes cf-sdlc-implement — code written with @cpt-*
+       markers; cfs validate --artifact + CI gate PASS.
+    7. cfs spec-coverage run to confirm marker coverage meets project
+       threshold.
+    8. cf-sdlc-pr-review run on the implementation PR; findings
+       addressed.
+  DECISION_POINTS:
+    - ADRCount: one ADR per major decision (architecture, library
+      choice, API design)
+    - FeatureGranularity: split or merge DECOMPOSITION entries based on
+      estimated effort
+    - TestFirst: write FEATURE test scenarios before implementation?
+  GUARDS: [
+    Every FEATURE references its parent DECOMPOSITION entry,
+    Every @cpt-* marker in code traces to a cpt-flow-* in a FEATURE
+      spec,
+    cfs validate --artifact PASS at every artifact stage,
+    CI green before PR review
+  ]
+  NEXT: cf-sdlc-change-impact-analysis (for future changes),
+        cf-sdlc-pr-status (ongoing monitoring)
+```
+
+---
+
+### Journey 17: Release Readiness Estimation
+
+```cdsl
+ALGORITHM ReleaseReadinessEstimation
+  ACTOR: Release Manager, Tech Lead
+  GOAL: Before a release, assess the downstream impact of all artifact
+        changes and get a version bump recommendation
+        (major / minor / patch)
+  INPUTS: [
+    Upstream artifact ID that changed,
+    Baseline ref (prior release tag),
+    Current ref (HEAD or release branch)
+  ]
+  OUTPUTS: [
+    Impact report at .change-impact/{ID}/report.md: cascade tree,
+    stale @cpt-* flags, coverage gaps, version bump recommendation
+  ]
+  STEPS:
+    1. Identify the upstream artifact that changed most significantly
+       (e.g. a PRD FR was revised).
+    2. Invoke cf-sdlc-change-impact-analysis, choose mode:
+       release-readiness-estimation.
+    3. Studio diffs upstream artifact between baseline tag and HEAD.
+    4. Studio runs cfs where-used to trace all downstream dependents
+       (bounded per artifact type).
+    5. Studio runs cfs spec-coverage on affected downstream set.
+    6. Studio flags stale @cpt-* markers (not updated within threshold
+       since the upstream change).
+    7. Studio aggregates cascade tree, coverage gaps, and stale flags.
+    8. Studio derives version bump recommendation from impact severity
+       (breaking → major, new behavior → minor, fix → patch).
+    9. Release manager reviews report and decides go / no-go.
+  DECISION_POINTS:
+    - BaselineRef: prior release tag vs main branch tip
+    - MultipleChangedArtifacts: run analysis per artifact or pick
+      highest-impact one
+  GUARDS: [
+    Read-only — report only, never edits artifacts or code,
+    Report written under .change-impact/ only
+  ]
+  NEXT: Update stale downstream artifacts, then re-run analysis to
+        confirm clean; proceed to release
+```
+
+---
+
+### Journey 18: PR Status Monitoring
+
+```cdsl
+ALGORITHM PRStatusMonitoring
+  ACTOR: Team Lead, PM, Release Manager
+  GOAL: Get a current status snapshot of one or all open GitHub PRs —
+        CI state, open comments, severity of unresolved feedback,
+        resolved-comment audit
+  INPUTS: [
+    GitHub PR number or "ALL",
+    Access to GitHub repo
+  ]
+  OUTPUTS: [
+    Status report at .prs/{ID}/status.md per PR: CI status, open
+    comment count, severity assessment, resolved-comment audit
+  ]
+  STEPS:
+    1. Invoke cf-sdlc-pr-status with PR number or ALL.
+    2. Studio re-fetches PR data from GitHub fresh (never reuses prior
+       run).
+    3. Studio generates status report: CI checks, open vs resolved
+       comments, severity of open feedback (critical / major / minor).
+    4. Studio audits resolved comments: flags any that were resolved
+       without a corresponding code change.
+    5. Studio emits report to .prs/{ID}/status.md.
+    6. Team lead reviews: decide to merge, request changes, or escalate.
+  DECISION_POINTS:
+    - ReviewScope: single PR or all open PRs?
+    - ResolvedCommentAudit: surface all or only suspicious resolutions?
+  GUARDS: [
+    Always re-fetched from scratch — never reuses prior conversation
+      data,
+    Read-only: no local file modifications
+  ]
+  NEXT: cf-sdlc-pr-review (for deeper review of a specific PR),
+        or merge / close decision
+```
+
+---
+
+### Journey 19: Spec Coverage Gate in CI
+
+```cdsl
+ALGORITHM SpecCoverageGateInCI
+  ACTOR: Tech Lead, Developer, DevOps
+  GOAL: Enforce a minimum @cpt-* marker coverage threshold as a quality
+        gate — fail the pipeline if coverage or granularity drops below
+        the configured floor
+  INPUTS: [
+    Configured min-coverage and min-granularity thresholds in project
+    config,
+    Codebase with @cpt-* markers
+  ]
+  OUTPUTS: [
+    Coverage report (JSON or human-readable): per-file coverage %,
+    aggregate coverage %, granularity score;
+    exit code 0 (PASS) or non-zero (FAIL)
+  ]
+  STEPS:
+    1. Developer adds or modifies code with @cpt-* markers after
+       implementing a FEATURE.
+    2. CI pipeline (or developer locally) runs
+       cfs spec-coverage --min-coverage 80 --min-granularity 0.7.
+    3. Studio scans codebase for @cpt-* markers; computes per-file and
+       aggregate coverage.
+    4. Studio computes granularity score (ratio of instruction-level
+       markers to block-level markers).
+    5. Studio compares results against thresholds; emits PASS or FAIL
+       with per-file breakdown.
+    6. On FAIL: developer identifies uncovered files, adds missing
+       @cpt-* markers, re-runs.
+    7. Optional: cfs spec-coverage --output report.json for CI artifact
+       storage.
+  DECISION_POINTS:
+    - ScanScope: run against full codebase or specific system
+      (--source filter)?
+    - FailMode: fail pipeline or warn only?
+      (--min-* flags control hard failure)
+  GUARDS: [
+    Thresholds configured before enforcement,
+    Report always emitted even on failure for diagnosis
+  ]
+  NEXT: Add missing markers → re-run → merge when PASS
+```
+
+---
+
+### Journey 20: Cross-Repo Traceability Navigation
+
+```cdsl
+ALGORITHM CrossRepoTraceabilityNavigation
+  ACTOR: Tech Lead, Architect
+  GOAL: In a multi-repo workspace, trace a CPT ID from its definition
+        in one repo to all its usages across all registered workspace
+        sources
+  INPUTS: [
+    Initialized multi-repo workspace (.cf-workspace.toml),
+    CPT ID to investigate,
+    All sources reachable
+  ]
+  OUTPUTS: [
+    Definition location (file:line in source repo),
+    All usage locations across workspace repos,
+    Content of the ID's text block
+  ]
+  STEPS:
+    1. Confirm workspace is initialized and sources are synced
+       (cfs workspace-info, cfs workspace-sync if needed).
+    2. Run cfs list-ids to enumerate all CPT IDs across the workspace
+       (or filter by kind with --kind).
+    3. Run cfs where-defined <ID> --source <workspace-source> to find
+       the definition file and line.
+    4. Run cfs where-used <ID> across all workspace sources to find
+       downstream references.
+    5. Run cfs get-content <ID> to read the full text block associated
+       with that ID.
+    6. Assess blast radius: how many files and repos reference this ID.
+    7. DECISION: Planning a change?
+       - YES: run cf-sdlc-change-impact-analysis on the upstream
+         artifact containing this ID.
+       - NO: navigation complete; use findings for review or
+         documentation.
+  DECISION_POINTS:
+    - NavigationScope: single ID deep-dive vs scan all IDs of a kind?
+    - IncludeCodeScan: include code file scan in where-used
+      (--code flag)?
+  GUARDS: [
+    All workspace sources must be reachable before cross-repo query,
+    Queries are read-only
+  ]
+  NEXT: cf-sdlc-change-impact-analysis (if change is planned),
+        or update artifact referencing this ID
+```
+
+---
+
+### Journey 21: Interactive Kit Update Cycle
+
+```cdsl
+ALGORITHM InteractiveKitUpdateCycle
+  ACTOR: Developer, Tech Lead
+  GOAL: Update an installed kit to the latest version, reviewing each
+        changed file individually before accepting changes
+  INPUTS: [
+    Installed kit (copy or register mode),
+    Upstream kit source (local path, GitHub, or Git)
+  ]
+  OUTPUTS: [
+    Updated kit files on disk (only accepted files),
+    Preserved files for declined changes,
+    .cf-studio-kit.toml reflecting new version
+  ]
+  STEPS:
+    1. Run cfs kit check-updates to see which installed kits have
+       upstream changes available.
+    2. Review the update summary (new version, changed files, breaking
+       changes noted).
+    3. Run cfs kit update for the target kit.
+    4. For each changed file, Studio presents a diff and asks:
+       accept / decline / modify.
+         - accept: upstream version replaces local file.
+         - decline: local file kept as-is.
+         - modify: user edits the merged result before writing.
+    5. After all files reviewed, Studio writes only accepted / modified
+       files.
+    6. Run cfs generate-agents to refresh IDE agent integrations
+       reflecting kit changes.
+    7. Run cfs validate-kits to confirm updated kit structure is valid.
+  DECISION_POINTS:
+    - PerFileDecision: accept / decline / modify (per changed file)
+    - RegenerateAgents: regenerate agent integrations after update?
+      (recommended yes)
+  GUARDS: [
+    Declined files are never overwritten,
+    Modified files written only after user confirms edit,
+    validate-kits run after update
+  ]
+  NEXT: cfs generate-agents, then test updated kit behavior in a
+        workflow run
+```
+
+---
+
+### Journey 22: CDSL ID Navigation Workflow
+
+```cdsl
+ALGORITHM CDSLIDNavigationWorkflow
+  ACTOR: Developer, Architect
+  GOAL: Understand the full traceability picture for a given feature
+        area — enumerate IDs, find definitions, find usages, read
+        content — before making a change
+  INPUTS: [
+    Feature area or subsystem of interest,
+    Constructor Studio initialized with registered artifacts
+  ]
+  OUTPUTS: [
+    List of all CPT IDs in the area,
+    Definition locations,
+    Usage locations across artifacts and code,
+    Content of relevant ID blocks
+  ]
+  STEPS:
+    1. Run cfs list-id-kinds to understand what ID kinds exist in the
+       project (feature, flow, component, etc.).
+    2. Run cfs list-ids --kind feature --pattern <area> to enumerate all
+       feature IDs in the subsystem.
+    3. For each ID of interest: run cfs where-defined <ID> to locate the
+       defining artifact and line.
+    4. Run cfs where-used <ID> to find all artifacts and code that
+       reference this ID.
+    5. Run cfs get-content <ID> to read the full specification block for
+       that ID.
+    6. DECISION: Include code-level inspection?
+       - YES: run cfs get-content <ID> --code --inst to read
+         instruction-level marker content.
+       - NO: artifact-level navigation complete.
+    7. Build a mental map of the subsystem's artifact → code
+       traceability before deciding what to change.
+  DECISION_POINTS:
+    - NavigationDepth: single ID deep-dive vs breadth scan of all IDs
+      in an area?
+    - IncludeCodeScan: include code file scan? (adds --code flag to
+      where-used and get-content)
+  GUARDS: [
+    All commands are read-only,
+    No files modified
+  ]
+  NEXT: cf-sdlc-change-impact-analysis (to assess impact of planned
+        change), or cf-sdlc-implement (to add missing markers)
 ```
 
 ---

--- a/docs/research/user-journeys.md
+++ b/docs/research/user-journeys.md
@@ -34,7 +34,7 @@ All workflows in v1.5.9 are monolithic. Each workflow owns its full lifecycle �
 | 5 | Create and publish a behavior kit | Platform engineer | Package reusable behaviors into a validated, installable kit | `cf-kit` | `cfs kit install` → `cfs generate-agents` |
 | 6 | Generate project documentation | Technical writer / Developer | Produce audience-tuned, reviewed, committed documentation | `cf-explore` → `cf-write-docs` | — |
 | 7 | Author a Product Requirements Document (PRD) | Product Manager | Produce a validated PRD with actors, FR/NFR, use cases, success criteria, and cpt-IDs | `cf-sdlc-doc-prd` → `cf-write-docs` | `cfs validate --artifact` |
-| 8 | Record an Architecture Decision (ADR) | Architect / Tech Lead | Capture a technology or design decision with context, options, consequences, and a cpt-adr-* ID | `cf-sdlc-doc-adr` → `cf-write-docs` | `cfs validate --artifact` |
+| 8 | Record an Architecture Decision (ADR) | Architect / Tech Lead | Capture a technology or design decision with context, options, consequences, and a cpt-{system}-adr-* ID | `cf-sdlc-doc-adr` → `cf-write-docs` | `cfs validate --artifact` |
 | 9 | Author a System DESIGN Document | Architect / Tech Lead | Document system architecture: components, interfaces, boundaries, principles, constraints | `cf-sdlc-doc-design` → `cf-write-docs` | `cfs validate --artifact` |
 | 10 | Decompose DESIGN into Feature List (DECOMPOSITION) | Tech Lead / PM | Break a DESIGN into an ordered, dependency-linked FEATURE list with PRD/DESIGN coverage | `cf-sdlc-decompose` → `cf-write-docs` | `cfs validate --artifact` |
 | 11 | Author a FEATURE Specification | Tech Lead / Developer | Write a precise, implementable FEATURE spec with CDSL flows, algorithms, states, and test scenarios | `cf-sdlc-doc-feature` → `cf-write-docs` | `cfs validate --artifact` |
@@ -56,7 +56,7 @@ All workflows in v1.5.9 are monolithic. Each workflow owns its full lifecycle �
 
 ### Journey 1: Plan and Implement a New Feature
 
-```cdsl
+```text
 ALGORITHM PlanAndImplementFeature
   ACTOR: Developer
   GOAL: Deliver a working, reviewed, and committed feature implementation
@@ -147,7 +147,7 @@ ALGORITHM PlanAndImplementFeature
 
 ### Journey 2: Onboard a Brownfield Project to Studio
 
-```cdsl
+```text
 ALGORITHM OnboardBrownfieldProject
   ACTOR: Tech lead or DevOps engineer
   GOAL: Bring an existing codebase under Studio governance by generating
@@ -226,7 +226,7 @@ ALGORITHM OnboardBrownfieldProject
 
 ### Journey 3: Brainstorm and Write an Architectural Decision Record
 
-```cdsl
+```text
 ALGORITHM BrainstormAndWriteADR
   ACTOR: Architect or Tech lead
   GOAL: Produce a structured, persisted, and reviewed Architectural
@@ -327,7 +327,7 @@ ALGORITHM BrainstormAndWriteADR
 
 ### Journey 4: Review and Fix Existing Code
 
-```cdsl
+```text
 ALGORITHM ReviewAndFixExistingCode
   ACTOR: Developer or Reviewer
   GOAL: Systematically identify issues in existing code, obtain per-finding
@@ -408,7 +408,7 @@ ALGORITHM ReviewAndFixExistingCode
 
 ### Journey 5: Create and Publish a Behavior Kit
 
-```cdsl
+```text
 ALGORITHM CreateAndPublishBehaviorKit
   ACTOR: Platform engineer
   GOAL: Package reusable Studio behaviors into a validated, installable
@@ -492,7 +492,7 @@ ALGORITHM CreateAndPublishBehaviorKit
 
 ### Journey 6: Generate Project Documentation
 
-```cdsl
+```text
 ALGORITHM GenerateProjectDocumentation
   ACTOR: Technical writer or Developer
   GOAL: Produce audience-tuned, reviewed, and committed project documentation
@@ -592,7 +592,7 @@ ALGORITHM GenerateProjectDocumentation
 
 ### Journey 7: Author a Product Requirements Document (PRD)
 
-```cdsl
+```text
 ALGORITHM AuthorPRD
   ACTOR: Product Manager
   GOAL: Produce a validated PRD with actors, FR/NFR, use cases, success
@@ -602,7 +602,7 @@ ALGORITHM AuthorPRD
     Stakeholder context
   ]
   OUTPUTS: [
-    Validated PRD markdown file with cpt-fr-* and cpt-nfr-* IDs,
+    Validated PRD markdown file with cpt-{system}-fr-* and cpt-{system}-nfr-* IDs,
     cfs validate --artifact PASS
   ]
   STEPS:
@@ -653,11 +653,11 @@ ALGORITHM AuthorPRD
 
 ### Journey 8: Record an Architecture Decision (ADR)
 
-```cdsl
+```text
 ALGORITHM RecordADR
   ACTOR: Architect or Tech Lead
   GOAL: Capture a technology or design decision with context, options,
-        consequences, and a cpt-adr-* ID that can be cross-referenced
+        consequences, and a cpt-{system}-adr-* ID that can be cross-referenced
         in the system DESIGN document
   INPUTS: [
     Decision description,
@@ -665,7 +665,7 @@ ALGORITHM RecordADR
     DESIGN artifact (optional, for cross-reference)
   ]
   OUTPUTS: [
-    ADR markdown file with cpt-adr-* ID,
+    ADR markdown file with cpt-{system}-adr-* ID,
     ADR ID registered and cross-referenced in DESIGN
   ]
   STEPS:
@@ -681,7 +681,7 @@ ALGORITHM RecordADR
          3d. Decision Outcome — chosen option with rationale.
          3e. Consequences — positive, negative, and neutral effects;
              risks introduced; follow-on actions.
-         3f. cpt-adr-* ID — assigned and embedded in front-matter.
+         3f. cpt-{system}-adr-* ID — assigned and embedded in front-matter.
     4. Deterministic gate: run `cfs validate --artifact` on the ADR file.
     5. Semantic review against ADR checklist; findings presented by severity.
     6. DECISION: Fix which findings?
@@ -691,7 +691,7 @@ ALGORITHM RecordADR
     - FixWhichFindings: per-finding selection
   GUARDS: [
     Decision must have at least two considered options before authoring is complete,
-    cpt-adr-* ID must be assigned before the ADR file is written,
+    cpt-{system}-adr-* ID must be assigned before the ADR file is written,
     Consequences section must be non-empty,
     cfs validate --artifact must return PASS before the ADR is considered complete
   ]
@@ -702,7 +702,7 @@ ALGORITHM RecordADR
 
 ### Journey 9: Author a System DESIGN Document
 
-```cdsl
+```text
 ALGORITHM AuthorSystemDesign
   ACTOR: Architect or Tech Lead
   GOAL: Document system architecture covering components, interfaces,
@@ -714,8 +714,8 @@ ALGORITHM AuthorSystemDesign
     High-level architecture knowledge
   ]
   OUTPUTS: [
-    DESIGN markdown with cpt-component-*, cpt-principle-*, and
-    cpt-constraint-* IDs,
+    DESIGN markdown with cpt-{system}-component-*, cpt-{system}-principle-*, and
+    cpt-{system}-constraint-* IDs,
     cfs validate --artifact PASS
   ]
   STEPS:
@@ -745,7 +745,7 @@ ALGORITHM AuthorSystemDesign
     - IncludeSequenceDiagrams: yes (auto-embed Mermaid) / skip (placeholders)
     - FixWhichFindings: per-finding selection
   GUARDS: [
-    All cpt-component-* IDs must be unique within the system namespace,
+    All cpt-{system}-component-* IDs must be unique within the system namespace,
     DESIGN must reference existing ADR IDs for every major technology choice,
     PRD FR coverage must be noted in the component model or interface descriptions,
     cfs validate --artifact must return PASS before DESIGN is considered complete
@@ -757,7 +757,7 @@ ALGORITHM AuthorSystemDesign
 
 ### Journey 10: Decompose DESIGN into Feature List (DECOMPOSITION)
 
-```cdsl
+```text
 ALGORITHM DecomposeDesign
   ACTOR: Tech Lead or PM
   GOAL: Break a DESIGN into an ordered, dependency-linked FEATURE list
@@ -768,7 +768,7 @@ ALGORITHM DecomposeDesign
     PRD (for coverage links back to FRs)
   ]
   OUTPUTS: [
-    DECOMPOSITION markdown with cpt-feature-* IDs, ordering,
+    DECOMPOSITION markdown with cpt-{system}-feature-* IDs, ordering,
     dependency graph, and coverage links,
     cfs validate --artifact PASS
   ]
@@ -780,9 +780,9 @@ ALGORITHM DecomposeDesign
          3a. Feature entries — for each deliverable unit of work:
              - Assign a unique cpt-{system}-feature-* ID.
              - Write a one-paragraph description of scope and boundaries.
-             - Record dependency links to other cpt-feature-* IDs.
-             - Record coverage links to PRD cpt-fr-* IDs and DESIGN
-               cpt-component-* IDs.
+             - Record dependency links to other cpt-{system}-feature-* IDs.
+             - Record coverage links to PRD cpt-{system}-fr-* IDs and DESIGN
+               cpt-{system}-component-* IDs.
              - Set initial status (planned).
              - Define a measurable Definition of Done.
          3b. DECISION: Ordering strategy?
@@ -801,7 +801,7 @@ ALGORITHM DecomposeDesign
     - OrderingStrategy: dependency / risk / value priority
     - FixWhichFindings: per-finding selection
   GUARDS: [
-    Every cpt-feature-* entry must reference at least one PRD cpt-fr-* ID,
+    Every cpt-{system}-feature-* entry must reference at least one PRD cpt-{system}-fr-* ID,
     Dependency graph must have no cycles,
     All features must have a non-empty Definition of Done,
     cfs validate --artifact must return PASS before DECOMPOSITION is complete
@@ -813,24 +813,24 @@ ALGORITHM DecomposeDesign
 
 ### Journey 11: Author a FEATURE Specification
 
-```cdsl
+```text
 ALGORITHM AuthorFeatureSpec
   ACTOR: Tech Lead or Developer
   GOAL: Write a precise, implementable FEATURE specification with CDSL
         flows, algorithms, state diagrams, and test scenarios that
         developers can implement with full traceability
   INPUTS: [
-    DECOMPOSITION entry (cpt-feature-* ID and description),
+    DECOMPOSITION entry (cpt-{system}-feature-* ID and description),
     DESIGN (for interface contracts),
     PRD (for acceptance criteria)
   ]
   OUTPUTS: [
-    FEATURE markdown with cpt-flow-*, cpt-algo-*, and cpt-state-* IDs
+    FEATURE markdown with cpt-{system}-flow-*, cpt-{system}-algo-*, and cpt-{system}-state-* IDs
     and test scenarios,
     cfs validate --artifact PASS
   ]
   STEPS:
-    1. Invoke cf-sdlc-doc-feature with the target cpt-feature-* ID.
+    1. Invoke cf-sdlc-doc-feature with the target cpt-{system}-feature-* ID.
     2. Studio binds FEATURE template + rules + checklist + example from
        the SDLC kit before any authoring begins.
     3. Studio authors the FEATURE spec via cf-write-docs engine:
@@ -846,7 +846,7 @@ ALGORITHM AuthorFeatureSpec
                entities; each state assigned a cpt-{system}-state-* ID.
              - SKIP: state diagram section omitted.
          3e. Test Scenarios — at least one happy-path scenario and one
-             error/edge-case scenario per cpt-flow-* ID.
+             error/edge-case scenario per cpt-{system}-flow-* ID.
          3f. Definition of Done — measurable, checkable criteria derived
              from PRD acceptance conditions.
     4. Deterministic gate: run `cfs validate --artifact` on the FEATURE file.
@@ -859,7 +859,7 @@ ALGORITHM AuthorFeatureSpec
     - IncludeStateDiagrams: yes (Mermaid state diagrams) / skip
     - FixWhichFindings: per-finding selection
   GUARDS: [
-    Every cpt-flow-* ID must be unique within the system namespace,
+    Every cpt-{system}-flow-* ID must be unique within the system namespace,
     Test scenarios must cover at least one happy-path and one error case
       per flow,
     Definition of Done must be measurable and checkable,
@@ -872,14 +872,14 @@ ALGORITHM AuthorFeatureSpec
 
 ### Journey 12: Implement a FEATURE with Traceability
 
-```cdsl
+```text
 ALGORITHM ImplementFeatureWithTraceability
   ACTOR: Developer
   GOAL: Write production code that implements a FEATURE specification,
         with @cpt-* markers in source linking every code unit back to
         the FEATURE flow and algorithm IDs it satisfies
   INPUTS: [
-    FEATURE spec (cpt-feature-* ID and cpt-flow-* IDs),
+    FEATURE spec (cpt-{system}-feature-* ID and cpt-{system}-flow-* IDs),
     Codebase rules (codebase_rules),
     Codebase checklist (codebase_checklist)
   ]
@@ -896,11 +896,11 @@ ALGORITHM ImplementFeatureWithTraceability
        and interfaces in the codebase that the FEATURE will touch.
     4. DECISION: Write tests first?
        - YES (test-first): developer (or Studio) writes failing tests
-         for each cpt-flow-* scenario before implementation code.
+         for each cpt-{system}-flow-* scenario before implementation code.
        - NO: implementation code written first; tests follow.
     5. Author dispatch — cf-coding writes implementation with
        @cpt-{kind}:{id}:p{N} markers on every function, class, or
-       block that satisfies a cpt-flow-* or cpt-algo-* ID per
+       block that satisfies a cpt-{system}-flow-* or cpt-{system}-algo-* ID per
        codebase_rules.
     6. Deterministic gate: run project tests + lint + typecheck + build
        + `cfs validate --artifact` (traceability check). Any failure
@@ -916,7 +916,7 @@ ALGORITHM ImplementFeatureWithTraceability
     - TestFirstPath: yes (test-first) / no (implementation-first)
     - FixWhichFindings: per-finding selection
   GUARDS: [
-    @cpt-* markers must be present for all cpt-flow-* IDs declared
+    @cpt-* markers must be present for all cpt-{system}-flow-* IDs declared
       in the FEATURE spec,
     cfs validate --artifact must return PASS before implementation is done,
     CI (tests + lint + typecheck + build) must be green before done,
@@ -929,7 +929,7 @@ ALGORITHM ImplementFeatureWithTraceability
 
 ### Journey 13: Analyze Change Impact Across the Artifact Pipeline
 
-```cdsl
+```text
 ALGORITHM AnalyzeChangeImpact
   ACTOR: Tech Lead, PM, or Release Manager
   GOAL: Understand which downstream artifacts and @cpt-* code markers
@@ -983,7 +983,7 @@ ALGORITHM AnalyzeChangeImpact
 
 ### Journey 14: Review a GitHub Pull Request
 
-```cdsl
+```text
 ALGORITHM ReviewGitHubPullRequest
   ACTOR: Tech Lead, Reviewer, or Team Lead
   GOAL: Obtain a structured, checklist-based review of a GitHub PR
@@ -1036,7 +1036,7 @@ ALGORITHM ReviewGitHubPullRequest
 
 ### Journey 15: Reconstruct SDLC Artifacts from Existing Code
 
-```cdsl
+```text
 ALGORITHM ReconstructSDLCArtifacts
   ACTOR: Tech Lead or Architect (working with legacy or undocumented code)
   GOAL: Reconstruct missing PRD, DESIGN, DECOMPOSITION, and FEATURE
@@ -1116,7 +1116,7 @@ ALGORITHM ReconstructSDLCArtifacts
 
 ### Journey 16: Full SDLC Pipeline End-to-End
 
-```cdsl
+```text
 ALGORITHM FullSDLCPipelineEndToEnd
   ACTOR: Product Manager, Architect, Developer (team)
   GOAL: Deliver a fully traced feature from product requirement to
@@ -1134,17 +1134,17 @@ ALGORITHM FullSDLCPipelineEndToEnd
     CI green
   ]
   STEPS:
-    1. PM invokes cf-sdlc-doc-prd — authors PRD with cpt-fr-* and
-       cpt-nfr-* IDs; cfs validate --artifact PASS.
+    1. PM invokes cf-sdlc-doc-prd — authors PRD with cpt-{system}-fr-* and
+       cpt-{system}-nfr-* IDs; cfs validate --artifact PASS.
     2. Architect invokes cf-sdlc-doc-adr for each major technology
-       decision — ADRs with cpt-adr-* IDs cross-referenced in DESIGN.
+       decision — ADRs with cpt-{system}-adr-* IDs cross-referenced in DESIGN.
     3. Architect invokes cf-sdlc-doc-design — DESIGN with
-       cpt-component-*, cpt-principle-*, cpt-constraint-* IDs;
+       cpt-{system}-component-*, cpt-{system}-principle-*, cpt-{system}-constraint-* IDs;
        cfs validate --artifact PASS.
     4. Tech lead invokes cf-sdlc-decompose — DECOMPOSITION with ordered
-       cpt-feature-* IDs linking back to PRD FRs and DESIGN components.
+       cpt-{system}-feature-* IDs linking back to PRD FRs and DESIGN components.
     5. For each feature: developer invokes cf-sdlc-doc-feature — FEATURE
-       spec with cpt-flow-*, cpt-algo-*, cpt-state-* IDs and test
+       spec with cpt-{system}-flow-*, cpt-{system}-algo-*, cpt-{system}-state-* IDs and test
        scenarios.
     6. Developer invokes cf-sdlc-implement — code written with @cpt-*
        markers; cfs validate --artifact + CI gate PASS.
@@ -1160,7 +1160,7 @@ ALGORITHM FullSDLCPipelineEndToEnd
     - TestFirst: write FEATURE test scenarios before implementation?
   GUARDS: [
     Every FEATURE references its parent DECOMPOSITION entry,
-    Every @cpt-* marker in code traces to a cpt-flow-* in a FEATURE
+    Every @cpt-* marker in code traces to a cpt-{system}-flow-* in a FEATURE
       spec,
     cfs validate --artifact PASS at every artifact stage,
     CI green before PR review
@@ -1173,7 +1173,7 @@ ALGORITHM FullSDLCPipelineEndToEnd
 
 ### Journey 17: Release Readiness Estimation
 
-```cdsl
+```text
 ALGORITHM ReleaseReadinessEstimation
   ACTOR: Release Manager, Tech Lead
   GOAL: Before a release, assess the downstream impact of all artifact
@@ -1219,7 +1219,7 @@ ALGORITHM ReleaseReadinessEstimation
 
 ### Journey 18: PR Status Monitoring
 
-```cdsl
+```text
 ALGORITHM PRStatusMonitoring
   ACTOR: Team Lead, PM, Release Manager
   GOAL: Get a current status snapshot of one or all open GitHub PRs —
@@ -1259,7 +1259,7 @@ ALGORITHM PRStatusMonitoring
 
 ### Journey 19: Spec Coverage Gate in CI
 
-```cdsl
+```text
 ALGORITHM SpecCoverageGateInCI
   ACTOR: Tech Lead, Developer, DevOps
   GOAL: Enforce a minimum @cpt-* marker coverage threshold as a quality
@@ -1306,7 +1306,7 @@ ALGORITHM SpecCoverageGateInCI
 
 ### Journey 20: Cross-Repo Traceability Navigation
 
-```cdsl
+```text
 ALGORITHM CrossRepoTraceabilityNavigation
   ACTOR: Tech Lead, Architect
   GOAL: In a multi-repo workspace, trace a CPT ID from its definition
@@ -1355,7 +1355,7 @@ ALGORITHM CrossRepoTraceabilityNavigation
 
 ### Journey 21: Interactive Kit Update Cycle
 
-```cdsl
+```text
 ALGORITHM InteractiveKitUpdateCycle
   ACTOR: Developer, Tech Lead
   GOAL: Update an installed kit to the latest version, reviewing each
@@ -1402,7 +1402,7 @@ ALGORITHM InteractiveKitUpdateCycle
 
 ### Journey 22: CDSL ID Navigation Workflow
 
-```cdsl
+```text
 ALGORITHM CDSLIDNavigationWorkflow
   ACTOR: Developer, Architect
   GOAL: Understand the full traceability picture for a given feature


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Constructor Studio CLI reference for `cfs` v1.5.9, including invocation syntax, a categorized command list, per-command options (including `--json`), and shared terms/aliases.
  * Expanded the Studio overview with Capability Domain 14: SDLC Artifact Pipeline, including new end-to-end scenarios and updated summary tables.
  * Added a full “User Journeys” specification (15 journeys) with detailed step-by-step CDSL ALGORITHM blocks and cross-journey patterns, including embedded git finalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->