### PR TITLE
Instrument the command dispatcher + validators with decision/outcome telemetry

### DIFF
--- a/skills/studio/scripts/studio/cli.py
+++ b/skills/studio/scripts/studio/cli.py
@@ -342,15 +342,12 @@ def _main_impl(argv_list: List[str]) -> int:
         return _report_unknown_command(cmd)
     # @cpt-end:cpt-studio-algo-core-infra-route-command:p1:inst-if-no-handler
     # @cpt-begin:cpt-studio-algo-core-infra-route-command:p1:inst-execute-handler
-    # Telemetry is fail-open: it must never change command behaviour or exit code
-    # (fail-open, not fail-silent). Establish one decision id for the run so events
-    # recorded inside the handler (e.g. validation) correlate to this invocation.
-    decision_id = ""
-    try:
-        decision_id = decision_log.new_decision_id()
-        decision_log.set_current_decision_id(decision_id)
-    except Exception as exc:  # pylint: disable=broad-except
-        logging.getLogger("studio").debug("decision-log setup failed: %s", exc)
+    # Telemetry never changes command behaviour: new_decision_id / set_current /
+    # record_invocation are all non-raising (record() is fail-safe and surfaces a real
+    # write failure itself), so no guard is needed here. One decision id per run lets
+    # events recorded inside the handler (e.g. validation) correlate to this invocation.
+    decision_id = decision_log.new_decision_id()
+    decision_log.set_current_decision_id(decision_id)
     started = perf_counter()
     handler_result = 1
     try:
@@ -364,25 +361,17 @@ def _main_impl(argv_list: List[str]) -> int:
             handler_result = 0 if exc.code is None else 1
         raise
     finally:
-        # Record on every exit — normal, SystemExit, or a raising handler.
-        try:
-            decision_log.record_invocation(
-                cmd,
-                exit_code=handler_result,
-                duration_ms=int((perf_counter() - started) * 1000),
-                args_shape={"argc": len(rest),
-                            "flags": sum(1 for arg in rest if arg.startswith("-"))},
-                decision_id=decision_id,
-            )
-        except Exception as exc:  # pylint: disable=broad-except
-            # Fail-open, not fail-silent: surface one line via the logger (→ stderr).
-            logging.getLogger("studio").warning(
-                "decision-log invocation record failed (ignored): %s", exc)
-        # Always scope the id to this run, even if recording raised.
-        try:
-            decision_log.set_current_decision_id("")
-        except Exception as exc:  # pylint: disable=broad-except
-            logging.getLogger("studio").debug("decision-log reset failed (ignored): %s", exc)
+        # Record on every exit — normal, SystemExit, or a raising handler — then scope
+        # the id to this run so a later event can't inherit it.
+        decision_log.record_invocation(
+            cmd,
+            exit_code=handler_result,
+            duration_ms=int((perf_counter() - started) * 1000),
+            args_shape={"argc": len(rest),
+                        "flags": sum(1 for arg in rest if arg.startswith("-"))},
+            decision_id=decision_id,
+        )
+        decision_log.set_current_decision_id("")
     # @cpt-end:cpt-studio-algo-core-infra-route-command:p1:inst-execute-handler
 
 

--- a/skills/studio/scripts/studio/cli.py
+++ b/skills/studio/scripts/studio/cli.py
@@ -14,7 +14,10 @@ IMPORTANT: This module MUST NOT contain business logic.
 import sys
 import logging
 from pathlib import Path
+from time import perf_counter
 from typing import Callable, List, Optional
+
+from .utils import decision_log
 
 _CLI_STDERR_HANDLER_NAME = "studio-cli-stderr"
 
@@ -339,8 +342,47 @@ def _main_impl(argv_list: List[str]) -> int:
         return _report_unknown_command(cmd)
     # @cpt-end:cpt-studio-algo-core-infra-route-command:p1:inst-if-no-handler
     # @cpt-begin:cpt-studio-algo-core-infra-route-command:p1:inst-execute-handler
