### PR TITLE
Suppress fallback path warnings in agents

### DIFF
--- a/skills/studio/scripts/studio/commands/agents.py
+++ b/skills/studio/scripts/studio/commands/agents.py
@@ -1098,21 +1098,21 @@ def _target_path_from_root(target: Path, project_root: Path, studio_root: Option
 
     Falls back to ``@/<project-root-relative>`` for paths outside studio_root.
     """
+    resolved_target = target.resolve()
+    resolved_project_root = project_root.resolve()
     if studio_root is not None:
-        try:
-            rel = target.relative_to(studio_root).as_posix()
+        resolved_studio_root = studio_root.resolve()
+        if resolved_target.is_relative_to(resolved_studio_root):
+            rel = resolved_target.relative_to(resolved_studio_root).as_posix()
             return "{cf-studio-path}/" + rel
-        except ValueError as exc:
-            _warn_agents(f"path {target} is not relative to studio root {studio_root}: {exc}")
-    try:
-        rel = target.relative_to(project_root).as_posix()
+    if resolved_target.is_relative_to(resolved_project_root):
+        rel = resolved_target.relative_to(resolved_project_root).as_posix()
         return "{cf-studio-path}/" + rel if studio_root is None else f"@/{rel}"
-    except ValueError:
-        _warn_agents(
-            f"path {target} is outside project root {project_root}, "
-            "agent proxy will contain an absolute path"
-        )
-        return target.as_posix()
+    _warn_agents(
+        f"path {resolved_target} is outside project root {resolved_project_root}, "
+        "agent proxy will contain an absolute path"
+    )
+    return resolved_target.as_posix()
 # @cpt-end:cpt-studio-algo-agent-integration-generate-shims:p1:inst-path-helpers
 
 # @cpt-begin:cpt-studio-algo-agent-integration-generate-shims:p1:inst-ensure-local-copy
@@ -2151,13 +2151,21 @@ def _registered_kit_roots(
         if not isinstance(kit_cfg, dict):
             continue
         raw_path = str(kit_cfg.get("path") or f"config/kits/{slug}").strip()
-        resolved = _resolve_registered_project_relative_path(project_root_resolved, raw_path)
-        if resolved is None or not resolved.exists():
-            resolved = _resolve_registered_legacy_studio_path(
+        project_resolved = _resolve_registered_project_relative_path(project_root_resolved, raw_path)
+        legacy_resolved = None
+        if project_resolved is None or not project_resolved.exists():
+            legacy_resolved = _resolve_registered_legacy_studio_path(
                 _studio_root.resolve(),
                 project_root_resolved,
                 raw_path,
             )
+        if project_resolved is None and legacy_resolved is None:
+            _warn_registered_path_escape(raw_path, project_root_resolved, _studio_root)
+        resolved = (
+            project_resolved
+            if project_resolved is not None and project_resolved.exists()
+            else legacy_resolved
+        )
         if resolved is not None:
             roots[str(slug)] = resolved
     return roots
@@ -2257,12 +2265,7 @@ def _resolve_registered_project_relative_path(
     ):
         return None
     resolved = (project_root / Path(normalized)).resolve()
-    try:
-        resolved.relative_to(project_root.resolve())
-    except ValueError as exc:
-        _warn_agents(f"registered legacy project path escapes project root: {resolved} ({exc})")
-        return None
-    return resolved
+    return resolved if resolved.is_relative_to(project_root.resolve()) else None
 # @cpt-end:cpt-studio-algo-agent-integration-discover-agents:p1:inst-resolve-kits
 # @cpt-end:cpt-studio-algo-agent-integration-discover-agents:p1:inst-resolve-register-project-root-kit
 
@@ -2283,12 +2286,15 @@ def _resolve_registered_legacy_studio_path(
     ):
         return None
     resolved = (studio_root / Path(normalized)).resolve()
-    try:
-        resolved.relative_to(project_root.resolve())
-    except ValueError as exc:
-        _warn_agents(f"registered legacy studio path escapes project root: {resolved} ({exc})")
-        return None
-    return resolved
+    return resolved if resolved.is_relative_to(project_root.resolve()) else None
+
+
+def _warn_registered_path_escape(raw_path: str, project_root: Path, studio_root: Path) -> None:
+    """Warn once when neither registered-kit path base keeps *raw_path* in-project."""
+    _warn_agents(
+        "registered kit path escapes project root after checking project and studio roots: "
+        f"{raw_path!r} (project={project_root.resolve()}, studio={studio_root.resolve()})"
+    )
 # @cpt-end:cpt-studio-algo-agent-integration-discover-agents:p1:inst-resolve-register-project-root-kit
 
 
@@ -2315,6 +2321,8 @@ def _resolve_registered_kit_path(project_root: Path, studio_root: Path, slug: st
             legacy_resolved = _resolve_registered_legacy_studio_path(studio_root, project_root, raw_path)
             if legacy_resolved is not None:
                 return legacy_resolved
+            if resolved is None:
+                _warn_registered_path_escape(raw_path, project_root, studio_root)
             return resolved
     # @cpt-end:cpt-studio-algo-agent-integration-discover-agents:p1:inst-resolve-register-project-root-kit
     return _resolve_registered_project_relative_path(project_root, f"config/kits/{slug}")
@@ -2340,6 +2348,8 @@ def _resolve_registered_resource_path(
         legacy_resolved = _resolve_registered_legacy_studio_path(_studio_root, project_root, raw_path)
         if legacy_resolved is not None:
             return legacy_resolved
+        if resolved is None:
+            _warn_registered_path_escape(raw_path, project_root, _studio_root)
         return resolved
     component_source = source if source is not None else str(getattr(component, "source", ""))
     if not component_source:
@@ -2574,13 +2584,10 @@ def _resolve_registered_public_skill_source(
 
 
 def _path_within_any_root(path: Path, roots: Tuple[Path, ...]) -> bool:
+    resolved_path = path.resolve()
     for root in roots:
-        try:
-            path.relative_to(root.resolve())
+        if resolved_path.is_relative_to(root.resolve()):
             return True
-        except ValueError as exc:
-            _warn_agents(f"path {path} is not under trusted root {root}: {exc}")
-            continue
     return False
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agents_coverage.py
+++ b/tests/test_agents_coverage.py
@@ -58,6 +58,18 @@ class TestStudioEndpointTarget(unittest.TestCase):
         self.assertEqual(result, target.as_posix())
         self.assertIn("outside project root", "\n".join(captured.output))
 
+    def test_target_path_project_fallback_is_quiet(self):
+        from studio.commands.agents import _target_path_from_root
+
+        with TemporaryDirectory() as td:
+            project_root = Path(td) / "project"
+            studio_root = project_root / ".cf-studio"
+            target = project_root / "workflows" / "example.md"
+            with self.assertNoLogs("studio.commands.agents", level="WARNING"):
+                result = _target_path_from_root(target, project_root, studio_root)
+
+        self.assertEqual(result, "@/workflows/example.md")
+
     def test_registered_legacy_studio_path_allows_parent_traversal_within_project(self):
         from studio.commands.agents import _resolve_registered_legacy_studio_path
 
@@ -129,6 +141,49 @@ class TestStudioEndpointTarget(unittest.TestCase):
             )
 
         self.assertIsNone(resolved)
+
+    def test_registered_kit_path_warns_once_after_all_fallbacks_escape(self):
+        from studio.commands.agents import _resolve_registered_kit_path
+
+        with TemporaryDirectory() as td:
+            project_root = Path(td) / "project"
+            studio_root = project_root / ".cf-studio"
+            studio_root.mkdir(parents=True)
+            with self.assertLogs("studio.commands.agents", level="WARNING") as captured:
+                resolved = _resolve_registered_kit_path(
+                    project_root,
+                    studio_root,
+                    "demo",
+                    {"path": "../../escape"},
+                )
+
+        self.assertIsNone(resolved)
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn("registered kit path escapes project root", captured.output[0])
+
+    def test_path_within_any_root_accepts_later_root_quietly(self):
+        from studio.commands.agents import _path_within_any_root
+
+        with TemporaryDirectory() as td:
+            project_root = Path(td) / "project"
+            studio_root = project_root / ".cf-studio"
+            target = project_root / "workflows" / "example.md"
+            with self.assertNoLogs("studio.commands.agents", level="WARNING"):
+                accepted = _path_within_any_root(target, (studio_root, project_root))
+
+        self.assertTrue(accepted)
+
+    def test_path_within_any_root_rejects_when_no_root_matches(self):
+        from studio.commands.agents import _path_within_any_root
+
+        with TemporaryDirectory() as td:
+            project_root = Path(td) / "project"
+            studio_root = project_root / ".cf-studio"
+            target = Path(td) / "outside" / "example.md"
+            with self.assertNoLogs("studio.commands.agents", level="WARNING"):
+                accepted = _path_within_any_root(target, (studio_root, project_root))
+
+        self.assertFalse(accepted)
 
     def test_registered_kit_path_prefers_legacy_studio_fallback(self):
         from studio.commands.agents import _resolve_registered_kit_path
@@ -949,14 +1004,15 @@ class TestCanonicalKitPublicComponentGeneration(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            result = _process_single_agent(
-                "cursor",
-                root,
-                studio_root,
-                _default_agents_config(),
-                None,
-                dry_run=False,
-            )
+            with self.assertNoLogs("studio.commands.agents", level="WARNING"):
+                result = _process_single_agent(
+                    "cursor",
+                    root,
+                    studio_root,
+                    _default_agents_config(),
+                    None,
+                    dry_run=False,
+                )
 
             self.assertEqual(result["status"], "PASS")
             generated_skill = root / ".agents" / "skills" / "cf-gears-doc-prd" / "SKILL.md"
@@ -1177,6 +1233,7 @@ class TestCanonicalKitPublicComponentGeneration(unittest.TestCase):
                 f"kit 'pubkit' public skill source escapes project/studio root: {outside_skill.resolve()}, skipping",
                 "\n".join(captured.output),
             )
+            self.assertEqual(len(captured.output), 1)
 
     def test_list_public_components_skips_unresolvable_source(self):
         from studio.commands.agents import _list_public_components


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation during agent and kit integration generation.
  * Added clearer warnings when configured paths fall outside the project or approved resource locations.
  * Improved handling of portable project-relative paths, including safe fallback behavior.
  * Prevented invalid paths from being silently accepted or ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->