### PR TITLE
Add local decision/outcome log writer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -564,6 +564,11 @@ coverage.xml
 .cypilot/
 **/.cache/explain/
 
+# Local decision/outcome log (decision_log.py) — per-user runtime state, never committed
+**/.cache/decisions.jsonl
+**/.cache/decisions.jsonl.1
+**/.cache/decisions.jsonl.lock
+
 # Superpowers brainstorming/planning specs (local-only)
 docs/superpowers/
 

--- a/architecture/features/core-infra.md
+++ b/architecture/features/core-infra.md
@@ -32,6 +32,7 @@
   - [Registry Parsing](#registry-parsing)
   - [Context Loading](#context-loading)
   - [Mirror Override](#mirror-override)
+  - [Decision Log](#decision-log)
 - [4. States (CDSL)](#4-states-cdsl)
   - [Project Installation State](#project-installation-state)
 - [5. Definitions of Done](#5-definitions-of-done)
@@ -692,6 +693,22 @@ Enables users to install Studio globally, initialize it in any project with sens
 - [x] - `p1` - `_load_overrides`: merge XDG and brand-home entries; brand-home wins on duplicate `from` - `inst-mirror-merge-overrides`
 - [x] - `p1` - `apply_override`: apply all registered overrides as substring replacements to a URL - `inst-mirror-apply-override`
 
+### Decision Log
+
+- [x] `p1` - **ID**: `cpt-studio-algo-core-infra-decision-log`
+
+**Input**: A decision event (type + payload) emitted by an engine command
+
+**Output**: One appended JSONL line in the local decision log, or a silent no-op
+
+1. [x] - `p1` - Generate a decision id used to chain the events of one decision - `inst-log-id`
+2. [x] - `p1` - Resolve the log location (env override, else project `.cache/decisions.jsonl`, else no-op) and the persistent opt-out sentinel path - `inst-log-locate`
+3. [x] - `p1` - Report whether logging is enabled — an env off-value or the sentinel file disables it - `inst-log-enabled`
+4. [x] - `p1` - Redact `$HOME` to `~` recursively so no username is recorded - `inst-log-redact`
+5. [x] - `p1` - Append one schema-versioned event (run_id, decision_id, event, command, payload); never raise into the caller; rotate by size; show a one-time notice - `inst-log-record`
+6. [x] - `p1` - Typed record helpers — routing, dispatch, validation, review, escalation, and command invocation (exit code, duration, arg-shape) — that call the writer - `inst-log-api`
+7. [x] - `p1` - Read events back oldest-first (skipping unparseable lines) and summarise counts by event and run - `inst-log-read`
+
 ## 4. States (CDSL)
 
 ### Project Installation State
@@ -932,6 +949,7 @@ See ADR-0020 (`architecture/ADR/0020-cpt-studio-adr-rebrand-and-mirror-override-
 | TOML Utilities | `skills/.../utils/toml_utils.py` | TOML reading/writing, markdown TOML extraction |
 | Artifacts Meta | `skills/.../utils/artifacts_meta.py` | Artifacts registry parsing, autodetect expansion |
 | Mirror Override | `src/studio_proxy/mirrors.py` | URL override load/apply/set/remove/list; dual-location config; canonicalization |
+| Decision Log | `skills/.../utils/decision_log.py` | Local-only JSONL decision/outcome log: locate/opt-out, redact, append (never fatal), rotate, read/summarize |
 
 ## 7. Acceptance Criteria
 

--- a/skills/studio/scripts/studio/utils/decision_log.py
+++ b/skills/studio/scripts/studio/utils/decision_log.py
@@ -1,0 +1,408 @@
+"""Local decision/outcome log — a private JSONL record of what the engine decided.
+
+This is **not** the proxy's ``telemetry.py`` (which records a command name plus git
+identity and sends them to a remote endpoint). This module is deliberately the
+opposite on every axis that matters:
+
+  * **Local only.** It writes one JSONL file inside the project's studio ``.cache/``
+    directory. There is no network code here and no new remote surface.
+  * **Never fatal.** Every failure path degrades to "no line written" and returns
+    normally. Instrumentation must never change what a command does or its exit code.
+  * **Opt-out honoured.** Disabled by an environment variable or a persistent
+    sentinel file (see :func:`is_enabled`).
+  * **No project, no log.** Outside a Constructor Studio project there is nowhere to
+    write, so the writer is a clean no-op rather than an error.
+  * **Decisions, not content.** It records *what was decided* (intent, tier, verdict),
+    never artifact or source text, and collapses ``$HOME`` to ``~`` so a log is safe to
+    paste into a bug report.
+  * **stdlib only.**
+
+Schema — one JSON object per line, newline-terminated::
+
+    {
+      "schema":      1,                                  # bump on incompatible change
+      "ts":          "2026-08-12T09:34:12.123456+00:00", # UTC, ISO-8601
+      "run_id":      "9b7953324c12",                     # one CLI invocation
+      "decision_id": "1f2e3d4c5b6a7182",                 # chains the events of one decision
+      "event":       "validation",                       # see EVENTS
+      "command":     "validate",                         # command name, never raw argv
+      "payload":     {...}                               # event-specific; keys optional
+    }
+
+Readers must ignore unknown event names and unknown payload keys so that newer
+instrumentation never breaks an older reader.
+
+@cpt-algo:cpt-studio-algo-core-infra-decision-log:p1
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+#: Event names this module writes. Readers must tolerate others.
+EVENTS = ("routing", "dispatch", "validation", "review", "escalation", "invocation")
+
+#: Environment overrides.
+_ENV_PATH = "CFS_DECISION_LOG"          # explicit path, or an off-value to disable
+_OFF_VALUES = {"0", "off", "no", "none", "false", "disabled"}
+
+_BRAND_DIR = ".cf-studio"               # per-user home dir for the opt-out sentinel
+_OPT_OUT_SENTINEL = "decisions.off"
+_CACHE_SUBDIR = ".cache"
+_LOG_NAME = "decisions.jsonl"
+
+#: Rotate once the log passes this size, keeping a single ``.1`` backup.
+_MAX_BYTES = 5 * 1024 * 1024
+
+#: Fixed for the life of the process, so every event of one invocation shares it.
+_RUN_ID = uuid.uuid4().hex[:12]
+
+#: Guards the one-time transparency notice.
+_NOTICE_SHOWN = False
+
+
+# ---------------------------------------------------------------------------
+# Correlation
+# ---------------------------------------------------------------------------
+# @cpt-begin:cpt-studio-algo-core-infra-decision-log:p1:inst-log-id
+def new_decision_id() -> str:
+    """Return a fresh id used to chain the events (routing → dispatch → …) of one decision."""
+    return uuid.uuid4().hex[:16]
+# @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-id
+
+
+# ---------------------------------------------------------------------------
+# Location and opt-out
+# ---------------------------------------------------------------------------
+# @cpt-begin:cpt-studio-algo-core-infra-decision-log:p1:inst-log-locate
+def _brand_dir() -> Path:
+    return Path.home() / _BRAND_DIR
+
+
+def opt_out_sentinel_path() -> Path:
+    """Return the path whose existence disables logging permanently for this user."""
+    return _brand_dir() / _OPT_OUT_SENTINEL
+
+
+def default_log_path() -> Optional[Path]:
+    """Resolve the log location, or ``None`` when there is nowhere to write.
+
+    Order:
+      1. ``$CFS_DECISION_LOG`` if it names a path (an off-value there disables logging).
+      2. ``<studio-dir>/.cache/decisions.jsonl`` for the project containing the cwd.
+      3. ``None`` — outside a project, so the writer no-ops.
+    """
+    override = os.environ.get(_ENV_PATH, "").strip()
+    if override and override.lower() not in _OFF_VALUES:
+        return Path(override).expanduser()
+
+    try:
+        from .files import find_studio_directory
+        studio_dir = find_studio_directory(Path.cwd())
+    except Exception:  # pylint: disable=broad-except
+        studio_dir = None
+    if studio_dir is None:
+        return None
+    return studio_dir / _CACHE_SUBDIR / _LOG_NAME
+# @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-locate
+
+
+# @cpt-begin:cpt-studio-algo-core-infra-decision-log:p1:inst-log-enabled
+def is_enabled() -> bool:
+    """Report whether decision logging is active.
+
+    Disabled by any of: ``$CFS_DECISION_LOG`` set to an off-value; the sentinel file
+    ``~/.cf-studio/decisions.off`` existing. The sentinel lets an opt-out survive a new
+    shell without remembering an environment variable.
+    """
+    raw = os.environ.get(_ENV_PATH)
+    if raw is not None and raw.strip().lower() in _OFF_VALUES:
+        return False
+    try:
+        if opt_out_sentinel_path().exists():
+            return False
+    except OSError as exc:
+        # An unreadable home directory is not a reason to fail a command.
+        logger.debug("decision log opt-out check skipped: %s", exc)
+        return False
+    return True
+# @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-enabled
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+# @cpt-begin:cpt-studio-algo-core-infra-decision-log:p1:inst-log-redact
+def _redact(value: Any) -> Any:
+    """Collapse absolute paths under ``$HOME`` to ``~/…`` form, recursively.
+
+    The log records decisions, never artifact or source content. Removing the home
+    prefix keeps a username out of a file a user may paste into a bug report.
+    """
+    if isinstance(value, str):
+        try:
+            home = str(Path.home())
+        except (OSError, RuntimeError):
+            return value
+        return value.replace(home, "~") if home and home in value else value
+    if isinstance(value, dict):
+        return {_redact(k): _redact(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_redact(v) for v in value]
+    return value
+# @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-redact
+
+
+# ---------------------------------------------------------------------------
+# Writing
+# ---------------------------------------------------------------------------
+# @cpt-begin:cpt-studio-algo-core-infra-decision-log:p1:inst-log-record
+def _show_notice_once(path: Path) -> None:
+    """Tell the user once, on stderr, that a local log was started."""
+    global _NOTICE_SHOWN  # pylint: disable=global-statement
+    if _NOTICE_SHOWN:
+        return
+    _NOTICE_SHOWN = True
+    logger.warning(
+        "Constructor Studio is recording its decisions to a local log:\n"
+        "  %s\n"
+        "  Nothing is sent anywhere. Turn it off with %s=off, or permanently: touch %s",
+        _redact(str(path)), _ENV_PATH, _redact(str(opt_out_sentinel_path())),
+    )
+
+
+def _rotate_if_large(path: Path) -> None:
+    """Keep a single ``.1`` backup once the log passes ``_MAX_BYTES``. Best-effort."""
+    try:
+        if path.exists() and path.stat().st_size >= _MAX_BYTES:
+            backup = path.with_name(path.name + ".1")
+            os.replace(path, backup)
+    except OSError as exc:
+        # Rotation is a convenience; failing it must not stop a write attempt.
+        logger.debug("decision log rotation skipped: %s", exc)
+
+
+def _append_locked(target: Path, line: str) -> None:
+    """Append one line, serialising rotation + write across processes where possible.
+
+    Two concurrent invocations can both observe an oversized log; without a lock, one
+    could rotate the file the other is mid-write on, dropping events. Where ``fcntl`` is
+    available (POSIX) an exclusive advisory lock on a sibling ``.lock`` file serialises
+    the rotate-then-append; elsewhere it degrades to a best-effort unlocked append.
+    """
+    try:
+        import fcntl  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        fcntl = None
+    if fcntl is None:
+        _rotate_if_large(target)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        return
+    with open(target.with_name(target.name + ".lock"), "a", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        _rotate_if_large(target)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        # The exclusive lock is released when lock_fh closes.
+
+
+def record(
+    event: str,
+    payload: Optional[Dict[str, Any]] = None,
+    *,
+    command: str = "",
+    decision_id: str = "",
+    path: Optional[Path] = None,
+) -> bool:
+    """Append one event to the decision log.
+
+    Returns ``True`` when a line was written, ``False`` otherwise (disabled, no project,
+    or an unwritable/unserialisable record). **Never raises** — callers are
+    instrumentation, so a failure here must not change what the command does.
+    """
+    try:
+        if not is_enabled():
+            return False
+        target = path or default_log_path()
+        if target is None:
+            return False
+        is_new = not target.exists()
+        record_obj = {
+            "schema": SCHEMA_VERSION,
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "run_id": _RUN_ID,
+            "decision_id": decision_id,
+            "event": event,
+            "command": _redact(command),
+            "payload": _redact(payload or {}),
+        }
+        line = json.dumps(record_obj, ensure_ascii=False, default=str)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        _append_locked(target, line)
+        if is_new:
+            _show_notice_once(target)
+        return True
+    except Exception as exc:  # pylint: disable=broad-except
+        # Deliberately broad: instrumentation must degrade to silence.
+        logger.debug("decision log write skipped: %s", exc)
+        return False
+# @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-record
+
+
+# Thin wrappers so call sites read as intent, and a schema change lands in one place.
+
+# @cpt-begin:cpt-studio-algo-core-infra-decision-log:p1:inst-log-api
+def record_routing(intent: str, candidates: List[str], selected: str,
+                    reason: str = "", *, command: str = "", decision_id: str = "",
+                    path: Optional[Path] = None) -> bool:
+    """Log which candidate a routing decision chose, and why."""
+    return record("routing", {
+        "intent": intent, "candidates": list(candidates),
+        "selected": selected, "reason": reason,
+    }, command=command, decision_id=decision_id, path=path)
+
+
+def record_dispatch(agent: str, tier: str = "", model: str = "", provider: str = "",
+                    target: str = "", *, command: str = "", decision_id: str = "",
+                    path: Optional[Path] = None) -> bool:
+    """Log the tier and concrete model a dispatch resolved to."""
+    return record("dispatch", {
+        "agent": agent, "tier": tier, "model": model,
+        "provider": provider, "target": target,
+    }, command=command, decision_id=decision_id, path=path)
+
+
+def record_validation(check: str, status: str, findings: int = 0,
+                      rules: Optional[Dict[str, int]] = None, *,
+                      command: str = "", decision_id: str = "",
+                    path: Optional[Path] = None) -> bool:
+    """Log a validator verdict and its finding counts."""
+    return record("validation", {
+        "check": check, "status": status,
+        "findings": findings, "rules": dict(rules or {}),
+    }, command=command, decision_id=decision_id, path=path)
+
+
+def record_review(subject: str, decision: str, actor: str = "human", *,
+                  command: str = "", decision_id: str = "",
+                    path: Optional[Path] = None) -> bool:
+    """Log a human accept/reject on generated output."""
+    return record("review", {
+        "subject": subject, "decision": decision, "actor": actor,
+    }, command=command, decision_id=decision_id, path=path)
+
+
+def record_escalation(from_tier: str, to_tier: str, reason: str = "", *,
+                      command: str = "", decision_id: str = "",
+                    path: Optional[Path] = None) -> bool:
+    """Log a move to a more capable/expensive tier."""
+    return record("escalation", {
+        "from_tier": from_tier, "to_tier": to_tier, "reason": reason,
+    }, command=command, decision_id=decision_id, path=path)
+
+
+def record_invocation(command: str, exit_code: int = 0, duration_ms: int = 0,
+                      args_shape: Optional[Dict[str, Any]] = None, *,
+                      decision_id: str = "", path: Optional[Path] = None) -> bool:
+    """Log a command invocation: exit code, duration, and an argument *shape* summary.
+
+    ``args_shape`` is a pre-summarised description of the arguments (counts / kinds),
+    never the raw argv — some commands take paths or user data.
+    """
+    return record("invocation", {
+        "exit_code": exit_code, "duration_ms": duration_ms,
+        "args": dict(args_shape or {}),
+    }, command=command, decision_id=decision_id, path=path)
+# @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-api
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+# @cpt-begin:cpt-studio-algo-core-infra-decision-log:p1:inst-log-read
+def read_events(path: Optional[Path] = None, *, event: str = "",
+                run_id: str = "", decision_id: str = "",
+                limit: int = 0) -> Iterator[Dict[str, Any]]:
+    """Yield events oldest-first, skipping any line that will not parse.
+
+    A truncated or hand-edited log stays readable: a bad line is dropped, not raised,
+    because a partially corrupt log is still evidence.
+    """
+    target = path or default_log_path()
+    if target is None:
+        return
+    try:
+        if not target.is_file():
+            return
+        with target.open("r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except OSError as exc:
+        logger.debug("decision log unreadable: %s", exc)
+        return
+
+    matched: List[Dict[str, Any]] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError) as exc:
+            logger.debug("decision log: skipping unparseable line: %s", exc)
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if event and obj.get("event") != event:
+            continue
+        if run_id and obj.get("run_id") != run_id:
+            continue
+        if decision_id and obj.get("decision_id") != decision_id:
+            continue
+        matched.append(obj)
+
+    if limit > 0:
+        matched = matched[-limit:]
+    yield from matched
+
+
+def summarize(path: Optional[Path] = None) -> Dict[str, Any]:
+    """Count events by type and by run — a small read view over the log."""
+    counts: Dict[str, int] = {}
+    runs: Dict[str, int] = {}
+    total = 0
+    first_ts = ""
+    last_ts = ""
+    for obj in read_events(path):
+        total += 1
+        name = str(obj.get("event", "?"))
+        counts[name] = counts.get(name, 0) + 1
+        run = str(obj.get("run_id", "?"))
+        runs[run] = runs.get(run, 0) + 1
+        ts = str(obj.get("ts", ""))
+        if ts:
+            first_ts = first_ts or ts
+            last_ts = ts
+    target = path or default_log_path()
+    return {
+        "path": _redact(str(target)) if target else None,
+        "exists": bool(target and target.is_file()),
+        "enabled": is_enabled(),
+        "schema": SCHEMA_VERSION,
+        "total_events": total,
+        "event_counts": counts,
+        "runs": len(runs),
+        "first_ts": first_ts,
+        "last_ts": last_ts,
+    }
+# @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-read

--- a/skills/studio/scripts/studio/utils/decision_log.py
+++ b/skills/studio/scripts/studio/utils/decision_log.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -151,10 +152,14 @@ def _redact(value: Any) -> Any:
     """
     if isinstance(value, str):
         try:
-            home = str(Path.home())
+            home = str(Path.home()).rstrip(os.sep)
         except (OSError, RuntimeError):
             return value
-        return value.replace(home, "~") if home and home in value else value
+        if not home:
+            return value
+        # Substitute $HOME only at a path boundary (separator or end-of-string), so a
+        # sibling like ``/Users/maxine`` is never mangled into ``~ine`` for home ``/Users/max``.
+        return re.sub(re.escape(home) + r"(?=" + re.escape(os.sep) + r"|$)", "~", value)
     if isinstance(value, dict):
         return {_redact(k): _redact(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):

--- a/tests/test_decision_log.py
+++ b/tests/test_decision_log.py
@@ -175,3 +175,121 @@ def test_record_invocation_shape(log_path: Path) -> None:
     assert ev["payload"]["exit_code"] == 2
     assert ev["payload"]["duration_ms"] == 42
     assert ev["payload"]["args"] == {"paths": 1}      # arg-shape summary, never raw argv
+
+
+# ---------------------------------------------------------------------------
+# path resolution
+
+def test_env_override_sets_log_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "custom.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(target))
+    assert dl.default_log_path() == target
+
+
+def test_default_path_in_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CFS_DECISION_LOG", raising=False)
+    monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+    assert dl.default_log_path() == tmp_path / ".cache" / "decisions.jsonl"
+
+
+def test_default_path_survives_locator_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CFS_DECISION_LOG", raising=False)
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("no working directory")
+
+    monkeypatch.setattr("studio.utils.files.find_studio_directory", _boom)
+    assert dl.default_log_path() is None          # locator error → no project, no raise
+
+
+# ---------------------------------------------------------------------------
+# fail-safe opt-out / redaction branches
+
+def test_is_enabled_survives_unreadable_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CFS_DECISION_LOG", raising=False)
+
+    class _Unreadable:
+        def exists(self):
+            raise OSError("home directory unreadable")
+
+    monkeypatch.setattr(dl, "opt_out_sentinel_path", lambda: _Unreadable())
+    assert dl.is_enabled() is False               # can't check opt-out → stay disabled, don't crash
+
+
+def test_redact_survives_missing_home(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom():
+        raise RuntimeError("no home directory")
+
+    monkeypatch.setattr(Path, "home", _boom)
+    assert dl._redact("/some/absolute/path") == "/some/absolute/path"   # returned unchanged, no raise
+
+
+def test_rotation_failure_is_swallowed(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dl, "_MAX_BYTES", 50)
+    dl.record("routing", {"pad": "x" * 80}, path=log_path)     # push the log over the limit
+
+    def _boom(*_a, **_k):
+        raise OSError("cannot rename")
+
+    monkeypatch.setattr(dl.os, "replace", _boom)
+    assert dl.record("routing", {"i": 1}, path=log_path) is True   # rotation fails, write still proceeds
+
+
+def test_append_without_fcntl_still_writes(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_fcntl(name, *a, **k):
+        if name == "fcntl":
+            raise ImportError("fcntl unavailable on this platform")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _no_fcntl)
+    assert dl.record("routing", {"x": 1}, path=log_path) is True    # unlocked fallback path
+    assert len(list(dl.read_events(log_path))) == 1
+
+
+# ---------------------------------------------------------------------------
+# read_events branches
+
+def test_read_events_no_project_yields_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CFS_DECISION_LOG", raising=False)
+    monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: None)
+    assert list(dl.read_events()) == []
+
+
+def test_read_events_missing_file_yields_nothing(tmp_path: Path) -> None:
+    assert list(dl.read_events(tmp_path / "absent.jsonl")) == []
+
+
+def test_read_events_unreadable_file_yields_nothing(log_path: Path,
+                                                    monkeypatch: pytest.MonkeyPatch) -> None:
+    dl.record("routing", {"a": 1}, path=log_path)
+    real_open = Path.open
+
+    def _boom(self, *a, **k):
+        if self == log_path:
+            raise OSError("permission denied")
+        return real_open(self, *a, **k)
+
+    monkeypatch.setattr(Path, "open", _boom)
+    assert list(dl.read_events(log_path)) == []      # unreadable log → empty, not a raise
+
+
+def test_read_events_skips_non_dict_json(log_path: Path) -> None:
+    dl.record("routing", {"a": 1}, path=log_path)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write("123\n[1, 2]\n")                     # valid JSON, but not event objects
+    events = list(dl.read_events(log_path))
+    assert len(events) == 1
+    assert events[0]["event"] == "routing"
+
+
+def test_read_events_filters_and_limit(log_path: Path) -> None:
+    dl.record("routing", {"a": 1}, path=log_path)
+    dl.record("validation", {"status": "PASS"}, path=log_path)
+    dl.record("routing", {"a": 2}, path=log_path)
+    assert [e["payload"]["a"] for e in dl.read_events(log_path, event="routing")] == [1, 2]
+    assert list(dl.read_events(log_path, run_id="does-not-exist")) == []
+    assert len(list(dl.read_events(log_path, limit=1))) == 1

--- a/tests/test_decision_log.py
+++ b/tests/test_decision_log.py
@@ -1,0 +1,177 @@
+"""Tests for the local decision/outcome log (``studio.utils.decision_log``).
+
+Covers the rigor the design note calls for: local-only (no socket), opt-out silences
+everything, fail-safe (never raises), no-project no-op, rotation, redaction, and the
+decision_id correlation that chains one decision's events.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from studio.utils import decision_log as dl
+
+
+@pytest.fixture
+def log_path(tmp_path: Path) -> Path:
+    return tmp_path / ".cache" / "decisions.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# writing + reading
+
+def test_record_writes_one_wellformed_line(log_path: Path) -> None:
+    assert dl.record("validation", {"check": "toc", "status": "PASS"},
+                     command="validate", path=log_path) is True
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    obj = json.loads(lines[0])
+    assert obj["schema"] == dl.SCHEMA_VERSION
+    assert obj["event"] == "validation"
+    assert obj["command"] == "validate"
+    assert obj["run_id"]                      # non-empty
+    assert obj["payload"]["status"] == "PASS"
+    assert "ts" in obj
+
+
+def test_append_never_truncates(log_path: Path) -> None:
+    for i in range(3):
+        dl.record("routing", {"i": i}, path=log_path)
+    assert len(log_path.read_text().splitlines()) == 3
+
+
+def test_read_events_and_summarize_roundtrip(log_path: Path) -> None:
+    dl.record("routing", {"a": 1}, path=log_path)
+    dl.record("validation", {"status": "FAIL"}, path=log_path)
+    events = list(dl.read_events(log_path))
+    assert [e["event"] for e in events] == ["routing", "validation"]
+    summary = dl.summarize(log_path)
+    assert summary["total_events"] == 2
+    assert summary["event_counts"] == {"routing": 1, "validation": 1}
+
+
+def test_read_events_skips_corrupt_lines(log_path: Path) -> None:
+    dl.record("routing", {"a": 1}, path=log_path)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write("this is not json\n\n")
+    dl.record("routing", {"a": 2}, path=log_path)
+    assert len(list(dl.read_events(log_path))) == 2   # the junk line is dropped, not raised
+
+
+# ---------------------------------------------------------------------------
+# decision_id correlation
+
+def test_decision_id_chains_and_filters(log_path: Path) -> None:
+    did = dl.new_decision_id()
+    dl.record_routing("gen", ["a", "b"], "a", decision_id=did, path=log_path)
+    dl.record_dispatch("author", tier="cheap", decision_id=did, path=log_path)
+    dl.record("routing", {"other": True}, decision_id="zzz", path=log_path)
+    chained = list(dl.read_events(log_path, decision_id=did))
+    assert len(chained) == 2
+    assert {e["event"] for e in chained} == {"routing", "dispatch"}
+
+
+# ---------------------------------------------------------------------------
+# opt-out
+
+def test_env_off_writes_nothing(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CFS_DECISION_LOG", "off")
+    assert dl.is_enabled() is False
+    assert dl.record("routing", {}, path=log_path) is False
+    assert not log_path.exists()
+
+
+def test_sentinel_file_disables(tmp_path: Path, log_path: Path,
+                                monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CFS_DECISION_LOG", raising=False)
+    brand = tmp_path / ".cf-studio"
+    brand.mkdir()
+    (brand / "decisions.off").write_text("")
+    monkeypatch.setattr(dl, "_brand_dir", lambda: brand)
+    assert dl.is_enabled() is False
+    assert dl.record("routing", {}, path=log_path) is False
+
+
+# ---------------------------------------------------------------------------
+# no-project no-op
+
+def test_no_project_is_a_noop_not_an_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CFS_DECISION_LOG", raising=False)
+    monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: None)
+    assert dl.default_log_path() is None
+    assert dl.record("routing", {}) is False          # returns, does not raise
+
+
+# ---------------------------------------------------------------------------
+# fail-safe + local-only
+
+def test_record_never_raises_on_bad_target(tmp_path: Path) -> None:
+    # Point the path at a directory: opening it for append fails — must degrade to False.
+    bad = tmp_path / "adir"
+    bad.mkdir()
+    assert dl.record("routing", {}, path=bad) is False
+
+
+def test_record_opens_no_socket(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import socket
+
+    def _boom(*_a, **_k):  # any socket construction is a failure for this module
+        raise AssertionError("decision_log must not open a network socket")
+
+    monkeypatch.setattr(socket, "socket", _boom)
+    assert dl.record_validation("toc", "PASS", path=log_path) is True   # still writes, no socket
+
+
+# ---------------------------------------------------------------------------
+# redaction
+
+def test_home_path_is_redacted(log_path: Path) -> None:
+    home = str(Path.home())
+    # $HOME must be redacted in payload values, payload keys, AND the command field.
+    dl.record("dispatch", {f"{home}/k": f"{home}/project/x.md"},
+              command=f"run {home}/x", path=log_path)
+    obj = json.loads(log_path.read_text().splitlines()[0])
+    assert obj["payload"]["~/k"].startswith("~/")
+    assert obj["command"] == "run ~/x"
+    assert home not in json.dumps(obj)
+
+
+# ---------------------------------------------------------------------------
+# rotation
+
+def test_rotation_keeps_single_backup(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dl, "_MAX_BYTES", 200)
+    for i in range(50):
+        dl.record("routing", {"pad": "x" * 20, "i": i}, path=log_path)
+    assert log_path.exists()
+    assert log_path.with_name("decisions.jsonl.1").exists()   # rotated backup present
+
+
+# ---------------------------------------------------------------------------
+# wrappers
+
+def test_wrappers_emit_expected_shapes(log_path: Path) -> None:
+    dl.record_routing("gen", ["a", "b"], "b", "why", path=log_path)
+    dl.record_dispatch("author", tier="std", model="m", path=log_path)
+    dl.record_validation("toc", "FAIL", findings=3, rules={"E1": 3}, path=log_path)
+    dl.record_review("PRD", "accept", path=log_path)
+    dl.record_escalation("cheap", "std", "hard", path=log_path)
+    events = {e["event"]: e["payload"] for e in dl.read_events(log_path)}
+    assert set(events) == {"routing", "dispatch", "validation", "review", "escalation"}
+    assert events["routing"]["selected"] == "b"
+    assert events["validation"]["findings"] == 3
+    assert events["review"]["decision"] == "accept"
+    assert events["escalation"]["to_tier"] == "std"
+
+
+def test_record_invocation_shape(log_path: Path) -> None:
+    dl.record_invocation("validate", exit_code=2, duration_ms=42,
+                         args_shape={"paths": 1}, path=log_path)
+    ev = next(iter(dl.read_events(log_path, event="invocation")))
+    assert ev["command"] == "validate"
+    assert ev["payload"]["exit_code"] == 2
+    assert ev["payload"]["duration_ms"] == 42
+    assert ev["payload"]["args"] == {"paths": 1}      # arg-shape summary, never raw argv

--- a/tests/test_decision_log.py
+++ b/tests/test_decision_log.py
@@ -224,6 +224,17 @@ def test_redact_survives_missing_home(monkeypatch: pytest.MonkeyPatch) -> None:
     assert dl._redact("/some/absolute/path") == "/some/absolute/path"   # returned unchanged, no raise
 
 
+def test_redact_respects_home_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    # $HOME is only collapsed at a path boundary — a sibling dir must not be mangled.
+    monkeypatch.setattr(Path, "home", lambda: Path("/Users/max"))
+    assert dl._redact("/Users/maxine/x") == "/Users/maxine/x"   # sibling untouched (not "~ine/x")
+    assert dl._redact("/Users/max/x") == "~/x"                  # real home redacted
+    assert dl._redact("/Users/max") == "~"                      # bare home
+    assert dl._redact("run /Users/max/x") == "run ~/x"          # mid-string, at boundary
+    monkeypatch.setattr(Path, "home", lambda: Path("/"))
+    assert dl._redact("/Users/max/x") == "/Users/max/x"         # root home -> no-op (never redact "/")
+
+
 def test_rotation_failure_is_swallowed(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dl, "_MAX_BYTES", 50)
     dl.record("routing", {"pad": "x" * 80}, path=log_path)     # push the log over the limit

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -39,3 +39,29 @@ from studio.commands.map.categorize import OverrideCategory  # noqa: E402
 MAX_ROW_W  # documented packing cap, retained for future tuning
 _oc = OverrideCategory(name="", paths=[], color=None, background=None)
 _oc.background  # set by md-map.toml [categories.<name>.style] entries
+
+# decision_log public API — the recorder entrypoints, correlation id, and read view.
+# Wired by the forthcoming command instrumentation (dispatch wrapper) and called by
+# log consumers; not yet reached from production paths. Exercised by tests.
+# See skills/studio/scripts/studio/utils/decision_log.py.
+from studio.utils.decision_log import (  # noqa: E402
+    EVENTS,
+    new_decision_id,
+    record_routing,
+    record_dispatch,
+    record_validation,
+    record_review,
+    record_escalation,
+    record_invocation,
+    summarize,
+)
+
+EVENTS  # noqa: B018
+new_decision_id  # noqa: B018
+record_routing  # noqa: B018
+record_dispatch  # noqa: B018
+record_validation  # noqa: B018
+record_review  # noqa: B018
+record_escalation  # noqa: B018
+record_invocation  # noqa: B018
+summarize  # noqa: B018


### PR DESCRIPTION
Implements the decision/outcome telemetry proposed in #72 (the first of three; wiring into command dispatch is a deliberate follow-up PR).

## What

A stdlib-only, **local-only** JSONL writer (`skills/studio/scripts/studio/utils/decision_log.py`) that records what the engine decided per run — routing, dispatch, validation, review, escalation, and command invocation — correlated by `run_id` and `decision_id`.

- **Local-only** — no network code, no new remote surface (proven by a test that fails on any socket construction).
- **Opt-out** — `CFS_DECISION_LOG=off`, or a persistent `~/.cf-studio/decisions.off` sentinel, disables it.
- **Fail-safe** — `record()` never raises into the caller; logging can't change a command's exit code.
- **No-project no-op** — outside a Studio project there's nowhere to write, so it's a clean no-op.
- **Private** — records decisions, not content; `$HOME` redacted to `~`; records command name / exit code / duration / an arg-shape summary, never raw argv.
- Size-based rotation; `read_events` / `summarize` for consumers.

## Scope

Writer + tests only. Wiring it into command dispatch (so commands actually emit events) is a separate follow-up PR — keeping the change that touches the central dispatch path isolated.

## Traceability

Traced under `cpt-studio-algo-core-infra-decision-log`, declared in `architecture/features/core-infra.md`.

## Checks (local)

- `cfs validate` — 0 errors, 0 warnings, 216/216 code coverage
- `spec-coverage` — all thresholds met
- `make test` — full suite passes (incl. 14 new tests)
- `pylint`, `vulture` — clean
- No new dependencies (`dependencies = []` respected); DCO signed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local decision-event logging for routing, dispatch, validation, reviews, escalations, and command invocations.
  * Added event filtering, reading, and summary support.
  * Added privacy controls, including path redaction and opt-out options.
  * Added automatic log rotation and resilient handling of write or malformed-record failures.

* **Documentation**
  * Documented decision logging, configuration, and operational behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->