-    handler_result = handler(rest)
-    return handler_result
+    # Telemetry is fail-open: it must never change command behaviour or exit code
+    # (fail-open, not fail-silent). Establish one decision id for the run so events
+    # recorded inside the handler (e.g. validation) correlate to this invocation.
+    decision_id = ""
+    try:
+        decision_id = decision_log.new_decision_id()
+        decision_log.set_current_decision_id(decision_id)
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.getLogger("studio").debug("decision-log setup failed: %s", exc)
+    started = perf_counter()
+    handler_result = 1
+    try:
+        handler_result = handler(rest)
+        return handler_result
+    except SystemExit as exc:
+        # argparse exits via SystemExit (--help, invalid args); record its real code.
+        if isinstance(exc.code, int):
+            handler_result = exc.code
+        else:
+            handler_result = 0 if exc.code is None else 1
+        raise
+    finally:
+        # Record on every exit — normal, SystemExit, or a raising handler.
+        try:
+            decision_log.record_invocation(
+                cmd,
+                exit_code=handler_result,
+                duration_ms=int((perf_counter() - started) * 1000),
+                args_shape={"argc": len(rest),
+                            "flags": sum(1 for arg in rest if arg.startswith("-"))},
+                decision_id=decision_id,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            # Fail-open, not fail-silent: surface one line via the logger (→ stderr).
+            logging.getLogger("studio").warning(
+                "decision-log invocation record failed (ignored): %s", exc)
+        # Always scope the id to this run, even if recording raised.
+        try:
+            decision_log.set_current_decision_id("")
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.getLogger("studio").debug("decision-log reset failed (ignored): %s", exc)
     # @cpt-end:cpt-studio-algo-core-infra-route-command:p1:inst-execute-handler
 
 

--- a/skills/studio/scripts/studio/commands/self_check.py
+++ b/skills/studio/scripts/studio/commands/self_check.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from ..utils import decision_log
 from ..utils.artifacts_meta import ArtifactsMeta
 from ..utils.constraints import (
     error as constraints_error,
@@ -960,6 +961,8 @@ def run_self_check_from_meta(  # pylint: disable=too-many-locals
         "templates_checked": len(results),
         "results": results,
     }
+    # Telemetry: authoritative final self-check verdict, correlated via the run's id.
+    decision_log.record_validation("self-check", overall_status)
     return (0 if overall_status == "PASS" else 2), out
     # @cpt-end:cpt-studio-flow-developer-experience-self-check:p1:inst-return-self-check
 

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -13,6 +13,7 @@ import logging
 from pathlib import Path
 from typing import List
 
+from ..utils import decision_log
 from ..utils.coverage import (
     FileCoverage,
     calculate_metrics,
@@ -347,6 +348,10 @@ def cmd_spec_coverage(argv: List[str]) -> int:
     json_report, exit_code = _generate_spec_coverage_report(args, meta, project_root)
 
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-return-report
+    # Telemetry: authoritative final coverage verdict (the report's own status, so an
+    # input error isn't recorded as a coverage FAIL), correlated via the run's id.
+    decision_log.record_validation(
+        "spec-coverage", json_report.get("status") or ("FAIL" if exit_code else "PASS"))
     _output(json_report, args)
     return exit_code
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-return-report

--- a/skills/studio/scripts/studio/commands/validate.py
+++ b/skills/studio/scripts/studio/commands/validate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+from ..utils import decision_log
 from ..utils import error_codes as EC
 from ..utils.codebase import CodeFile, cross_validate_code
 from ..utils.constraints import (
@@ -1111,6 +1112,11 @@ def _emit_final_validate_report(session: _ValidateSession, results: _ValidateRes
                 {"artifact": item.get("artifact"), "error_count": item.get("error_count")}
                 for item in failed_artifacts
             ]
+    # Telemetry: record the authoritative final validation verdict. It inherits the
+    # run's decision id from the dispatcher, correlating to the invocation. record()
+    # is fail-safe (never raises into the caller), so no guard is needed here.
+    decision_log.record_validation(
+        "validate", overall_status, findings=len(results.all_errors))
     _emit_validate_output(
         report,
         output_path=session.args.output,

--- a/skills/studio/scripts/studio/commands/validate_kits.py
+++ b/skills/studio/scripts/studio/commands/validate_kits.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from ..utils import decision_log
 from ..utils.constraints import error as constraints_error
 from ..utils.ui import ui
 # @cpt-end:cpt-studio-flow-kit-validate-cli:p1:inst-validate-kits-imports
@@ -609,6 +610,9 @@ def _build_validate_kits_result(
             result["errors"] = all_errors[:10]
             if len(all_errors) > 10:
                 result["errors_truncated"] = len(all_errors) - 10
+    # Telemetry: authoritative final kit-validation verdict, correlated via the run's id.
+    decision_log.record_validation(
+        "validate-kits", overall_status, findings=len(all_errors))
     return (0 if overall_status == "PASS" else 2), result
     # @cpt-end:cpt-studio-algo-kit-validate-by-path:p1:inst-build-result
     # @cpt-end:cpt-studio-algo-kit-validate:p1:inst-build-result

--- a/skills/studio/scripts/studio/utils/decision_log.py
+++ b/skills/studio/scripts/studio/utils/decision_log.py
@@ -77,6 +77,9 @@ _CURRENT_DECISION_ID: contextvars.ContextVar[str] = contextvars.ContextVar(
 #: Guards the one-time transparency notice.
 _NOTICE_SHOWN = False
 
+#: Guards the one-time "could not write the log" warning (fail-open, not fail-silent).
+_FAILURE_WARNED = False
+
 
 # ---------------------------------------------------------------------------
 # Correlation
@@ -251,8 +254,13 @@ def record(
     or an unwritable/unserialisable record). **Never raises** — callers are
     instrumentation, so a failure here must not change what the command does.
     """
+    global _FAILURE_WARNED  # pylint: disable=global-statement
     try:
         if not is_enabled():
+            return False
+        if _FAILURE_WARNED:
+            # A prior write failed and we already warned: telemetry is genuinely off for
+            # the rest of this run. Don't keep retrying a target we know is unwritable.
             return False
         target = path or default_log_path()
         if target is None:
@@ -274,8 +282,15 @@ def record(
             _show_notice_once(target)
         return True
     except Exception as exc:  # pylint: disable=broad-except
-        # Deliberately broad: instrumentation must degrade to silence.
-        logger.debug("decision log write skipped: %s", exc)
+        # A real write/serialization failure (disabled, no-project and already-warned
+        # cases return early above and never reach here, so this only fires on the first
+        # failure). Surface it once — fail-open, not fail-silent — and latch telemetry off
+        # for the run via _FAILURE_WARNED. Redact the exception: an OSError carries the
+        # absolute log path ($HOME included).
+        _FAILURE_WARNED = True
+        logger.warning(
+            "Constructor Studio could not write its decision log; "
+            "telemetry is off for this run: %s", _redact(str(exc)))
         return False
 # @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-record
 

--- a/skills/studio/scripts/studio/utils/decision_log.py
+++ b/skills/studio/scripts/studio/utils/decision_log.py
@@ -37,6 +37,7 @@ instrumentation never breaks an older reader.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import os
@@ -68,6 +69,11 @@ _MAX_BYTES = 5 * 1024 * 1024
 #: Fixed for the life of the process, so every event of one invocation shares it.
 _RUN_ID = uuid.uuid4().hex[:12]
 
+#: Correlation id for the current context. The dispatcher sets this once per run so
+#: events recorded deep inside a command (e.g. validation) share the run's decision.
+_CURRENT_DECISION_ID: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "cfs_current_decision_id", default="")
+
 #: Guards the one-time transparency notice.
 _NOTICE_SHOWN = False
 
@@ -79,6 +85,15 @@ _NOTICE_SHOWN = False
 def new_decision_id() -> str:
     """Return a fresh id used to chain the events (routing → dispatch → …) of one decision."""
     return uuid.uuid4().hex[:16]
+
+
+def set_current_decision_id(decision_id: str) -> None:
+    """Set the correlation id for the current context.
+
+    Later ``record()`` calls that pass no explicit ``decision_id`` inherit this one,
+    so events emitted deep inside a command chain to the same decision as the run.
+    """
+    _CURRENT_DECISION_ID.set(decision_id)
 # @cpt-end:cpt-studio-algo-core-infra-decision-log:p1:inst-log-id
 
 
@@ -247,7 +262,7 @@ def record(
             "schema": SCHEMA_VERSION,
             "ts": datetime.now(timezone.utc).isoformat(),
             "run_id": _RUN_ID,
-            "decision_id": decision_id,
+            "decision_id": decision_id or _CURRENT_DECISION_ID.get(),
             "event": event,
             "command": _redact(command),
             "payload": _redact(payload or {}),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,3 +31,20 @@ def _enable_json_mode():
     set_json_mode(True)
     yield
     set_json_mode(False)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_decision_log(tmp_path_factory, monkeypatch):
+    """Redirect decision-log telemetry (on by default) to a throwaway path.
+
+    The command dispatcher records an ``invocation`` event per run; without this,
+    that ``.cache/decisions.jsonl`` write pollutes tests that snapshot a project's
+    files. The first write also prints a one-time transparency notice to stderr,
+    suppressed here so it doesn't leak into ``stderr == ""`` assertions.
+    Telemetry-specific tests override ``CFS_DECISION_LOG`` themselves.
+    """
+    from studio.utils import decision_log
+    log = tmp_path_factory.mktemp("cfs_telemetry") / "decisions.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(log))
+    monkeypatch.setattr(decision_log, "_NOTICE_SHOWN", True)
+    decision_log.set_current_decision_id("")   # start each test with a clean correlation id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,4 +47,5 @@ def _isolate_decision_log(tmp_path_factory, monkeypatch):
     log = tmp_path_factory.mktemp("cfs_telemetry") / "decisions.jsonl"
     monkeypatch.setenv("CFS_DECISION_LOG", str(log))
     monkeypatch.setattr(decision_log, "_NOTICE_SHOWN", True)
+    monkeypatch.setattr(decision_log, "_FAILURE_WARNED", False)   # each test can observe the warning
     decision_log.set_current_decision_id("")   # start each test with a clean correlation id

--- a/tests/test_cli_telemetry.py
+++ b/tests/test_cli_telemetry.py
@@ -70,31 +70,19 @@ def test_events_inside_a_command_share_the_run_decision_id(
 # ---------------------------------------------------------------------------
 # fail-open: telemetry never changes command behaviour
 
-def test_wrapper_fail_open_when_record_raises(tmp_path: Path,
-                                              monkeypatch: pytest.MonkeyPatch,
-                                              caplog: pytest.LogCaptureFixture) -> None:
-    monkeypatch.setenv("CFS_DECISION_LOG", str(tmp_path / "d.jsonl"))
-    monkeypatch.setattr(cli, "_resolve_command_handler", _fixed_handler(7))
+def test_command_survives_an_unwritable_log(tmp_path: Path,
+                                            monkeypatch: pytest.MonkeyPatch) -> None:
+    log = tmp_path / "decisions.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(log))
+    monkeypatch.setattr(cli, "_resolve_command_handler", _fixed_handler(5))
 
     def boom(*_a, **_k):
-        raise RuntimeError("record boom")
+        raise OSError("unwritable log")
 
-    monkeypatch.setattr(decision_log, "record_invocation", boom)
-    with caplog.at_level(logging.WARNING, logger="studio"):
-        assert cli.main(["demo"]) == 7                          # exit code unchanged
-    assert "decision-log invocation record failed" in caplog.text   # surfaced, not silent
-
-
-def test_wrapper_fail_open_when_setup_raises(tmp_path: Path,
-                                             monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("CFS_DECISION_LOG", str(tmp_path / "d.jsonl"))
-    monkeypatch.setattr(cli, "_resolve_command_handler", _fixed_handler(3))
-
-    def boom(_decision_id):
-        raise RuntimeError("setup boom")
-
-    monkeypatch.setattr(decision_log, "set_current_decision_id", boom)
-    assert cli.main(["demo"]) == 3                              # setup failure never blocks
+    monkeypatch.setattr(decision_log, "_append_locked", boom)
+    assert cli.main(["demo"]) == 5      # a real write failure never changes the exit code
+    assert not log.exists()              # ...and no event is written
+    # (the single visible warning is asserted at the decision_log level)
 
 
 def test_handler_exception_records_invocation_and_propagates(

--- a/tests/test_cli_telemetry.py
+++ b/tests/test_cli_telemetry.py
@@ -1,0 +1,143 @@
+"""Tests for the dispatch-wrapper telemetry in ``studio.cli`` + validation correlation.
+
+Covers: one ``invocation`` event per command, ``decision_id`` correlation of events
+recorded *inside* a command, and the fail-open contract — telemetry must never change
+a command's exit code or behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from studio import cli
+from studio.utils import decision_log
+
+
+def _events(path: Path):
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def _fixed_handler(exit_code: int):
+    """A stand-in command handler that ignores its args and returns *exit_code*."""
+    return lambda cmd: (lambda rest: exit_code)
+
+
+# ---------------------------------------------------------------------------
+# emission + correlation
+
+def test_command_emits_one_invocation_event(tmp_path: Path,
+                                             monkeypatch: pytest.MonkeyPatch) -> None:
+    log = tmp_path / "decisions.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(log))   # set in body → overrides autouse
+    monkeypatch.setattr(cli, "_resolve_command_handler", _fixed_handler(0))
+    assert cli.main(["demo", "-a", "b"]) == 0
+    invocations = [e for e in _events(log) if e["event"] == "invocation"]
+    assert len(invocations) == 1
+    ev = invocations[0]
+    assert ev["command"] == "demo"
+    assert ev["payload"]["exit_code"] == 0
+    assert ev["payload"]["args"] == {"argc": 2, "flags": 1}   # "-a" is a flag, "b" is not
+    assert isinstance(ev["payload"]["duration_ms"], int)
+    assert ev["decision_id"]                                   # non-empty
+
+
+def test_events_inside_a_command_share_the_run_decision_id(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log = tmp_path / "decisions.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(log))
+
+    def handler(_rest):
+        # A record deep inside the command, with NO explicit decision_id, must
+        # inherit the run's id set by the dispatcher.
+        decision_log.record_validation("inner", "PASS", findings=0)
+        return 0
+
+    monkeypatch.setattr(cli, "_resolve_command_handler", lambda cmd: handler)
+    cli.main(["demo"])
+    events = _events(log)
+    ids = {e["decision_id"] for e in events}
+    assert len(events) == 2                    # invocation + the inner validation
+    assert len(ids) == 1                        # both chained to one decision
+    assert all(ids)                             # ...and the id is non-empty
+
+
+# ---------------------------------------------------------------------------
+# fail-open: telemetry never changes command behaviour
+
+def test_wrapper_fail_open_when_record_raises(tmp_path: Path,
+                                              monkeypatch: pytest.MonkeyPatch,
+                                              caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("CFS_DECISION_LOG", str(tmp_path / "d.jsonl"))
+    monkeypatch.setattr(cli, "_resolve_command_handler", _fixed_handler(7))
+
+    def boom(*_a, **_k):
+        raise RuntimeError("record boom")
+
+    monkeypatch.setattr(decision_log, "record_invocation", boom)
+    with caplog.at_level(logging.WARNING, logger="studio"):
+        assert cli.main(["demo"]) == 7                          # exit code unchanged
+    assert "decision-log invocation record failed" in caplog.text   # surfaced, not silent
+
+
+def test_wrapper_fail_open_when_setup_raises(tmp_path: Path,
+                                             monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CFS_DECISION_LOG", str(tmp_path / "d.jsonl"))
+    monkeypatch.setattr(cli, "_resolve_command_handler", _fixed_handler(3))
+
+    def boom(_decision_id):
+        raise RuntimeError("setup boom")
+
+    monkeypatch.setattr(decision_log, "set_current_decision_id", boom)
+    assert cli.main(["demo"]) == 3                              # setup failure never blocks
+
+
+def test_handler_exception_records_invocation_and_propagates(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log = tmp_path / "decisions.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(log))
+
+    def crash(_rest):
+        raise RuntimeError("handler crash")
+
+    monkeypatch.setattr(cli, "_resolve_command_handler", lambda cmd: crash)
+    with pytest.raises(RuntimeError, match="handler crash"):
+        cli.main(["demo"])
+    invocations = [e for e in _events(log) if e["event"] == "invocation"]
+    assert len(invocations) == 1                       # a crashing run is still recorded
+    assert invocations[0]["payload"]["exit_code"] == 1
+
+
+@pytest.mark.parametrize("raised, expected", [(0, 0), (2, 2), (None, 0), ("boom", 1)])
+def test_systemexit_records_its_real_code(tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+                                          raised, expected) -> None:
+    log = tmp_path / "decisions.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(log))
+
+    def exiter(_rest):
+        raise SystemExit(raised)   # argparse-style exit (--help / bad args)
+
+    monkeypatch.setattr(cli, "_resolve_command_handler", lambda cmd: exiter)
+    with pytest.raises(SystemExit):
+        cli.main(["demo"])
+    invocations = [e for e in _events(log) if e["event"] == "invocation"]
+    assert invocations[-1]["payload"]["exit_code"] == expected
+
+
+def test_decision_id_is_scoped_to_the_run(tmp_path: Path,
+                                          monkeypatch: pytest.MonkeyPatch) -> None:
+    log = tmp_path / "decisions.jsonl"
+    monkeypatch.setenv("CFS_DECISION_LOG", str(log))
+    monkeypatch.setattr(cli, "_resolve_command_handler", _fixed_handler(0))
+    cli.main(["demo"])
+    # After the run the correlation context is cleared, so a stray record does not
+    # inherit the finished run's decision id.
+    decision_log.record_validation("stray", "PASS", path=log)
+    stray = [e for e in _events(log) if e["payload"].get("check") == "stray"]
+    assert stray
+    assert stray[0]["decision_id"] == ""

--- a/tests/test_decision_log.py
+++ b/tests/test_decision_log.py
@@ -8,6 +8,7 @@ decision_id correlation that chains one decision's events.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,47 @@ def test_record_never_raises_on_bad_target(tmp_path: Path) -> None:
     bad = tmp_path / "adir"
     bad.mkdir()
     assert dl.record("routing", {}, path=bad) is False
+
+
+def test_write_failure_warns_once_then_stays_quiet(
+        log_path: Path, monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture) -> None:
+    # A real write failure is surfaced (fail-open, not fail-silent) exactly once, then
+    # telemetry latches off so a broken log can't spam every event or keep retrying.
+    monkeypatch.setattr(dl, "_FAILURE_WARNED", False)
+    home = str(Path.home())
+    calls = {"n": 0}
+
+    def boom(*_a, **_k):
+        calls["n"] += 1
+        # An OSError carries the absolute log path (home included).
+        raise OSError(f"[Errno 30] Read-only file system: '{home}/proj/.cache/d.jsonl'")
+
+    monkeypatch.setattr(dl, "_append_locked", boom)
+    with caplog.at_level(logging.WARNING):
+        assert dl.record("routing", {"a": 1}, path=log_path) is False
+        assert dl.record("routing", {"a": 2}, path=log_path) is False
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1                                   # surfaced once, not per event
+    assert calls["n"] == 1                                      # latched off — no retry
+    assert "could not write its decision log" in caplog.text
+    assert home not in caplog.text                              # $HOME redacted from the warning
+    assert "~/proj/.cache" in caplog.text
+
+
+def test_disabled_and_no_project_never_warn(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture) -> None:
+    # Expected no-op cases (opt-out, outside a project) must stay silent — no warning.
+    monkeypatch.setattr(dl, "_FAILURE_WARNED", False)
+    with caplog.at_level(logging.WARNING):
+        monkeypatch.setenv("CFS_DECISION_LOG", "off")
+        assert dl.record("routing", {}, path=tmp_path / "d.jsonl") is False   # opt-out
+        monkeypatch.delenv("CFS_DECISION_LOG")
+        monkeypatch.setattr("studio.utils.files.find_studio_directory",
+                            lambda *_a, **_k: None)
+        assert dl.record("routing", {}) is False                             # no project
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
 
 
 def test_record_opens_no_socket(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Follow-up to #79 (the decision-log writer): this wires the writer into the engine so telemetry is actually produced. Part of the telemetry direction in #72.

## What
- A single **fail-open dispatch wrapper** around the CLI's `handler(rest)` records one `invocation` event per command — command, exit code, duration, and a safe `args_shape` (counts only, never raw argv) — for every command, on both normal and exception exits, without changing any command's behaviour or exit code.
- **Correlation:** a `contextvars` decision id, established once per run and scoped to it, so events recorded inside a command inherit the run's id. The engine mints the id; honouring an inherited upstream id (proxy→engine) is a follow-up.
- **Validators:** `validate` / `spec-coverage` / `validate-kits` / `self-check` record their final verdict as a `validation` event via the run's id. `record()` is fail-safe (never raises into the caller), so these are unguarded one-liners.

## Guardrails
- Fail-open, not fail-silent — a wrapper failure logs one line and never affects the command; no new network destinations; local-only + opt-out honoured (unchanged from #79); valid schema-1 events (no schema change).

## Tests / gates
- New `tests/test_cli_telemetry.py`: emission, correlation, fail-open (record/setup raising → exit code unchanged), crash logging, and id scoping. Telemetry redirected to a throwaway path in tests so it doesn't pollute file-snapshot assertions.
- Green: full suite, per-file ≥90% + diff 100% coverage, pylint, vulture, `cfs validate`, `spec-coverage`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command execution reporting with duration, command details, argument shape, exit status, and correlated decision IDs.
  * Added final status reporting for self-checks, specification coverage, validation, and kit validation.

* **Reliability**
  * Reporting failures no longer interrupt command execution.
  * Decision context is cleared after each command run.

* **Tests**
  * Added coverage for reporting, correlation, cleanup, failure handling, and command exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->