### PR TITLE
test(kit): correct the Windows path assertion that fails on Python 3.11

### DIFF
--- a/tests/test_kit_manifest_migration.py
+++ b/tests/test_kit_manifest_migration.py
@@ -350,7 +350,27 @@ class TestMigrateLegacyKitToManifest(unittest.TestCase):
             self.assertEqual(result["status"], "FAIL")
             self.assertIn("not accessible on this OS", result["errors"][0])
 
+    def test_posix_absolute_registered_root_rejected_when_os_is_windows(self):
+        """A POSIX absolute path is rejected under Windows semantics.
+
+        Asserted on the resolver directly rather than through the full
+        migration: ``pathlib.Path.__new__`` reads ``os.name`` at call time to
+        choose its concrete flavour, so patching ``os.name`` globally turns
+        every ``Path(...)`` in the call graph into a ``WindowsPath``, which
+        pathlib refuses to instantiate on a POSIX host. This keeps the Windows
+        branch covered on every platform; the end-to-end variant below runs
+        on Windows.
+        """
+        import studio.commands.kit as kit_module
+
+        with patch.object(kit_module.os, "name", "nt"):
+            self.assertIsNone(
+                kit_module._resolve_same_os_absolute_path("/external-kits/mykit")
+            )
+
     def test_posix_absolute_registered_root_fails_on_windows(self):
+        if os.name != "nt":
+            self.skipTest("Windows-only absolute path regression")
         import studio.commands.kit as kit_module
         from studio.commands.kit import migrate_legacy_kit_to_manifest
         from studio.utils import toml_utils


### PR DESCRIPTION
**What.** Splits `test_posix_absolute_registered_root_fails_on_windows` so the Windows rejection branch is covered on every platform, and guards the end-to-end variant to Windows hosts.

**Why.** The test patched `os.name` to `"nt"` and then drove the full migration. On Python 3.11, `pathlib.Path.__new__` reads `os.name` at call time to choose its concrete flavour, so the patch turns every `Path(...)` in the call graph into a `WindowsPath`. The failure surfaces at `utils/kit_model.py:896` — `Path(source).name` with `source="artifacts/ADR"`:

```
NotImplementedError: cannot instantiate 'WindowsPath' on your system
```

So on 3.11 the test raises rather than asserting the rejection it was written to check. `_resolve_same_os_absolute_path` itself is correct — only the test's simulation is unsound.

**Scope — Python 3.11 only.** `Path.__new__` stopped selecting the flavour from `os.name` in 3.12, so the patch is harmless there. Measured on this commit:

| Python | Result |
|---|---|
| 3.11 | **fails** |
| 3.12 / 3.13 / 3.14 | passes |

`pyproject.toml` declares `requires-python = ">=3.11.4"`, so 3.11 is supported and this is a real failure for anyone developing on it.

**How.** A new unit test asserts `_resolve_same_os_absolute_path` returns `None` for a POSIX absolute path under Windows semantics — that branch returns before any `Path` is constructed, so it runs on every version and keeps the Windows behaviour covered. The end-to-end test now skips unless `os.name == "nt"`, mirroring `test_windows_absolute_registered_root_fails_on_non_windows`, which already guards itself the other way.

The new assertion was mutation-tested rather than assumed: inverting the production guard at `commands/kit.py:996` (`if os.name != "nt"` to `if True`) makes it fail, so it genuinely covers that branch.

**Gates.** Full suite green on 3.12+ (4,417 passed, 3 skipped, 18 xfailed). On 3.11 the only remaining failure is the one this PR fixes. `pylint`, `vulture-ci` and `spec-coverage` do not scope `tests/`, and no artifact changed, so `cfs validate` is unaffected. No new dependencies.

---

**Aside, possibly worth its own issue.** The CI matrix declares `Test (Python 3.11 ... 3.14)`, and the 3.11 job reported success at `53e8b4e8` — the commit where this test fails on 3.11. I may be misreading the setup, but one explanation is that `make test` runs `$(PYTEST_PIPX)` (`~/.local/bin/pytest`), whose interpreter is fixed when pipx installs it and may not be the one `setup-python` selected — in which case all four matrix jobs would execute the same Python and 3.11 would not actually be exercised. Happy to open a separate issue with the details if that's useful; it's independent of this change.
