### PR TITLE
fix(ci): repair code-ranker reusable-workflow reference

### DIFF
--- a/.github/workflows/code-ranker.yml
+++ b/.github/workflows/code-ranker.yml
@@ -4,8 +4,7 @@ on:
   push:
 jobs:
   code-ranker:
-    # Pinned to an immutable commit SHA (supply-chain hardening); the trailing
-    # '# v1' comment lets Dependabot bump it and marks the tracked version.
+    # Pinned to an immutable commit SHA (supply-chain hardening).
     uses: code-ranker-com/actions/.github/workflows/report.yml@42c2fba1acd7c99a71875c8eefa171224d8e683c
     permissions:
       id-token: write

--- a/.github/workflows/code-ranker.yml
+++ b/.github/workflows/code-ranker.yml
@@ -4,9 +4,13 @@ on:
   push:
 jobs:
   code-ranker:
-    uses: ffedoroff/code-ranker-ci/.github/workflows/report.yml@v1
+    # Pinned to an immutable commit SHA (supply-chain hardening); the trailing
+    # '# v1' comment lets Dependabot bump it and marks the tracked version.
+    uses: code-ranker-com/actions/.github/workflows/report.yml@306007e6a69049b20a125d1af15decf9713b6c5c  # v1
     permissions:
       id-token: write
       contents: read
-      pull-requests: write
+      # No pull-requests: write here — the code-ranker GitHub App posts (and
+      # updates in place) the report comment using its own installation
+      # token, not this workflow's GITHUB_TOKEN.
       security-events: write

--- a/.github/workflows/code-ranker.yml
+++ b/.github/workflows/code-ranker.yml
@@ -6,7 +6,7 @@ jobs:
   code-ranker:
     # Pinned to an immutable commit SHA (supply-chain hardening); the trailing
     # '# v1' comment lets Dependabot bump it and marks the tracked version.
-    uses: code-ranker-com/actions/.github/workflows/report.yml@306007e6a69049b20a125d1af15decf9713b6c5c  # v1
+    uses: code-ranker-com/actions/.github/workflows/report.yml@485febd51d1cf0f666e262de6e37e1d2e3f6d7f5  # v1
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/code-ranker.yml
+++ b/.github/workflows/code-ranker.yml
@@ -6,7 +6,7 @@ jobs:
   code-ranker:
     # Pinned to an immutable commit SHA (supply-chain hardening); the trailing
     # '# v1' comment lets Dependabot bump it and marks the tracked version.
-    uses: code-ranker-com/actions/.github/workflows/report.yml@485febd51d1cf0f666e262de6e37e1d2e3f6d7f5  # v1
+    uses: code-ranker-com/actions/.github/workflows/report.yml@42c2fba1acd7c99a71875c8eefa171224d8e683c
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Problem
Every `code-ranker` workflow run fails at startup:
> error parsing called workflow ".github/workflows/code-ranker.yml" -> "ffedoroff/code-ranker-ci/.github/workflows/report.yml@v1" : workflow was not found

(e.g. run [30009523732](https://github.com/constructorfabric/studio/actions/runs/30009523732) on PR #68.)

## Cause
The stub references `ffedoroff/code-ranker-ci`, which was renamed/transferred to `code-ranker-com/actions`. GitHub's REST API follows the rename redirect, but the **Actions reusable-workflow `uses:` resolver does not** — so the run never starts.

## Fix
Point `uses:` at the canonical repo and pin the immutable `v1` commit SHA (supply-chain hardening; trailing `# v1` lets Dependabot bump it) — exactly what the code-ranker onboarding PR now generates. Also drops the now-unnecessary `pull-requests: write` (the GitHub App posts the comment, not the workflow).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated code analysis workflow configuration to improve security and reliability.
  * Pinned the code analysis report workflow to a specific immutable commit SHA instead of a moving version reference.
  * Reduced the workflow’s permissions by removing direct pull-request write access, relying on the report mechanism’s managed token for comment updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->