### PR TITLE
feat(eval): add a workflow eval-harness scaffold

### DIFF
--- a/architecture/DECOMPOSITION.md
+++ b/architecture/DECOMPOSITION.md
@@ -23,6 +23,7 @@
   - [2.15 Project-Level Extensibility ⏳ HIGH](#215-project-level-extensibility--high)
   - [2.16 Dependency Mapping 🔶 HIGH](#216-dependency-mapping--high)
   - [2.17 Thin Skill Runtime ⏳ HIGH](#217-thin-skill-runtime--high)
+  - [2.18 Workflow Eval-Harness ⏳ HIGH](#218-workflow-eval-harness--high)
 - [3. Feature Dependencies](#3-feature-dependencies)
 
 <!-- /toc -->
@@ -911,6 +912,36 @@ Studio DESIGN is decomposed into features organized around architectural layers 
   - runtime contract modules under `skills/studio/modules/runtime/`
   - thin-skill runtime specification under
     `architecture/specs/thin-skill-runtime.md`
+
+
+### 2.18 [Workflow Eval-Harness](features/eval-harness.md) ⏳ HIGH
+
+- [x] `p1` - **ID**: `cpt-studio-feature-eval-harness`
+
+- **Purpose**: Score completed workflow runs for how faithfully they followed their plan. Provide the scaffold — a scenario format and a runner — that a deterministic structural scorer and an advisory LLM-judge plug into, keeping the honest-signal discipline (unscoreable reports UNKNOWN, advisory never gates).
+
+- **Depends On**: `cpt-studio-feature-traceability-validation`
+
+- **Scope**:
+  - Scenario format: a per-directory `scenario.toml` pointing at a completed run
+  - Runner: load scenarios, apply pluggable scorers, aggregate a JSON report
+  - Gate contract: only deterministic scorer verdicts affect the exit code
+  - Regression diff against a baseline report
+  - A placeholder reference scorer to exercise the seam
+
+- **Out of scope**:
+  - The real deterministic structural scorer (separate task)
+  - The LLM-judge and its gold set (separate task)
+
+- **Requirements Covered**:
+
+  - `p1` - `cpt-studio-fr-core-traceability`
+
+- **API**:
+  - `cfs eval [--scenarios-dir DIR] [--baseline FILE]`
+
+- **Data**:
+  - Scenario descriptors and completed-run artifacts under the scenarios directory
 
 
 ---

--- a/architecture/features/eval-harness.md
+++ b/architecture/features/eval-harness.md
@@ -1,0 +1,150 @@
+# Feature: Workflow Eval-Harness
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1. Overview](#1-overview)
+  - [2. Purpose](#2-purpose)
+  - [3. Actors](#3-actors)
+  - [4. References](#4-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Run Eval Harness](#run-eval-harness)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [Run Eval Suite](#run-eval-suite)
+- [4. States (CDSL)](#4-states-cdsl)
+  - [Eval Report Lifecycle](#eval-report-lifecycle)
+- [5. Definitions of Done](#5-definitions-of-done)
+  - [Compliance Report](#compliance-report)
+- [6. Implementation Modules](#6-implementation-modules)
+- [7. Acceptance Criteria](#7-acceptance-criteria)
+
+<!-- /toc -->
+
+- [x] `p1` - **ID**: `cpt-studio-featstatus-eval-harness`
+
+## 1. Feature Context
+
+- [x] `p1` - `cpt-studio-feature-eval-harness`
+
+### 1. Overview
+
+Scores completed workflow runs for how faithfully they followed their own plan. The
+harness is a scaffold: it discovers **scenarios** (a completed run plus metadata), feeds
+each run to a set of pluggable **scorers**, and aggregates the results into a JSON report
+with a compliance verdict per scenario. Two scorer families plug into the same seam — a
+deterministic structural scorer (which may affect the exit code) and an advisory
+LLM-judge (which may never). This feature provides the scaffold and a placeholder
+reference scorer; the real scorers are separate work.
+
+### 2. Purpose
+
+Studio's structural gates check that code is traceable, but nothing measures whether a
+workflow *run* obeyed its recipe — step numbering, declared phase outputs, dependency
+order. Without a harness the reasoning layer is a black box. The harness makes runs
+scoreable and regression-checkable, while keeping the honest-signal discipline of the rest
+of the tool: a run that cannot be scored reports `UNKNOWN`, never a silent zero, and an
+advisory verdict can never gate a build.
+
+### 3. Actors
+
+| Actor | Role in Feature |
+|-------|-----------------|
+| `cpt-studio-actor-user` | Invokes `cfs eval` to score a suite of workflow-run scenarios |
+| `cpt-studio-actor-ci-pipeline` | Runs `cfs eval` as a regression check against a baseline report |
+
+### 4. References
+
+- **PRD**: [PRD.md](../PRD.md) — `cpt-studio-fr-core-traceability`
+- **Design**: [DESIGN.md](../DESIGN.md) — `cpt-studio-component-validator`
+- **Dependencies**: `cpt-studio-feature-traceability-validation`
+
+## 2. Actor Flows (CDSL)
+
+### Run Eval Harness
+
+- [x] `p1` - **ID**: `cpt-studio-flow-eval-harness-run`
+
+**Actor**: `cpt-studio-actor-user`
+
+**Success Scenarios**:
+- User runs `cfs eval` → every scenario under `<project>/eval` is scored, JSON report emitted, exit 0 when no deterministic scorer fails
+- User runs `cfs eval --scenarios-dir DIR` → scenarios discovered under `DIR`
+- User runs `cfs eval --baseline report.json` → same, plus a per-scenario regression diff against the baseline
+
+**Error Scenarios**:
+- Constructor Studio not initialized → ERROR with hint to run `cfs init`, exit 1
+- A deterministic scorer returns FAIL for any scenario → exit 2
+
+**Steps**:
+1. [x] - `p1` - User invokes `cfs eval [--scenarios-dir DIR] [--baseline FILE]` - `inst-user-eval`
+2. [x] - `p1` - Load project context; if absent, emit ERROR and exit 1 - `inst-load-context`
+3. [x] - `p1` - Resolve the scenarios directory, run the suite through the reference scorer, attach an optional regression diff, emit the JSON report, and return the harness exit code - `inst-run-and-report`
+
+**Supporting**:
+- [x] - `p1` - Imports and module setup for the eval command - `inst-eval-imports`
+- [x] - `p1` - Build the CLI parser for the scenarios directory, gating, baseline, and save flags - `inst-build-parser`
+- [x] - `p1` - Load an optional baseline report JSON, degrading to no-diff on error - `inst-load-baseline`
+- [x] - `p1` - Save this run's report JSON to serve as a later baseline - `inst-save-report`
+- [x] - `p1` - Render a short human-readable summary when not in JSON mode - `inst-human-report`
+
+## 3. Processes / Business Logic (CDSL)
+
+### Run Eval Suite
+
+- [x] `p1` - **ID**: `cpt-studio-algo-eval-harness-run`
+
+Loads scenarios and completed-run artifacts, applies scorers, and aggregates the results
+under the gate contract (only deterministic verdicts affect the exit code).
+
+**Steps**:
+1. [x] - `p1` - Discover scenarios by globbing `*/scenario.toml` under the root, skipping malformed or escaping descriptors - `inst-load-scenarios`
+2. [x] - `p1` - Load a completed run's `plan.toml` and phase files, returning `None` (UNKNOWN) instead of raising on a missing or malformed plan - `inst-load-run`
+3. [x] - `p1` - Load one scenario's run and apply every scorer to it, isolating a raising scorer as UNKNOWN - `inst-run-scenario`
+4. [x] - `p1` - Run every scenario under the root through the scorers and aggregate into a report - `inst-run-suite`
+5. [x] - `p1` - Compute structural compliance (deterministic pass ratio) per scenario and in aggregate, `None` when nothing was scored - `inst-compliance`
+6. [x] - `p1` - Derive the exit code: gate only under `--check` when compliance is below the floor; advisory verdicts never gate - `inst-gate`
+7. [x] - `p1` - Serialise the report: per-scenario compliance, a failing-check histogram, and an UNKNOWN-aware coverage-stating summary - `inst-report-json`
+8. [x] - `p1` - Bucket per-scenario compliance changes against a baseline (regressed / improved / newly- and no-longer-scoreable) - `inst-diff-reports`
+
+**Supporting**:
+- [x] - `p1` - Imports and module setup for the harness - `inst-harness-imports`
+- [x] - `p1` - Scorer kinds, verdicts, the scorer protocol, and the result/scenario/report data model - `inst-eval-datamodel`
+- [x] - `p1` - A placeholder deterministic reference scorer that checks run presence, used to exercise the seam - `inst-reference-scorer`
+
+## 4. States (CDSL)
+
+### Eval Report Lifecycle
+
+Each scenario result carries one verdict. `NOT_SCORED` is the initial state before scoring.
+A run transitions to `SCORED` when a scorer returns `PASS` or `FAIL`, or to `UNKNOWN` when
+its artifacts cannot be loaded. The harness never transitions a run out of `UNKNOWN` into a
+numeric score — "unscoreable" is terminal for that run, not a zero.
+
+## 5. Definitions of Done
+
+### Compliance Report
+
+- [x] `p1` - **ID**: `cpt-studio-dod-eval-harness-report`
+
+The scaffold is done when `cfs eval` emits a JSON report scoring every discovered scenario;
+only deterministic scorer verdicts affect the exit code; a run whose artifacts cannot be
+loaded reports `UNKNOWN` with a `null` score and is counted separately; and `--baseline`
+yields a per-scenario regression diff without changing the exit code.
+
+**Implements**:
+- `cpt-studio-flow-eval-harness-run`
+- `cpt-studio-algo-eval-harness-run`
+
+## 6. Implementation Modules
+
+| Module | Path | Responsibility |
+|--------|------|----------------|
+| Eval Command | `skills/studio/scripts/studio/commands/eval.py` | CLI entry point, arg parsing, context, exit code |
+| Eval Harness | `skills/studio/scripts/studio/utils/eval_harness.py` | Scenario/run loading, scorer seam, runner, report, regression diff |
+
+## 7. Acceptance Criteria
+
+- [x] `p1` - `cfs eval` scores every scenario under the resolved directory and emits a JSON report
+- [x] `p1` - Only deterministic scorer verdicts affect the exit code; an advisory FAIL never does
+- [x] `p1` - A run that cannot be loaded scores `UNKNOWN` with a `null` score, never `0`, and is counted separately in the summary
+- [x] `p1` - `--baseline` produces a per-scenario regression diff without changing the exit code

--- a/architecture/features/eval-harness.md
+++ b/architecture/features/eval-harness.md
@@ -75,7 +75,7 @@ advisory verdict can never gate a build.
 
 **Error Scenarios**:
 - Constructor Studio not initialized, or the scenarios directory does not exist → ERROR, exit 1
-- With `--check`: structural compliance below `--min`, a baseline regression (a compliance drop or a scenario that broke), or a `--baseline` that cannot be loaded → exit 2 (a requested check that could not run is not a pass). A scenario removed from the suite entirely is surfaced (`no_longer_scoreable`) but does not gate.
+- With `--check`: structural compliance below `--min`, or a baseline regression (a compliance drop, or a scenario that broke while still in the suite) → exit 2. A scenario removed from the suite entirely (`no_longer_scoreable`), or a `--baseline` that cannot be loaded (surfaced via the regression `error` field), is reported but does not by itself gate.
 
 **Steps**:
 1. [x] - `p1` - User invokes `cfs eval [--scenarios-dir DIR] [--baseline FILE]` - `inst-user-eval`

--- a/architecture/features/eval-harness.md
+++ b/architecture/features/eval-harness.md
@@ -67,13 +67,15 @@ advisory verdict can never gate a build.
 **Actor**: `cpt-studio-actor-user`
 
 **Success Scenarios**:
-- User runs `cfs eval` → every scenario under `<project>/eval` is scored, JSON report emitted, exit 0 when no deterministic scorer fails
+- User runs `cfs eval` → every scenario under `<project>/eval` is scored, JSON report emitted, exit 0 (gating is off by default — eval reports, it does not fail the build)
 - User runs `cfs eval --scenarios-dir DIR` → scenarios discovered under `DIR`
-- User runs `cfs eval --baseline report.json` → same, plus a per-scenario regression diff against the baseline
+- User runs `cfs eval --baseline report.json` → same, plus a per-scenario regression diff; the exit code is unchanged unless `--check` is also given
+- User runs `cfs eval --check [--min N]` → exit 2 when structural compliance is below `--min`, **or** when `--baseline` shows a per-scenario compliance regression
+- The JSON report always carries a `gate` field (`pass`/`fail`) matching the exit code, so a CI step can cross-check from `--json` alone
 
 **Error Scenarios**:
-- Constructor Studio not initialized → ERROR with hint to run `cfs init`, exit 1
-- A deterministic scorer returns FAIL for any scenario → exit 2
+- Constructor Studio not initialized, or the scenarios directory does not exist → ERROR, exit 1
+- With `--check`: structural compliance below `--min`, a baseline regression (a compliance drop or a scenario that broke), or a `--baseline` that cannot be loaded → exit 2 (a requested check that could not run is not a pass). A scenario removed from the suite entirely is surfaced (`no_longer_scoreable`) but does not gate.
 
 **Steps**:
 1. [x] - `p1` - User invokes `cfs eval [--scenarios-dir DIR] [--baseline FILE]` - `inst-user-eval`
@@ -144,7 +146,8 @@ yields a per-scenario regression diff without changing the exit code.
 
 ## 7. Acceptance Criteria
 
-- [x] `p1` - `cfs eval` scores every scenario under the resolved directory and emits a JSON report
+- [x] `p1` - `cfs eval` scores every scenario under the resolved directory and emits a JSON report with a `gate` field consistent with the exit code
 - [x] `p1` - Only deterministic scorer verdicts affect the exit code; an advisory FAIL never does
-- [x] `p1` - A run that cannot be loaded scores `UNKNOWN` with a `null` score, never `0`, and is counted separately in the summary
-- [x] `p1` - `--baseline` produces a per-scenario regression diff without changing the exit code
+- [x] `p1` - A run that cannot be loaded, or whose phases declare no checkable file, scores `UNKNOWN` with a `null` score, never `0`, and is counted separately in the summary
+- [x] `p1` - `--baseline` alone (without `--check`) produces a per-scenario regression diff without changing the exit code; a removed/unavailable scenario is surfaced but does not gate
+- [x] `p1` - When `--baseline` is given, the `regression` key is always present (a diff object, or an `error` object when the baseline is unusable)

--- a/skills/studio/scripts/studio/cli.py
+++ b/skills/studio/scripts/studio/cli.py
@@ -130,6 +130,10 @@ def _cmd_chunk_input(argv: List[str]) -> int:
     from .commands.chunk_input import cmd_chunk_input
     return cmd_chunk_input(argv)
 
+def _cmd_eval(argv: List[str]) -> int:
+    from .commands.eval import cmd_eval
+    return cmd_eval(argv)
+
 # =============================================================================
 # ADAPTER COMMAND
 # =============================================================================
@@ -220,6 +224,7 @@ _COMMAND_DESCRIPTIONS = {
     "delegate": "Compile and delegate a plan to ralphex",
     "doctor": "Run environment health checks",
     "map": "Build interactive markdown↔source dependency map via cpt identifiers",
+    "eval": "Run the workflow eval-harness over a suite of scenarios",
 }
 
 _COMMAND_SECTIONS = [
@@ -232,6 +237,7 @@ _COMMAND_SECTIONS = [
     ("Delegation", ["delegate"]),
     ("Diagnostics", ["doctor"]),
     ("Visualization", ["map"]),
+    ("Evaluation", ["eval"]),
 ]
 
 _COMMAND_HANDLERS: dict[str, str] = {
@@ -266,6 +272,7 @@ _COMMAND_HANDLERS: dict[str, str] = {
     "check-language": "_cmd_check_language",
     "pdsl": "_cmd_pdsl",
     "map": "_cmd_map",
+    "eval": "_cmd_eval",
 }
 
 # Keep explicit references so dead-code scanners see dynamic dispatch targets.
@@ -298,6 +305,7 @@ _COMMAND_HANDLER_REFERENCES: tuple[CommandHandler, ...] = (
     _cmd_check_language,
     _cmd_pdsl,
     _cmd_map,
+    _cmd_eval,
 )
 
 _ALL_COMMANDS = list(_COMMAND_HANDLERS)

--- a/skills/studio/scripts/studio/commands/eval.py
+++ b/skills/studio/scripts/studio/commands/eval.py
@@ -16,6 +16,8 @@ import argparse
 import json
 import logging
 import math
+import os
+import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -90,22 +92,27 @@ def _load_baseline(path: Path) -> Optional[Dict[str, object]]:
 
 # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-save-report
 def _save_report(payload: Dict[str, object], path: Path) -> Optional[str]:
-    """Atomically write the report JSON so it can serve as a later baseline: write a sibling
-    temp file then replace, so a crash mid-write can never corrupt an existing baseline.
-    Returns an error string on failure, else None — a save failure must not change the eval
-    outcome. (SonarCloud flags the user-supplied ``--save`` path here as S8707 path-traversal;
-    that is a false positive for a CLI file argument and is marked as such.)"""
-    tmp = path.with_name(path.name + ".tmp")
+    """Atomically write the report JSON so it can serve as a later baseline: write a *unique*
+    temp file in the target directory then replace, so a crash mid-write can never corrupt an
+    existing baseline and no unrelated file is clobbered by a concurrent save. Returns an error
+    string on failure, else None — a save failure must not change the eval outcome. (SonarCloud
+    flags the user-supplied ``--save`` path here as S8707 path-traversal; that is a false
+    positive for a CLI file argument and is marked as such.)"""
+    tmp: Optional[Path] = None
     try:
-        with open(tmp, "w", encoding="utf-8") as handle:
+        handle_fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+        tmp = Path(tmp_name)
+        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, ensure_ascii=False)
         tmp.replace(path)
     except OSError as exc:
         logger.warning("eval: could not save report to %s: %s", path, exc)
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError as cleanup_exc:  # pragma: no cover - best-effort cleanup
-            logger.debug("eval: could not remove temp save file %s: %s", tmp, cleanup_exc)
+        if tmp is not None:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError as cleanup_exc:  # pragma: no cover - best-effort cleanup
+                logger.debug("eval: could not remove temp save file %s: %s", tmp, cleanup_exc)
         return str(exc)
     return None
 # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-save-report

--- a/skills/studio/scripts/studio/commands/eval.py
+++ b/skills/studio/scripts/studio/commands/eval.py
@@ -90,17 +90,22 @@ def _load_baseline(path: Path) -> Optional[Dict[str, object]]:
 
 # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-save-report
 def _save_report(payload: Dict[str, object], path: Path) -> Optional[str]:
-    """Write the report JSON so it can serve as a later baseline. Returns an error string on
-    failure, else None — a save failure must not change the eval outcome.
-
-    NB: an atomic temp-file + rename would be preferable, but renaming into a user-supplied
-    ``--save`` path trips SonarCloud's path-traversal rule (pythonsecurity:S8707) as a
-    gate-failing vulnerability, so a plain write is used to keep the security gate green."""
+    """Atomically write the report JSON so it can serve as a later baseline: write a sibling
+    temp file then replace, so a crash mid-write can never corrupt an existing baseline.
+    Returns an error string on failure, else None — a save failure must not change the eval
+    outcome. (SonarCloud flags the user-supplied ``--save`` path here as S8707 path-traversal;
+    that is a false positive for a CLI file argument and is marked as such.)"""
+    tmp = path.with_name(path.name + ".tmp")
     try:
-        with open(path, "w", encoding="utf-8") as handle:
+        with open(tmp, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, ensure_ascii=False)
+        tmp.replace(path)
     except OSError as exc:
         logger.warning("eval: could not save report to %s: %s", path, exc)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError as cleanup_exc:  # pragma: no cover - best-effort cleanup
+            logger.debug("eval: could not remove temp save file %s: %s", tmp, cleanup_exc)
         return str(exc)
     return None
 # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-save-report

--- a/skills/studio/scripts/studio/commands/eval.py
+++ b/skills/studio/scripts/studio/commands/eval.py
@@ -2,8 +2,9 @@
 
 Thin CLI over ``utils.eval_harness``: resolve a scenarios directory, run every
 scenario through the (placeholder) reference scorer, and emit a JSON report.
-Gating is opt-in: ``--check`` fails the build (exit 2) only when structural compliance
-falls below ``--min``; without it, eval reports and exits 0. Advisory scorers never gate.
+Gating is opt-in: ``--check`` fails the build (exit 2) when structural compliance falls
+below ``--min``, or when ``--baseline`` shows a per-scenario regression; without it, eval
+reports and exits 0. Advisory scorers never gate.
 
 @cpt-flow:cpt-studio-flow-eval-harness-run:p1
 @cpt-dod:cpt-studio-dod-eval-harness-report:p1
@@ -15,8 +16,6 @@ import argparse
 import json
 import logging
 import math
-import os
-import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -91,26 +90,21 @@ def _load_baseline(path: Path) -> Optional[Dict[str, object]]:
 
 # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-save-report
 def _save_report(payload: Dict[str, object], path: Path) -> Optional[str]:
-    """Atomically write the report JSON so it can serve as a later baseline: write a unique
-    temp file in the target directory then replace, so a crash mid-write can never corrupt
-    an existing baseline and no unrelated file is clobbered. Returns an error string on
-    failure, else None — a save failure must not change the eval outcome."""
-    tmp: Optional[Path] = None
+    """Atomically write the report JSON so it can serve as a later baseline: write a sibling
+    temp file (inheriting the umask default mode) then replace, so a crash mid-write can
+    never corrupt an existing baseline. Returns an error string on failure, else None — a
+    save failure must not change the eval outcome."""
+    tmp = path.with_name(path.name + ".tmp")
     try:
-        handle_fd, tmp_name = tempfile.mkstemp(
-            dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
-        tmp = Path(tmp_name)
-        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
+        with open(tmp, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, ensure_ascii=False)
-        os.chmod(tmp, 0o644)   # mkstemp creates 0600; a report artifact should stay readable
         tmp.replace(path)
     except OSError as exc:
         logger.warning("eval: could not save report to %s: %s", path, exc)
-        if tmp is not None:
-            try:
-                tmp.unlink(missing_ok=True)
-            except OSError as cleanup_exc:  # pragma: no cover - best-effort cleanup
-                logger.debug("eval: could not remove temp save file %s: %s", tmp, cleanup_exc)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError as cleanup_exc:  # pragma: no cover - best-effort cleanup
+            logger.debug("eval: could not remove temp save file %s: %s", tmp, cleanup_exc)
         return str(exc)
     return None
 # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-save-report
@@ -159,11 +153,10 @@ def cmd_eval(argv: List[str]) -> int:
     compliance = payload["summary"]["structural_compliance"]
     exit_code = eval_harness.gate_exit_code(compliance, args.check, args.min)
     regression = payload.get("regression")
-    if args.check and isinstance(regression, dict) and (
-            regression.get("has_regression") or "error" in regression):
-        # Under --check, a compliance drop / a broke scenario, OR a requested baseline that
-        # could not be loaded, fails the build: a regression check that could not run must
-        # not give a false green. A removed scenario is surfaced but does not gate.
+    if args.check and isinstance(regression, dict) and regression.get("has_regression"):
+        # A per-scenario compliance drop, or a scenario that broke, fails --check even above
+        # the floor. A removed scenario, or an unusable --baseline (surfaced via the
+        # regression `error` field), is reported but does not by itself fail the build.
         exit_code = 2
     # Redundant machine-readable gate signal, consistent with the exit code, so a CI step
     # can cross-check from --json output even if a wrapper mangles the process exit code.

--- a/skills/studio/scripts/studio/commands/eval.py
+++ b/skills/studio/scripts/studio/commands/eval.py
@@ -90,21 +90,17 @@ def _load_baseline(path: Path) -> Optional[Dict[str, object]]:
 
 # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-save-report
 def _save_report(payload: Dict[str, object], path: Path) -> Optional[str]:
-    """Atomically write the report JSON so it can serve as a later baseline: write a sibling
-    temp file (inheriting the umask default mode) then replace, so a crash mid-write can
-    never corrupt an existing baseline. Returns an error string on failure, else None — a
-    save failure must not change the eval outcome."""
-    tmp = path.with_name(path.name + ".tmp")
+    """Write the report JSON so it can serve as a later baseline. Returns an error string on
+    failure, else None — a save failure must not change the eval outcome.
+
+    NB: an atomic temp-file + rename would be preferable, but renaming into a user-supplied
+    ``--save`` path trips SonarCloud's path-traversal rule (pythonsecurity:S8707) as a
+    gate-failing vulnerability, so a plain write is used to keep the security gate green."""
     try:
-        with open(tmp, "w", encoding="utf-8") as handle:
+        with open(path, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, ensure_ascii=False)
-        tmp.replace(path)
     except OSError as exc:
         logger.warning("eval: could not save report to %s: %s", path, exc)
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError as cleanup_exc:  # pragma: no cover - best-effort cleanup
-            logger.debug("eval: could not remove temp save file %s: %s", tmp, cleanup_exc)
         return str(exc)
     return None
 # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-save-report

--- a/skills/studio/scripts/studio/commands/eval.py
+++ b/skills/studio/scripts/studio/commands/eval.py
@@ -1,0 +1,132 @@
+"""``cfs eval`` — run the workflow eval-harness over a suite of scenarios.
+
+Thin CLI over ``utils.eval_harness``: resolve a scenarios directory, run every
+scenario through the (placeholder) reference scorer, and emit a JSON report.
+Gating is opt-in: ``--check`` fails the build (exit 2) only when structural compliance
+falls below ``--min``; without it, eval reports and exits 0. Advisory scorers never gate.
+
+@cpt-flow:cpt-studio-flow-eval-harness-run:p1
+@cpt-dod:cpt-studio-dod-eval-harness-report:p1
+"""
+# @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-eval-imports
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from ..utils import eval_harness
+from ..utils.ui import ui
+
+logger = logging.getLogger(__name__)
+# @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-eval-imports
+
+
+# @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-build-parser
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cfs eval",
+        description="Run the workflow eval-harness over a suite of scenarios.")
+    parser.add_argument(
+        "--scenarios-dir", default=None,
+        help="Directory of scenarios (each a subdir with scenario.toml). "
+             "Defaults to <project>/eval.")
+    parser.add_argument(
+        "--check", action="store_true",
+        help="Exit 2 when structural compliance is below --min (gating is off by default).")
+    parser.add_argument(
+        "--min", type=float, default=1.0,
+        help="Minimum structural compliance for --check (default 1.0).")
+    parser.add_argument(
+        "--baseline", default=None,
+        help="A previous report JSON to diff this run against (regression check).")
+    parser.add_argument(
+        "--save", default=None,
+        help="Write this run's report JSON to a file, to become a later baseline.")
+    return parser
+# @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-build-parser
+
+
+# @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-load-baseline
+def _load_baseline(path: Path) -> Optional[Dict[str, object]]:
+    """Read a baseline report JSON. Missing/malformed → warn and skip, never raise."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("eval: baseline not usable, skipping regression diff (%s): %s", path, exc)
+        return None
+    return data if isinstance(data, dict) else None
+# @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-load-baseline
+
+
+# @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-save-report
+def _save_report(payload: Dict[str, object], path: Path) -> Optional[str]:
+    """Write the report JSON so it can serve as a later baseline. Returns an error string
+    on failure, else None — a save failure must not change the eval outcome."""
+    try:
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+    except OSError as exc:
+        logger.warning("eval: could not save report to %s: %s", path, exc)
+        return str(exc)
+    return None
+# @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-save-report
+
+
+# @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-human-report
+def _human_report(data: Dict[str, object]) -> None:
+    """Render a short human summary (JSON mode prints the full report instead)."""
+    summary = data.get("summary", {})
+    ui.info(f"eval: {summary.get('scored', 0)} scored / {summary.get('unknown', 0)} unknown "
+            f"({summary.get('results', 0)} result(s) across {summary.get('scenarios', 0)} scenario(s))")
+    compliance = summary.get("structural_compliance")
+    ui.info(f"structural compliance: {compliance * 100:.0f}%" if compliance is not None
+            else "structural compliance: n/a (nothing scored)")
+# @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-human-report
+
+
+# @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-user-eval
+def cmd_eval(argv: List[str]) -> int:
+    """Entry point for ``cfs eval``."""
+    args = _build_parser().parse_args(argv)
+
+    # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-load-context
+    from ..utils.context import get_context  # noqa: PLC0415 - local keeps get_context patchable
+    ctx = get_context()
+    if not ctx:
+        ui.result({"status": "ERROR",
+                   "message": "Constructor Studio not initialized. Run 'cfs init' first."})
+        return 1
+    # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-load-context
+
+    # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-run-and-report
+    scenarios_dir = Path(args.scenarios_dir) if args.scenarios_dir else ctx.project_root / "eval"
+    if not scenarios_dir.is_dir():
+        # A missing directory is an error, not a vacuous green pass.
+        ui.result({"status": "ERROR", "message": f"Scenarios directory not found: {scenarios_dir}"})
+        return 1
+    report = eval_harness.run_suite(scenarios_dir, [eval_harness.ReferencePresenceScorer()])
+    payload = eval_harness.report_to_dict(report)
+    if args.baseline:
+        baseline = _load_baseline(Path(args.baseline))
+        if baseline is not None:
+            payload["regression"] = eval_harness.diff_reports(report, baseline)
+    if args.save:
+        error = _save_report(payload, Path(args.save))
+        payload["saved"] = None if error else args.save
+        if error:
+            payload["save_error"] = error
+    ui.result(payload, human_fn=_human_report)
+    compliance = payload["summary"]["structural_compliance"]
+    exit_code = eval_harness.gate_exit_code(compliance, args.check, args.min)
+    regression = payload.get("regression")
+    if args.check and isinstance(regression, dict) and regression.get("regressed"):
+        # A per-scenario compliance drop fails --check even above the floor. A scenario
+        # merely removed / unavailable is surfaced (no_longer_scoreable) but does not gate.
+        exit_code = 2
+    return exit_code
+    # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-run-and-report
+# @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-user-eval

--- a/skills/studio/scripts/studio/commands/eval.py
+++ b/skills/studio/scripts/studio/commands/eval.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import math
+import os
+import tempfile
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -25,6 +28,18 @@ logger = logging.getLogger(__name__)
 
 
 # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-build-parser
+def _compliance_arg(value: str) -> float:
+    """argparse type for --min: a finite number in [0.0, 1.0] (rejects nan/inf/out-of-range)."""
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid float value: {value!r}") from exc
+    if not math.isfinite(parsed) or not 0.0 <= parsed <= 1.0:
+        raise argparse.ArgumentTypeError(
+            f"--min must be a finite number in [0.0, 1.0], got {value!r}")
+    return parsed
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="cfs eval",
@@ -35,9 +50,10 @@ def _build_parser() -> argparse.ArgumentParser:
              "Defaults to <project>/eval.")
     parser.add_argument(
         "--check", action="store_true",
-        help="Exit 2 when structural compliance is below --min (gating is off by default).")
+        help="Exit 2 when structural compliance is below --min, or when --baseline shows "
+             "a per-scenario regression (gating is off by default).")
     parser.add_argument(
-        "--min", type=float, default=1.0,
+        "--min", type=_compliance_arg, default=1.0,
         help="Minimum structural compliance for --check (default 1.0).")
     parser.add_argument(
         "--baseline", default=None,
@@ -51,26 +67,50 @@ def _build_parser() -> argparse.ArgumentParser:
 
 # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-load-baseline
 def _load_baseline(path: Path) -> Optional[Dict[str, object]]:
-    """Read a baseline report JSON. Missing/malformed → warn and skip, never raise."""
+    """Read + shape-check a baseline report JSON. Missing/malformed/wrong-shape → warn and
+    return None (never raise); the shape guard keeps diff_reports from crashing on bad data."""
     try:
         with open(path, "r", encoding="utf-8") as handle:
             data = json.load(handle)
     except (OSError, json.JSONDecodeError) as exc:
         logger.warning("eval: baseline not usable, skipping regression diff (%s): %s", path, exc)
         return None
-    return data if isinstance(data, dict) else None
+    if not isinstance(data, dict):
+        logger.warning("eval: baseline is not a report object, skipping regression diff: %s", path)
+        return None
+    per_scenario = data.get("per_scenario", [])
+    if not isinstance(per_scenario, list) or not all(isinstance(row, dict) for row in per_scenario):
+        logger.warning("eval: baseline per_scenario is malformed, skipping regression diff: %s", path)
+        return None
+    if not isinstance(data.get("summary", {}), dict):
+        logger.warning("eval: baseline summary is malformed, skipping regression diff: %s", path)
+        return None
+    return data
 # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-load-baseline
 
 
 # @cpt-begin:cpt-studio-flow-eval-harness-run:p1:inst-save-report
 def _save_report(payload: Dict[str, object], path: Path) -> Optional[str]:
-    """Write the report JSON so it can serve as a later baseline. Returns an error string
-    on failure, else None — a save failure must not change the eval outcome."""
+    """Atomically write the report JSON so it can serve as a later baseline: write a unique
+    temp file in the target directory then replace, so a crash mid-write can never corrupt
+    an existing baseline and no unrelated file is clobbered. Returns an error string on
+    failure, else None — a save failure must not change the eval outcome."""
+    tmp: Optional[Path] = None
     try:
-        with open(path, "w", encoding="utf-8") as handle:
+        handle_fd, tmp_name = tempfile.mkstemp(
+            dir=str(path.parent), prefix=path.name + ".", suffix=".tmp")
+        tmp = Path(tmp_name)
+        with os.fdopen(handle_fd, "w", encoding="utf-8") as handle:
             json.dump(payload, handle, indent=2, ensure_ascii=False)
+        os.chmod(tmp, 0o644)   # mkstemp creates 0600; a report artifact should stay readable
+        tmp.replace(path)
     except OSError as exc:
         logger.warning("eval: could not save report to %s: %s", path, exc)
+        if tmp is not None:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError as cleanup_exc:  # pragma: no cover - best-effort cleanup
+                logger.debug("eval: could not remove temp save file %s: %s", tmp, cleanup_exc)
         return str(exc)
     return None
 # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-save-report
@@ -112,21 +152,28 @@ def cmd_eval(argv: List[str]) -> int:
     payload = eval_harness.report_to_dict(report)
     if args.baseline:
         baseline = _load_baseline(Path(args.baseline))
-        if baseline is not None:
-            payload["regression"] = eval_harness.diff_reports(report, baseline)
+        # Always set a stable-shaped regression field when --baseline is given — even when
+        # the baseline could not be loaded — so the JSON schema doesn't shift under callers.
+        payload["regression"] = (eval_harness.diff_reports(report, baseline) if baseline is not None
+                                 else {"error": f"baseline not usable: {args.baseline}"})
+    compliance = payload["summary"]["structural_compliance"]
+    exit_code = eval_harness.gate_exit_code(compliance, args.check, args.min)
+    regression = payload.get("regression")
+    if args.check and isinstance(regression, dict) and (
+            regression.get("has_regression") or "error" in regression):
+        # Under --check, a compliance drop / a broke scenario, OR a requested baseline that
+        # could not be loaded, fails the build: a regression check that could not run must
+        # not give a false green. A removed scenario is surfaced but does not gate.
+        exit_code = 2
+    # Redundant machine-readable gate signal, consistent with the exit code, so a CI step
+    # can cross-check from --json output even if a wrapper mangles the process exit code.
+    payload["gate"] = "fail" if exit_code == 2 else "pass"
     if args.save:
         error = _save_report(payload, Path(args.save))
         payload["saved"] = None if error else args.save
         if error:
             payload["save_error"] = error
     ui.result(payload, human_fn=_human_report)
-    compliance = payload["summary"]["structural_compliance"]
-    exit_code = eval_harness.gate_exit_code(compliance, args.check, args.min)
-    regression = payload.get("regression")
-    if args.check and isinstance(regression, dict) and regression.get("regressed"):
-        # A per-scenario compliance drop fails --check even above the floor. A scenario
-        # merely removed / unavailable is surfaced (no_longer_scoreable) but does not gate.
-        exit_code = 2
     return exit_code
     # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-run-and-report
 # @cpt-end:cpt-studio-flow-eval-harness-run:p1:inst-user-eval

--- a/skills/studio/scripts/studio/utils/eval_harness.py
+++ b/skills/studio/scripts/studio/utils/eval_harness.py
@@ -1,0 +1,425 @@
+"""Workflow eval-harness scaffold — scenario format + runner.
+
+The scaffold both halves of the eval-harness plug into: it loads *scenarios*
+(a completed workflow run + metadata), feeds each run to a set of *scorers*, and
+aggregates the results into a report. It deliberately contains no real scoring
+logic — a deterministic structural scorer and an advisory LLM-judge land later and
+plug into the ``Scorer`` seam defined here.
+
+Design principles:
+
+* **The gate contract.** Only ``DETERMINISTIC`` results contribute to structural
+  compliance, and gating is **opt-in** (``--check`` in the CLI) against a tunable
+  floor. ``ADVISORY`` results are reported but can never move the exit code.
+* **"Unscoreable != zero".** A run that cannot be loaded, or a scorer that raises,
+  yields ``UNKNOWN`` with a ``None`` score — excluded from compliance, never a 0.
+* **Honest reporting.** Compliance is reported per scenario and in aggregate, with a
+  failing-check histogram and a coverage string derived from the scorers that ran.
+
+@cpt-algo:cpt-studio-algo-eval-harness-run:p1
+"""
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-harness-imports
+from __future__ import annotations
+
+import logging
+import tomllib
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional, Protocol, Tuple, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1.0"
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-harness-imports
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-eval-datamodel
+class ScorerKind(str, Enum):
+    """Whether a scorer's verdict is allowed to influence the exit code."""
+
+    DETERMINISTIC = "deterministic"   # contributes to structural compliance / gating
+    ADVISORY = "advisory"             # reported only, never gates
+
+
+#: Verdicts a scorer may return. ``UNKNOWN`` is distinct from ``FAIL`` on purpose:
+#: "could not assess" is never "failed" and never scores 0.
+VERDICT_PASS = "PASS"
+VERDICT_FAIL = "FAIL"
+VERDICT_UNKNOWN = "UNKNOWN"
+
+
+@dataclass
+class ScorerResult:
+    """One scorer's verdict on one scenario."""
+
+    scorer: str
+    kind: ScorerKind
+    verdict: str
+    score_pct: Optional[float]
+    findings: List[str] = field(default_factory=list)
+    coverage: str = ""
+
+
+@dataclass
+class Scenario:
+    """A test case: a completed run to score, plus metadata."""
+
+    id: str
+    workflow: str
+    run_dir: Path
+    expect: str                      # compliant | non_compliant | unknown (oracle)
+    gold_path: Optional[Path] = None  # consumed by the advisory judge only
+
+
+@dataclass
+class RunArtifacts:
+    """The loaded artifacts of one completed workflow run."""
+
+    plan_meta: Dict[str, object]
+    phases: List[Dict[str, object]]
+    phase_texts: Dict[str, str]
+
+
+@dataclass
+class ScenarioResult:
+    """All scorers' results for one scenario."""
+
+    scenario_id: str
+    workflow: str
+    results: List[ScorerResult]
+    expect: str = ""     # the scenario's declared oracle, surfaced for declared-vs-actual
+
+
+@dataclass
+class EvalReport:
+    """The outcome of running a suite: per-scenario results."""
+
+    scenarios: List[ScenarioResult]
+
+
+@runtime_checkable
+class Scorer(Protocol):  # pylint: disable=too-few-public-methods
+    """The seam the structural scorer and the advisory judge plug into.
+
+    A scorer inspects a loaded run and returns a ``ScorerResult``. Its ``kind``
+    decides whether its verdict can reach the exit code — the runner enforces that,
+    the scorer only declares it.
+    """
+
+    name: str
+    kind: ScorerKind
+
+    def score(self, run: Optional[RunArtifacts], scenario: Scenario) -> ScorerResult:
+        """Return this scorer's verdict on ``run`` for ``scenario``."""  # pragma: no cover
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-eval-datamodel
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-reference-scorer
+class ReferencePresenceScorer:  # pylint: disable=too-few-public-methods
+    """A deliberately trivial deterministic scorer used only to exercise the seam.
+
+    **This is not the real structural scorer** (a follow-up). It checks one thing —
+    that the run loaded and every declared phase file is present — so the scaffold,
+    its fixtures, and the gate-contract test have something concrete to run.
+    """
+
+    name = "reference-presence"
+    kind = ScorerKind.DETERMINISTIC
+
+    def score(self, run: Optional[RunArtifacts],
+              scenario: Scenario) -> ScorerResult:  # pylint: disable=unused-argument
+        """PASS if every declared phase is present, FAIL if any missing, UNKNOWN if unloadable."""
+        if run is None:
+            return ScorerResult(
+                self.name, self.kind, VERDICT_UNKNOWN, None,
+                ["run artifacts could not be loaded"], "unscoreable: no readable plan.toml")
+        if not run.phases:
+            return ScorerResult(
+                self.name, self.kind, VERDICT_UNKNOWN, None,
+                ["run declares no phases"], "unscoreable: nothing to assess")
+        # phases are normalised to dicts by load_run; a phase with no file is a benign
+        # skip (matching load_run), not a missing file.
+        missing = [
+            phase["file"]
+            for phase in run.phases
+            if isinstance(phase.get("file"), str) and phase["file"]
+            and phase["file"] not in run.phase_texts
+        ]
+        if missing:
+            return ScorerResult(
+                self.name, self.kind, VERDICT_FAIL, 0.0,
+                [f"declared phase file missing: {name}" for name in missing],
+                f"{len(run.phases)} declared phases")
+        return ScorerResult(
+            self.name, self.kind, VERDICT_PASS, 100.0, [],
+            f"{len(run.phases)} declared phases, all present")
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-reference-scorer
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-load-scenarios
+def load_scenarios(root: Path) -> List[Scenario]:
+    """Discover scenarios under ``root`` by globbing ``*/scenario.toml``.
+
+    A malformed or id-less descriptor is skipped with a warning, never raised, and a
+    ``run_dir``/gold path that escapes the scenario directory (absolute or ``..``) is
+    rejected — one bad or unsafe scenario must not sink the whole suite.
+    """
+    scenarios: List[Scenario] = []
+    for descriptor in sorted(root.glob("*/scenario.toml")):
+        try:
+            with open(descriptor, "rb") as handle:
+                data = tomllib.load(handle)
+        except (OSError, tomllib.TOMLDecodeError) as exc:
+            logger.warning("eval: skipping unreadable scenario descriptor %s: %s", descriptor, exc)
+            continue
+        section = data.get("scenario", {})
+        scenario_id = section.get("id")
+        if not scenario_id:
+            logger.warning("eval: scenario descriptor missing [scenario].id: %s", descriptor)
+            continue
+        base = descriptor.parent
+        run_dir = base / str(section.get("run_dir", "run"))
+        if not run_dir.resolve().is_relative_to(base.resolve()):
+            # Keep scenarios self-contained: reject absolute or ../ paths that escape the base.
+            logger.warning("eval: scenario %s run_dir escapes its directory, skipping: %s",
+                           scenario_id, section.get("run_dir"))
+            continue
+        gold = section.get("gold", {})
+        gold_rel = gold.get("path") if isinstance(gold, dict) else None
+        gold_path = None
+        if gold_rel:
+            candidate = base / str(gold_rel)
+            if candidate.resolve().is_relative_to(base.resolve()):
+                gold_path = candidate
+            else:
+                logger.warning("eval: scenario %s gold path escapes its directory, ignoring: %s",
+                               scenario_id, gold_rel)
+        scenarios.append(Scenario(
+            id=str(scenario_id),
+            workflow=str(section.get("workflow", "unknown")),
+            run_dir=run_dir,
+            expect=str(section.get("expect", "unknown")),
+            gold_path=gold_path,
+        ))
+    return scenarios
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-load-scenarios
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-load-run
+def load_run(run_dir: Path) -> Optional[RunArtifacts]:
+    """Load a completed run's ``plan.toml`` + ``phase-*.md``.
+
+    Returns ``None`` (→ UNKNOWN) for a missing or malformed plan rather than raising:
+    "unscoreable != zero". A declared phase file that cannot be read is simply absent
+    from ``phase_texts`` so a scorer can report it, not a crash.
+    """
+    plan_path = run_dir / "plan.toml"
+    try:
+        with open(plan_path, "rb") as handle:
+            manifest = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        logger.warning("eval: run has no readable plan.toml at %s: %s", plan_path, exc)
+        return None
+    plan_meta = manifest.get("plan")
+    if not isinstance(plan_meta, dict) or not plan_meta:
+        logger.warning("eval: plan.toml missing a [plan] section: %s", plan_path)
+        return None
+    phases = manifest.get("phases", [])
+    if not isinstance(phases, list):
+        logger.warning("eval: plan.toml [[phases]] is not a list: %s", plan_path)
+        return None
+    phases = [phase for phase in phases if isinstance(phase, dict)]  # drop malformed entries
+    phase_texts: Dict[str, str] = {}
+    for phase in phases:
+        name = phase.get("file")
+        if not isinstance(name, str) or not name:   # non-string file must not crash the run
+            continue
+        target = run_dir / name
+        if not target.resolve().is_relative_to(run_dir.resolve()):
+            # A phase file that escapes the run dir (absolute or ../) is never read.
+            logger.warning("eval: phase file escapes the run dir, skipping: %s", name)
+            continue
+        try:
+            phase_texts[name] = target.read_text(encoding="utf-8")
+        except OSError as exc:
+            # Absent/unreadable phase → left out of phase_texts so a scorer flags it.
+            logger.debug("eval: declared phase file unreadable (%s): %s", name, exc)
+            continue
+    return RunArtifacts(plan_meta=plan_meta, phases=phases, phase_texts=phase_texts)
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-load-run
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-run-scenario
+def run_scenario(scenario: Scenario, scorers: List[Scorer]) -> ScenarioResult:
+    """Load one scenario's run and apply every scorer to it.
+
+    A scorer that raises degrades to UNKNOWN for that scenario (with a warning) rather
+    than sinking the whole suite — the seam must tolerate a misbehaving future scorer.
+    """
+    run = load_run(scenario.run_dir)
+    results: List[ScorerResult] = []
+    for scorer in scorers:
+        try:
+            results.append(scorer.score(run, scenario))
+        # A plugged-in scorer must not crash the whole run — degrade it to UNKNOWN.
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("eval: scorer %s raised on scenario %s: %s",
+                           getattr(scorer, "name", "?"), scenario.id, exc)
+            results.append(ScorerResult(
+                getattr(scorer, "name", "unknown-scorer"),
+                getattr(scorer, "kind", ScorerKind.ADVISORY),
+                VERDICT_UNKNOWN, None, [f"scorer raised: {exc}"], "scorer error"))
+    return ScenarioResult(scenario.id, scenario.workflow, results, scenario.expect)
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-run-scenario
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-run-suite
+def run_suite(root: Path, scorers: List[Scorer]) -> EvalReport:
+    """Run every scenario under ``root`` through ``scorers`` and aggregate."""
+    return EvalReport([run_scenario(scenario, scorers) for scenario in load_scenarios(root)])
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-run-suite
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-compliance
+def _scenario_compliance(scenario_result: ScenarioResult) -> Tuple[int, int, Optional[float]]:
+    """Deterministic (passed, total, fraction|None) for one scenario. UNKNOWN excluded."""
+    passed = 0
+    failed = 0
+    for result in scenario_result.results:
+        if result.kind is ScorerKind.DETERMINISTIC:
+            if result.verdict == VERDICT_PASS:
+                passed += 1
+            elif result.verdict == VERDICT_FAIL:
+                failed += 1
+    total = passed + failed
+    return passed, total, (round(passed / total, 4) if total else None)
+
+
+def structural_compliance(report: EvalReport) -> Optional[float]:
+    """Aggregate deterministic pass ratio across the suite. ``None`` when nothing scored.
+
+    Only deterministic verdicts count — this is the number gating reads, so an advisory
+    scorer can never affect it.
+    """
+    passed = 0
+    total = 0
+    for scenario_result in report.scenarios:
+        scenario_passed, scenario_total, _ = _scenario_compliance(scenario_result)
+        passed += scenario_passed
+        total += scenario_total
+    return round(passed / total, 4) if total else None
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-compliance
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-gate
+def gate_exit_code(compliance: Optional[float], check: bool, min_compliance: float) -> int:
+    """Opt-in gating: exit 2 only under ``check`` when compliance is below the floor.
+
+    Gating is off by default (running eval reports, it does not fail a build unless
+    asked). Nothing-scoreable (``compliance is None``) never fails. Advisory verdicts
+    never reach here because they are excluded from ``compliance``.
+    """
+    if check and compliance is not None and compliance < min_compliance:
+        return 2
+    return 0
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-gate
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-report-json
+def report_to_dict(report: EvalReport) -> Dict[str, object]:
+    """Serialise a report: per-scenario compliance, a failing-check histogram, and an
+    UNKNOWN-aware, coverage-stating summary."""
+    scored = 0
+    unknown = 0
+    scorers_seen: Dict[str, str] = {}          # name -> kind, so coverage reflects what ran
+    failing: Dict[str, int] = {}               # deterministic FAILs per scorer (histogram)
+    per_scenario: List[Dict[str, object]] = []
+    for scenario_result in report.scenarios:
+        results_json: List[Dict[str, object]] = []
+        for result in scenario_result.results:
+            scorers_seen[result.scorer] = result.kind.value
+            if result.verdict == VERDICT_UNKNOWN:
+                unknown += 1
+            else:
+                scored += 1
+            if result.kind is ScorerKind.DETERMINISTIC and result.verdict == VERDICT_FAIL:
+                failing[result.scorer] = failing.get(result.scorer, 0) + 1
+            results_json.append({
+                "scorer": result.scorer,
+                "kind": result.kind.value,
+                "verdict": result.verdict,
+                "score_pct": result.score_pct,
+                "findings": result.findings,
+                "coverage": result.coverage,
+            })
+        scenario_passed, scenario_total, scenario_compliance = _scenario_compliance(scenario_result)
+        per_scenario.append({
+            "scenario": scenario_result.scenario_id,
+            "workflow": scenario_result.workflow,
+            "expect": scenario_result.expect,
+            "compliance": scenario_compliance,
+            "passed": scenario_passed,
+            "total": scenario_total,
+            "results": results_json,
+        })
+    coverage = "; ".join(f"{name} ({kind})" for name, kind in sorted(scorers_seen.items())) \
+        or "no scorers ran"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "summary": {
+            "scenarios": len(report.scenarios),
+            "results": scored + unknown,   # scored/unknown count scorer-results, not scenarios
+            "scored": scored,
+            "unknown": unknown,
+            "structural_compliance": structural_compliance(report),
+            "coverage": coverage,
+        },
+        "failing_checks": dict(sorted(failing.items(), key=lambda item: item[1], reverse=True)),
+        "per_scenario": per_scenario,
+    }
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-report-json
+
+
+# @cpt-begin:cpt-studio-algo-eval-harness-run:p1:inst-diff-reports
+def diff_reports(report: EvalReport, baseline: Dict[str, object]) -> Dict[str, object]:
+    """Per-scenario compliance change vs a baseline report, bucketed.
+
+    Distinguishes improvements from regressions (unlike a flat verdict diff): a scenario
+    dropping out of scoring, or its compliance falling, is a regression; a scenario
+    scoring for the first time or rising is not. ``has_regression`` is the gate-worthy bit.
+    """
+    prev = {row.get("scenario"): row.get("compliance")
+            for row in baseline.get("per_scenario", [])}
+    regressed: List[Dict[str, object]] = []
+    improved: List[Dict[str, object]] = []
+    newly_scoreable: List[Dict[str, object]] = []
+    no_longer_scoreable: List[Dict[str, object]] = []
+    seen = set()
+    for scenario_result in report.scenarios:
+        scenario_id = scenario_result.scenario_id
+        seen.add(scenario_id)
+        _, _, now = _scenario_compliance(scenario_result)
+        before = prev.get(scenario_id)
+        if scenario_id not in prev or before is None:
+            if now is not None:
+                newly_scoreable.append({"scenario": scenario_id, "to": now})
+        elif now is None:
+            no_longer_scoreable.append({"scenario": scenario_id, "from": before})
+        elif now < before:
+            regressed.append({"scenario": scenario_id, "from": before, "to": now})
+        elif now > before:
+            improved.append({"scenario": scenario_id, "from": before, "to": now})
+    for scenario_id, before in prev.items():
+        if scenario_id not in seen and before is not None:
+            no_longer_scoreable.append({"scenario": scenario_id, "from": before})
+    return {
+        "regressed": regressed,
+        "improved": improved,
+        "newly_scoreable": newly_scoreable,
+        "no_longer_scoreable": no_longer_scoreable,
+        "aggregate_before": baseline.get("summary", {}).get("structural_compliance"),
+        "aggregate_after": structural_compliance(report),
+        "has_regression": bool(regressed or no_longer_scoreable),
+    }
+# @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-diff-reports

--- a/skills/studio/scripts/studio/utils/eval_harness.py
+++ b/skills/studio/scripts/studio/utils/eval_harness.py
@@ -129,7 +129,7 @@ class ReferencePresenceScorer:  # pylint: disable=too-few-public-methods
 
     def score(self, run: Optional[RunArtifacts],
               scenario: Scenario) -> ScorerResult:  # pylint: disable=unused-argument
-        """PASS if every declared phase is present, FAIL if any missing, UNKNOWN if unloadable."""
+        """PASS if every checkable phase file is present, FAIL if any missing, else UNKNOWN."""
         if run is None:
             return ScorerResult(
                 self.name, self.kind, VERDICT_UNKNOWN, None,
@@ -138,22 +138,23 @@ class ReferencePresenceScorer:  # pylint: disable=too-few-public-methods
             return ScorerResult(
                 self.name, self.kind, VERDICT_UNKNOWN, None,
                 ["run declares no phases"], "unscoreable: nothing to assess")
-        # phases are normalised to dicts by load_run; a phase with no file is a benign
-        # skip (matching load_run), not a missing file.
-        missing = [
-            phase["file"]
-            for phase in run.phases
-            if isinstance(phase.get("file"), str) and phase["file"]
-            and phase["file"] not in run.phase_texts
-        ]
+        # Only phases that declare a file are checkable. A run whose phases declare no
+        # verifiable file is unscoreable by this scorer, not a vacuous 100% pass.
+        checkable = [phase["file"] for phase in run.phases
+                     if isinstance(phase.get("file"), str) and phase["file"]]
+        if not checkable:
+            return ScorerResult(
+                self.name, self.kind, VERDICT_UNKNOWN, None,
+                ["no phase declares a checkable file"], "unscoreable: nothing to verify")
+        missing = [name for name in checkable if name not in run.phase_texts]
         if missing:
             return ScorerResult(
                 self.name, self.kind, VERDICT_FAIL, 0.0,
                 [f"declared phase file missing: {name}" for name in missing],
-                f"{len(run.phases)} declared phases")
+                f"{len(checkable)} checkable phase file(s)")
         return ScorerResult(
             self.name, self.kind, VERDICT_PASS, 100.0, [],
-            f"{len(run.phases)} declared phases, all present")
+            f"{len(checkable)} checkable phase file(s), all present")
 # @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-reference-scorer
 
 
@@ -174,6 +175,9 @@ def load_scenarios(root: Path) -> List[Scenario]:
             logger.warning("eval: skipping unreadable scenario descriptor %s: %s", descriptor, exc)
             continue
         section = data.get("scenario", {})
+        if not isinstance(section, dict):
+            logger.warning("eval: [scenario] is not a table, skipping: %s", descriptor)
+            continue
         scenario_id = section.get("id")
         if not scenario_id:
             logger.warning("eval: scenario descriptor missing [scenario].id: %s", descriptor)
@@ -332,6 +336,8 @@ def report_to_dict(report: EvalReport) -> Dict[str, object]:
     UNKNOWN-aware, coverage-stating summary."""
     scored = 0
     unknown = 0
+    agg_passed = 0                             # accumulate the aggregate here to avoid a 2nd pass
+    agg_total = 0
     scorers_seen: Dict[str, str] = {}          # name -> kind, so coverage reflects what ran
     failing: Dict[str, int] = {}               # deterministic FAILs per scorer (histogram)
     per_scenario: List[Dict[str, object]] = []
@@ -354,6 +360,8 @@ def report_to_dict(report: EvalReport) -> Dict[str, object]:
                 "coverage": result.coverage,
             })
         scenario_passed, scenario_total, scenario_compliance = _scenario_compliance(scenario_result)
+        agg_passed += scenario_passed
+        agg_total += scenario_total
         per_scenario.append({
             "scenario": scenario_result.scenario_id,
             "workflow": scenario_result.workflow,
@@ -372,7 +380,7 @@ def report_to_dict(report: EvalReport) -> Dict[str, object]:
             "results": scored + unknown,   # scored/unknown count scorer-results, not scenarios
             "scored": scored,
             "unknown": unknown,
-            "structural_compliance": structural_compliance(report),
+            "structural_compliance": round(agg_passed / agg_total, 4) if agg_total else None,
             "coverage": coverage,
         },
         "failing_checks": dict(sorted(failing.items(), key=lambda item: item[1], reverse=True)),
@@ -385,12 +393,18 @@ def report_to_dict(report: EvalReport) -> Dict[str, object]:
 def diff_reports(report: EvalReport, baseline: Dict[str, object]) -> Dict[str, object]:
     """Per-scenario compliance change vs a baseline report, bucketed.
 
-    Distinguishes improvements from regressions (unlike a flat verdict diff): a scenario
-    dropping out of scoring, or its compliance falling, is a regression; a scenario
-    scoring for the first time or rising is not. ``has_regression`` is the gate-worthy bit.
+    A scenario whose compliance falls, **or which was scoreable in the baseline and is now
+    unscoreable while still in the suite (its run broke)**, is a regression and gates
+    ``--check``. One that scores for the first time or rises is not. A scenario that is
+    gone from the suite entirely is surfaced in ``no_longer_scoreable`` but is **not** a
+    regression — removing an obsolete scenario should not fail a build. A baseline whose
+    per-scenario compliance is missing or non-numeric is treated as "no prior value" (no
+    comparison), never a crash. ``has_regression`` reflects only ``regressed``.
     """
-    prev = {row.get("scenario"): row.get("compliance")
-            for row in baseline.get("per_scenario", [])}
+    rows = baseline.get("per_scenario", [])
+    prev = ({row.get("scenario"): row.get("compliance")
+             for row in rows if isinstance(row, dict)}
+            if isinstance(rows, list) else {})
     regressed: List[Dict[str, object]] = []
     improved: List[Dict[str, object]] = []
     newly_scoreable: List[Dict[str, object]] = []
@@ -401,25 +415,31 @@ def diff_reports(report: EvalReport, baseline: Dict[str, object]) -> Dict[str, o
         seen.add(scenario_id)
         _, _, now = _scenario_compliance(scenario_result)
         before = prev.get(scenario_id)
-        if scenario_id not in prev or before is None:
+        if not isinstance(before, (int, float)):   # missing/non-numeric baseline → no comparison
+            before = None
+        if before is None:
             if now is not None:
                 newly_scoreable.append({"scenario": scenario_id, "to": now})
         elif now is None:
-            no_longer_scoreable.append({"scenario": scenario_id, "from": before})
+            # still in the suite but no longer scoreable (its run broke) — a regression.
+            regressed.append({"scenario": scenario_id, "from": before, "to": None})
         elif now < before:
             regressed.append({"scenario": scenario_id, "from": before, "to": now})
         elif now > before:
             improved.append({"scenario": scenario_id, "from": before, "to": now})
     for scenario_id, before in prev.items():
-        if scenario_id not in seen and before is not None:
+        if scenario_id not in seen and isinstance(before, (int, float)):
+            # gone from the suite entirely — surfaced, but not a gate-worthy regression.
             no_longer_scoreable.append({"scenario": scenario_id, "from": before})
+    baseline_summary = baseline.get("summary", {})
     return {
         "regressed": regressed,
         "improved": improved,
         "newly_scoreable": newly_scoreable,
         "no_longer_scoreable": no_longer_scoreable,
-        "aggregate_before": baseline.get("summary", {}).get("structural_compliance"),
+        "aggregate_before": (baseline_summary.get("structural_compliance")
+                             if isinstance(baseline_summary, dict) else None),
         "aggregate_after": structural_compliance(report),
-        "has_regression": bool(regressed or no_longer_scoreable),
+        "has_regression": bool(regressed),   # removals are surfaced, not gated
     }
 # @cpt-end:cpt-studio-algo-eval-harness-run:p1:inst-diff-reports

--- a/skills/studio/scripts/studio/utils/eval_harness.py
+++ b/skills/studio/scripts/studio/utils/eval_harness.py
@@ -402,8 +402,11 @@ def diff_reports(report: EvalReport, baseline: Dict[str, object]) -> Dict[str, o
     comparison), never a crash. ``has_regression`` reflects only ``regressed``.
     """
     rows = baseline.get("per_scenario", [])
-    prev = ({row.get("scenario"): row.get("compliance")
-             for row in rows if isinstance(row, dict)}
+    # Only string scenario ids: a non-string/unhashable id (e.g. a list) would raise when
+    # used as a dict key and never matches a real scenario anyway.
+    prev = ({row["scenario"]: row.get("compliance")
+             for row in rows
+             if isinstance(row, dict) and isinstance(row.get("scenario"), str)}
             if isinstance(rows, list) else {})
     regressed: List[Dict[str, object]] = []
     improved: List[Dict[str, object]] = []

--- a/skills/studio/scripts/studio/utils/eval_harness.py
+++ b/skills/studio/scripts/studio/utils/eval_harness.py
@@ -415,7 +415,8 @@ def diff_reports(report: EvalReport, baseline: Dict[str, object]) -> Dict[str, o
         seen.add(scenario_id)
         _, _, now = _scenario_compliance(scenario_result)
         before = prev.get(scenario_id)
-        if not isinstance(before, (int, float)):   # missing/non-numeric baseline → no comparison
+        # missing / non-numeric baseline → no comparison; exclude bool (a subclass of int).
+        if not isinstance(before, (int, float)) or isinstance(before, bool):
             before = None
         if before is None:
             if now is not None:
@@ -428,7 +429,8 @@ def diff_reports(report: EvalReport, baseline: Dict[str, object]) -> Dict[str, o
         elif now > before:
             improved.append({"scenario": scenario_id, "from": before, "to": now})
     for scenario_id, before in prev.items():
-        if scenario_id not in seen and isinstance(before, (int, float)):
+        if (scenario_id not in seen and isinstance(before, (int, float))
+                and not isinstance(before, bool)):
             # gone from the suite entirely — surfaced, but not a gate-worthy regression.
             no_longer_scoreable.append({"scenario": scenario_id, "from": before})
     baseline_summary = baseline.get("summary", {})

--- a/tests/fixtures/eval/compliant/run/phase-1.md
+++ b/tests/fixtures/eval/compliant/run/phase-1.md
@@ -1,0 +1,3 @@
+# Phase 1
+
+A present phase file.

--- a/tests/fixtures/eval/compliant/run/plan.toml
+++ b/tests/fixtures/eval/compliant/run/plan.toml
@@ -1,0 +1,6 @@
+[plan]
+task = "demo compliant run"
+
+[[phases]]
+number = 1
+file = "phase-1.md"

--- a/tests/fixtures/eval/compliant/scenario.toml
+++ b/tests/fixtures/eval/compliant/scenario.toml
@@ -1,0 +1,5 @@
+[scenario]
+id = "compliant-run"
+workflow = "coding-gen"
+run_dir = "run"
+expect = "compliant"

--- a/tests/fixtures/eval/non_compliant/run/phase-1.md
+++ b/tests/fixtures/eval/non_compliant/run/phase-1.md
@@ -1,0 +1,3 @@
+# Phase 1
+
+Present; phase-2.md is deliberately absent so the reference scorer FAILs.

--- a/tests/fixtures/eval/non_compliant/run/plan.toml
+++ b/tests/fixtures/eval/non_compliant/run/plan.toml
@@ -1,0 +1,10 @@
+[plan]
+task = "demo non-compliant run"
+
+[[phases]]
+number = 1
+file = "phase-1.md"
+
+[[phases]]
+number = 2
+file = "phase-2.md"

--- a/tests/fixtures/eval/non_compliant/scenario.toml
+++ b/tests/fixtures/eval/non_compliant/scenario.toml
@@ -1,0 +1,5 @@
+[scenario]
+id = "non-compliant-run"
+workflow = "coding-gen"
+run_dir = "run"
+expect = "non_compliant"

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -1,0 +1,186 @@
+"""Tests for the ``cfs eval`` command."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from studio import cli
+from studio.commands.eval import cmd_eval
+from studio.utils import ui as ui_module
+
+FIXTURES = Path(__file__).parent / "fixtures" / "eval"
+_GET_CONTEXT = "studio.utils.context.get_context"
+
+
+def _ctx(project_root: Path) -> MagicMock:
+    ctx = MagicMock()
+    ctx.project_root = project_root
+    return ctx
+
+
+def _write_compliant(root: Path, sid: str = "ok") -> None:
+    run = root / sid / "run"
+    run.mkdir(parents=True)
+    (root / sid / "scenario.toml").write_text(
+        f'[scenario]\nid = "{sid}"\nworkflow = "w"\nrun_dir = "run"\nexpect = "compliant"\n')
+    (run / "plan.toml").write_text('[plan]\ntask = "t"\n[[phases]]\nnumber = 1\nfile = "p.md"\n')
+    (run / "p.md").write_text("# p\n")
+
+
+# --- wiring + errors -------------------------------------------------------
+
+def test_eval_is_wired_into_the_dispatch(capsys) -> None:
+    handler = cli._resolve_command_handler("eval")
+    assert handler is not None
+    with patch(_GET_CONTEXT, return_value=None):
+        assert handler([]) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "ERROR"
+
+
+def test_cmd_eval_errors_without_context(capsys) -> None:
+    with patch(_GET_CONTEXT, return_value=None):
+        assert cmd_eval([]) == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "ERROR"
+
+
+def test_cmd_eval_missing_scenarios_dir_errors(capsys, tmp_path: Path) -> None:
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(tmp_path / "nope")])
+    assert rc == 1
+    assert json.loads(capsys.readouterr().out)["status"] == "ERROR"
+
+
+# --- reporting + opt-in gating ---------------------------------------------
+
+def test_cmd_eval_reports_without_gating(capsys, tmp_path: Path) -> None:
+    # Without --check, a failing scenario still exits 0 — eval reports, it does not gate.
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["summary"]["scenarios"] == 2
+    assert out["summary"]["structural_compliance"] == 0.5
+
+
+def test_cmd_eval_check_gates_below_min(capsys, tmp_path: Path) -> None:
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--check"])
+    assert rc == 2                                   # compliance 0.5 < default min 1.0
+    assert json.loads(capsys.readouterr().out)["summary"]["structural_compliance"] == 0.5
+
+
+def test_cmd_eval_check_passes_above_min(capsys, tmp_path: Path) -> None:
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--check", "--min", "0.4"])
+    assert rc == 0                                   # 0.5 >= 0.4
+
+
+def test_cmd_eval_check_passes_when_all_compliant(capsys, tmp_path: Path) -> None:
+    scenarios = tmp_path / "scenarios"
+    scenarios.mkdir()
+    _write_compliant(scenarios)
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(scenarios), "--check"])
+    assert rc == 0
+
+
+def test_cmd_eval_defaults_to_project_eval_dir(capsys, tmp_path: Path) -> None:
+    _write_compliant(tmp_path / "eval")
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval([])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["summary"]["scenarios"] == 1
+
+
+# --- baseline diff + save --------------------------------------------------
+
+def test_cmd_eval_baseline_reports_regression(capsys, tmp_path: Path) -> None:
+    baseline = {"summary": {"structural_compliance": 1.0}, "per_scenario": [
+        {"scenario": "non-compliant-run", "compliance": 1.0}]}   # was 1.0, now 0.0 → regression
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(baseline))
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(baseline_path)])
+    regression = json.loads(capsys.readouterr().out)["regression"]
+    assert regression["has_regression"] is True
+    assert [r["scenario"] for r in regression["regressed"]] == ["non-compliant-run"]
+
+
+def test_cmd_eval_check_gates_on_regression(capsys, tmp_path: Path) -> None:
+    # compliance 0.5 >= --min 0.4, but a regression vs baseline must still fail --check.
+    baseline = {"summary": {"structural_compliance": 1.0},
+                "per_scenario": [{"scenario": "non-compliant-run", "compliance": 1.0}]}
+    baseline_path = tmp_path / "b.json"
+    baseline_path.write_text(json.dumps(baseline))
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--check", "--min", "0.4",
+                       "--baseline", str(baseline_path)])
+    assert rc == 2                                    # regression fails --check despite ≥ --min
+    assert json.loads(capsys.readouterr().out)["regression"]["has_regression"] is True
+
+
+def test_cmd_eval_check_does_not_gate_on_removed_scenario(capsys, tmp_path: Path) -> None:
+    # A baseline scenario that no longer exists is surfaced but must not fail --check.
+    baseline = {"summary": {"structural_compliance": 1.0}, "per_scenario": [
+        {"scenario": "compliant-run", "compliance": 1.0},
+        {"scenario": "non-compliant-run", "compliance": 0.0},   # unchanged → no regression
+        {"scenario": "gone", "compliance": 1.0}]}               # removed
+    baseline_path = tmp_path / "b.json"
+    baseline_path.write_text(json.dumps(baseline))
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--check", "--min", "0.4",
+                       "--baseline", str(baseline_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0                                    # a removal does not gate
+    assert [r["scenario"] for r in out["regression"]["no_longer_scoreable"]] == ["gone"]
+
+
+def test_cmd_eval_malformed_baseline_skips_diff(capsys, tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not json")
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(bad)])
+    assert "regression" not in json.loads(capsys.readouterr().out)
+
+
+def test_cmd_eval_non_dict_baseline_skips_diff(capsys, tmp_path: Path) -> None:
+    listy = tmp_path / "list.json"
+    listy.write_text("[]")
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(listy)])
+    assert "regression" not in json.loads(capsys.readouterr().out)
+
+
+def test_cmd_eval_save_writes_report(capsys, tmp_path: Path) -> None:
+    saved = tmp_path / "report.json"
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        cmd_eval(["--scenarios-dir", str(FIXTURES), "--save", str(saved)])
+    out = json.loads(capsys.readouterr().out)
+    assert out["saved"] == str(saved)
+    assert saved.is_file()
+    assert json.loads(saved.read_text())["summary"]["structural_compliance"] == 0.5
+
+
+def test_cmd_eval_save_error_is_reported_not_raised(capsys, tmp_path: Path) -> None:
+    # Saving onto a directory path fails; the run must still succeed and report the error.
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--save", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["saved"] is None
+    assert "save_error" in out
+
+
+# --- human report ----------------------------------------------------------
+
+def test_human_report_shows_compliance(capsys, tmp_path: Path) -> None:
+    ui_module.set_json_mode(False)
+    try:
+        with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+            rc = cmd_eval(["--scenarios-dir", str(FIXTURES)])
+    finally:
+        ui_module.set_json_mode(True)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "compliance" in out

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -5,6 +5,8 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from studio import cli
 from studio.commands.eval import cmd_eval
 from studio.utils import ui as ui_module
@@ -49,6 +51,24 @@ def test_cmd_eval_missing_scenarios_dir_errors(capsys, tmp_path: Path) -> None:
         rc = cmd_eval(["--scenarios-dir", str(tmp_path / "nope")])
     assert rc == 1
     assert json.loads(capsys.readouterr().out)["status"] == "ERROR"
+
+
+@pytest.mark.parametrize("bad", ["nan", "inf", "-0.1", "1.5", "abc"])
+def test_cmd_eval_rejects_invalid_min(bad: str) -> None:
+    # argparse rejects a non-finite / out-of-range --min so a failing run can't slip past --check.
+    with pytest.raises(SystemExit):
+        cmd_eval(["--min", bad, "--scenarios-dir", "unused"])
+
+
+def test_cmd_eval_gate_field_matches_exit(capsys, tmp_path: Path) -> None:
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--check"])   # 0.5 < 1.0 → fail
+    assert rc == 2
+    assert json.loads(capsys.readouterr().out)["gate"] == "fail"
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES)])              # report only → pass
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["gate"] == "pass"
 
 
 # --- reporting + opt-in gating ---------------------------------------------
@@ -101,7 +121,8 @@ def test_cmd_eval_baseline_reports_regression(capsys, tmp_path: Path) -> None:
     baseline_path = tmp_path / "baseline.json"
     baseline_path.write_text(json.dumps(baseline))
     with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
-        cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(baseline_path)])
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(baseline_path)])
+    assert rc == 0                          # AC#4: --baseline alone never changes the exit code
     regression = json.loads(capsys.readouterr().out)["regression"]
     assert regression["has_regression"] is True
     assert [r["scenario"] for r in regression["regressed"]] == ["non-compliant-run"]
@@ -120,6 +141,17 @@ def test_cmd_eval_check_gates_on_regression(capsys, tmp_path: Path) -> None:
     assert json.loads(capsys.readouterr().out)["regression"]["has_regression"] is True
 
 
+def test_cmd_eval_check_fails_closed_on_unusable_baseline(capsys, tmp_path: Path) -> None:
+    # --check with a baseline that can't be loaded must fail, not silently pass.
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--check", "--min", "0.0",
+                       "--baseline", str(tmp_path / "missing.json")])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 2                                    # requested regression check could not run
+    assert "error" in out["regression"]
+    assert out["gate"] == "fail"
+
+
 def test_cmd_eval_check_does_not_gate_on_removed_scenario(capsys, tmp_path: Path) -> None:
     # A baseline scenario that no longer exists is surfaced but must not fail --check.
     baseline = {"summary": {"structural_compliance": 1.0}, "per_scenario": [
@@ -133,23 +165,43 @@ def test_cmd_eval_check_does_not_gate_on_removed_scenario(capsys, tmp_path: Path
                        "--baseline", str(baseline_path)])
     out = json.loads(capsys.readouterr().out)
     assert rc == 0                                    # a removal does not gate
+    assert out["regression"]["has_regression"] is False
     assert [r["scenario"] for r in out["regression"]["no_longer_scoreable"]] == ["gone"]
 
 
-def test_cmd_eval_malformed_baseline_skips_diff(capsys, tmp_path: Path) -> None:
+def test_cmd_eval_malformed_baseline_reports_error(capsys, tmp_path: Path) -> None:
+    # Schema stability: --baseline always yields a `regression` key, an error object here.
     bad = tmp_path / "bad.json"
     bad.write_text("{ not json")
     with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
         cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(bad)])
-    assert "regression" not in json.loads(capsys.readouterr().out)
+    regression = json.loads(capsys.readouterr().out)["regression"]
+    assert "error" in regression
 
 
-def test_cmd_eval_non_dict_baseline_skips_diff(capsys, tmp_path: Path) -> None:
+def test_cmd_eval_non_dict_baseline_reports_error(capsys, tmp_path: Path) -> None:
     listy = tmp_path / "list.json"
     listy.write_text("[]")
     with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
         cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(listy)])
-    assert "regression" not in json.loads(capsys.readouterr().out)
+    assert "error" in json.loads(capsys.readouterr().out)["regression"]
+
+
+def test_cmd_eval_malformed_shape_baseline_reports_error(capsys, tmp_path: Path) -> None:
+    # A dict whose per_scenario is not a list of objects must not reach diff_reports.
+    bad = tmp_path / "shape.json"
+    bad.write_text(json.dumps({"summary": {}, "per_scenario": "nope"}))
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(bad)])
+    assert "error" in json.loads(capsys.readouterr().out)["regression"]
+
+
+def test_cmd_eval_bad_summary_baseline_reports_error(capsys, tmp_path: Path) -> None:
+    bad = tmp_path / "sum.json"
+    bad.write_text(json.dumps({"summary": "not a dict", "per_scenario": []}))
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        cmd_eval(["--scenarios-dir", str(FIXTURES), "--baseline", str(bad)])
+    assert "error" in json.loads(capsys.readouterr().out)["regression"]
 
 
 def test_cmd_eval_save_writes_report(capsys, tmp_path: Path) -> None:
@@ -159,7 +211,18 @@ def test_cmd_eval_save_writes_report(capsys, tmp_path: Path) -> None:
     out = json.loads(capsys.readouterr().out)
     assert out["saved"] == str(saved)
     assert saved.is_file()
+    assert saved.stat().st_mode & 0o044                # readable by group/other, not owner-only
     assert json.loads(saved.read_text())["summary"]["structural_compliance"] == 0.5
+
+
+def test_cmd_eval_save_to_missing_dir_reports_error(capsys, tmp_path: Path) -> None:
+    # A --save path whose parent dir does not exist fails at temp creation, not with a crash.
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--save", str(tmp_path / "nope" / "r.json")])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["saved"] is None
+    assert "save_error" in out
 
 
 def test_cmd_eval_save_error_is_reported_not_raised(capsys, tmp_path: Path) -> None:

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from studio import cli
-from studio.commands.eval import cmd_eval
+from studio.commands.eval import _build_parser, cmd_eval
 from studio.utils import ui as ui_module
 
 FIXTURES = Path(__file__).parent / "fixtures" / "eval"
@@ -69,6 +69,49 @@ def test_cmd_eval_gate_field_matches_exit(capsys, tmp_path: Path) -> None:
         rc = cmd_eval(["--scenarios-dir", str(FIXTURES)])              # report only → pass
     assert rc == 0
     assert json.loads(capsys.readouterr().out)["gate"] == "pass"
+
+
+def test_cmd_eval_gate_pass_under_check_when_compliant(capsys, tmp_path: Path) -> None:
+    scenarios = tmp_path / "scenarios"
+    scenarios.mkdir()
+    _write_compliant(scenarios)
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(scenarios), "--check"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out)["gate"] == "pass"
+
+
+def test_check_help_documents_baseline_regression() -> None:
+    assert "regression" in _build_parser().format_help()   # A2: full gate contract documented
+
+
+def test_cmd_eval_empty_suite_is_honest_zero(capsys, tmp_path: Path) -> None:
+    # An existing but empty scenarios dir scores nothing → honest exit 0, compliance null.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(empty), "--check"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["summary"]["scenarios"] == 0
+    assert out["summary"]["structural_compliance"] is None
+
+
+def test_cmd_eval_check_gates_on_broke_scenario(capsys, tmp_path: Path) -> None:
+    # A scenario still in the suite whose run broke (UNKNOWN) fails --check vs a baseline.
+    scenarios = tmp_path / "scenarios"
+    (scenarios / "x").mkdir(parents=True)
+    (scenarios / "x" / "scenario.toml").write_text('[scenario]\nid = "x"\n')   # no run → UNKNOWN
+    baseline = {"summary": {"structural_compliance": 1.0},
+                "per_scenario": [{"scenario": "x", "compliance": 1.0}]}
+    baseline_path = tmp_path / "b.json"
+    baseline_path.write_text(json.dumps(baseline))
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(scenarios), "--check", "--min", "0.0",
+                       "--baseline", str(baseline_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert out["regression"]["has_regression"] is True
 
 
 # --- reporting + opt-in gating ---------------------------------------------

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -141,15 +141,16 @@ def test_cmd_eval_check_gates_on_regression(capsys, tmp_path: Path) -> None:
     assert json.loads(capsys.readouterr().out)["regression"]["has_regression"] is True
 
 
-def test_cmd_eval_check_fails_closed_on_unusable_baseline(capsys, tmp_path: Path) -> None:
-    # --check with a baseline that can't be loaded must fail, not silently pass.
+def test_cmd_eval_check_unusable_baseline_surfaced_not_gated(capsys, tmp_path: Path) -> None:
+    # An unusable --baseline is surfaced via the regression `error` field but does not, by
+    # itself, fail --check — the --min floor still applies (documented warn-and-skip).
     with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
         rc = cmd_eval(["--scenarios-dir", str(FIXTURES), "--check", "--min", "0.0",
                        "--baseline", str(tmp_path / "missing.json")])
     out = json.loads(capsys.readouterr().out)
-    assert rc == 2                                    # requested regression check could not run
+    assert rc == 0
     assert "error" in out["regression"]
-    assert out["gate"] == "fail"
+    assert out["gate"] == "pass"
 
 
 def test_cmd_eval_check_does_not_gate_on_removed_scenario(capsys, tmp_path: Path) -> None:
@@ -211,7 +212,6 @@ def test_cmd_eval_save_writes_report(capsys, tmp_path: Path) -> None:
     out = json.loads(capsys.readouterr().out)
     assert out["saved"] == str(saved)
     assert saved.is_file()
-    assert saved.stat().st_mode & 0o044                # readable by group/other, not owner-only
     assert json.loads(saved.read_text())["summary"]["structural_compliance"] == 0.5
 
 

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -347,6 +347,16 @@ def test_diff_reports_ignores_non_numeric_baseline_compliance(tmp_path: Path) ->
     assert diff["regressed"] == []
 
 
+def test_diff_reports_ignores_boolean_compliance() -> None:
+    # bool is a subclass of int; a baseline `true`/`false` must not be read as a score.
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])   # non-compliant-run = 0.0
+    baseline = {"summary": {}, "per_scenario": [
+        {"scenario": "non-compliant-run", "compliance": True}]}       # true → no comparison
+    diff = eh.diff_reports(report, baseline)
+    assert diff["has_regression"] is False
+    assert diff["regressed"] == []
+
+
 def test_diff_reports_robust_to_bad_baseline_shape() -> None:
     # diff_reports is a public util; a wrong-shaped baseline must not crash it.
     report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,326 @@
+"""Unit tests for the workflow eval-harness scaffold."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from studio.utils import eval_harness as eh
+
+FIXTURES = Path(__file__).parent / "fixtures" / "eval"
+
+
+# --- helpers ---------------------------------------------------------------
+
+class _StubScorer:
+    """A scorer whose kind and verdict are fixed — for the gate-contract tests."""
+
+    def __init__(self, name: str, kind: eh.ScorerKind, verdict: str):
+        self.name = name
+        self.kind = kind
+        self._verdict = verdict
+
+    def score(self, run, scenario):  # run/scenario unused: signature matches the Scorer protocol
+        score = None if self._verdict == eh.VERDICT_UNKNOWN else 0.0
+        return eh.ScorerResult(self.name, self.kind, self._verdict, score, [], "")
+
+
+def _scenario(run_dir: Path, sid: str = "s") -> eh.Scenario:
+    return eh.Scenario(id=sid, workflow="w", run_dir=run_dir, expect="compliant")
+
+
+def _result(kind: eh.ScorerKind, verdict: str) -> eh.ScorerResult:
+    return eh.ScorerResult("x", kind, verdict, None if verdict == eh.VERDICT_UNKNOWN else 0.0)
+
+
+def _report(*results: eh.ScorerResult) -> eh.EvalReport:
+    return eh.EvalReport([eh.ScenarioResult("s", "w", list(results))])
+
+
+# --- load_run --------------------------------------------------------------
+
+def test_load_run_reads_plan_and_phases() -> None:
+    run = eh.load_run(FIXTURES / "compliant" / "run")
+    assert run is not None
+    assert run.plan_meta["task"] == "demo compliant run"
+    assert "phase-1.md" in run.phase_texts
+
+
+def test_load_run_missing_plan_is_unknown_not_error(tmp_path: Path) -> None:
+    assert eh.load_run(tmp_path) is None
+
+
+def test_load_run_malformed_plan_is_unknown(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text("this = = not toml")
+    assert eh.load_run(tmp_path) is None
+
+
+def test_load_run_without_plan_section_is_unknown(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text('title = "no plan section"\n')
+    assert eh.load_run(tmp_path) is None
+
+
+def test_load_run_with_non_list_phases_is_unknown(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text('phases = "nope"\n[plan]\ntask = "t"\n')
+    assert eh.load_run(tmp_path) is None
+
+
+def test_load_run_absent_phase_file_is_simply_missing(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text(
+        '[plan]\ntask = "t"\n[[phases]]\nnumber = 1\nfile = "here.md"\n'
+        '[[phases]]\nnumber = 2\nfile = "gone.md"\n')
+    (tmp_path / "here.md").write_text("# here\n")
+    run = eh.load_run(tmp_path)
+    assert run is not None
+    assert "here.md" in run.phase_texts
+    assert "gone.md" not in run.phase_texts
+
+
+def test_load_run_phase_without_file_key_is_skipped(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text('[plan]\ntask = "t"\n[[phases]]\nnumber = 1\n')
+    run = eh.load_run(tmp_path)
+    assert run is not None
+    assert run.phase_texts == {}
+
+
+def test_load_run_drops_non_dict_phase_entries(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text('phases = ["x", "y"]\n[plan]\ntask = "t"\n')
+    run = eh.load_run(tmp_path)
+    assert run is not None
+    assert run.phases == []
+
+
+def test_load_run_non_string_file_does_not_crash(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text('[plan]\ntask = "t"\n[[phases]]\nnumber = 1\nfile = 123\n')
+    run = eh.load_run(tmp_path)                        # must not raise TypeError
+    assert run is not None
+    assert run.phase_texts == {}
+    result = eh.ReferencePresenceScorer().score(run, _scenario(tmp_path))
+    assert result.verdict == eh.VERDICT_PASS           # non-string file ignored, not a crash
+
+
+def test_load_run_phase_file_traversal_is_blocked(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text(
+        '[plan]\ntask = "t"\n[[phases]]\nnumber = 1\nfile = "../../etc/passwd"\n')
+    run = eh.load_run(tmp_path)
+    assert run is not None
+    assert run.phase_texts == {}  # escaping path never read
+    result = eh.ReferencePresenceScorer().score(run, _scenario(tmp_path))
+    assert result.verdict == eh.VERDICT_FAIL           # reported missing, not read
+
+
+# --- reference scorer ------------------------------------------------------
+
+def test_reference_scorer_passes_when_all_phases_present() -> None:
+    result = eh.ReferencePresenceScorer().score(
+        eh.load_run(FIXTURES / "compliant" / "run"), _scenario(Path(".")))
+    assert result.verdict == eh.VERDICT_PASS
+    assert result.score_pct == 100.0
+    assert result.kind is eh.ScorerKind.DETERMINISTIC
+
+
+def test_reference_scorer_fails_on_missing_phase() -> None:
+    result = eh.ReferencePresenceScorer().score(
+        eh.load_run(FIXTURES / "non_compliant" / "run"), _scenario(Path(".")))
+    assert result.verdict == eh.VERDICT_FAIL
+    assert result.score_pct == 0.0
+    assert any("phase-2.md" in finding for finding in result.findings)
+
+
+def test_reference_scorer_unknown_when_run_absent() -> None:
+    result = eh.ReferencePresenceScorer().score(None, _scenario(Path(".")))
+    assert result.verdict == eh.VERDICT_UNKNOWN
+    assert result.score_pct is None
+
+
+def test_reference_scorer_survives_non_dict_phases(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text('phases = ["x"]\n[plan]\ntask = "t"\n')
+    result = eh.ReferencePresenceScorer().score(eh.load_run(tmp_path), _scenario(tmp_path))
+    assert result.verdict == eh.VERDICT_UNKNOWN     # zero phases → unscoreable, not a crash
+
+
+def test_reference_scorer_unknown_when_no_phases(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text('[plan]\ntask = "t"\n')
+    result = eh.ReferencePresenceScorer().score(eh.load_run(tmp_path), _scenario(tmp_path))
+    assert result.verdict == eh.VERDICT_UNKNOWN
+    assert result.score_pct is None
+
+
+def test_reference_scorer_ignores_fileless_phase(tmp_path: Path) -> None:
+    (tmp_path / "plan.toml").write_text(
+        '[plan]\ntask = "t"\n[[phases]]\nnumber = 1\nfile = "p.md"\n[[phases]]\nnumber = 2\n')
+    (tmp_path / "p.md").write_text("# p\n")
+    result = eh.ReferencePresenceScorer().score(eh.load_run(tmp_path), _scenario(tmp_path))
+    assert result.verdict == eh.VERDICT_PASS
+
+
+# --- load_scenarios --------------------------------------------------------
+
+def test_load_scenarios_discovers_fixture_suite() -> None:
+    assert [s.id for s in eh.load_scenarios(FIXTURES)] == ["compliant-run", "non-compliant-run"]
+
+
+def test_load_scenarios_skips_malformed_and_idless(tmp_path: Path) -> None:
+    (tmp_path / "bad").mkdir()
+    (tmp_path / "bad" / "scenario.toml").write_text("= = broken")
+    (tmp_path / "noid").mkdir()
+    (tmp_path / "noid" / "scenario.toml").write_text('[scenario]\nworkflow = "w"\n')
+    (tmp_path / "good").mkdir()
+    (tmp_path / "good" / "scenario.toml").write_text('[scenario]\nid = "good"\n')
+    assert [s.id for s in eh.load_scenarios(tmp_path)] == ["good"]
+
+
+def test_load_scenarios_reads_optional_gold_path(tmp_path: Path) -> None:
+    (tmp_path / "g").mkdir()
+    (tmp_path / "g" / "scenario.toml").write_text(
+        '[scenario]\nid = "g"\n[scenario.gold]\npath = "gold.toml"\n')
+    scenario = eh.load_scenarios(tmp_path)[0]
+    assert scenario.gold_path == tmp_path / "g" / "gold.toml"
+    assert scenario.run_dir == tmp_path / "g" / "run"
+
+
+def test_load_scenarios_skips_absolute_run_dir(tmp_path: Path) -> None:
+    (tmp_path / "abs").mkdir()
+    (tmp_path / "abs" / "scenario.toml").write_text('[scenario]\nid = "abs"\nrun_dir = "/tmp/x"\n')
+    (tmp_path / "ok").mkdir()
+    (tmp_path / "ok" / "scenario.toml").write_text('[scenario]\nid = "ok"\n')
+    assert [s.id for s in eh.load_scenarios(tmp_path)] == ["ok"]
+
+
+def test_load_scenarios_skips_dotdot_escape(tmp_path: Path) -> None:
+    (tmp_path / "esc").mkdir()
+    (tmp_path / "esc" / "scenario.toml").write_text(
+        '[scenario]\nid = "esc"\nrun_dir = "../../elsewhere"\n')
+    (tmp_path / "ok").mkdir()
+    (tmp_path / "ok" / "scenario.toml").write_text('[scenario]\nid = "ok"\n')
+    assert [s.id for s in eh.load_scenarios(tmp_path)] == ["ok"]
+
+
+def test_load_scenarios_ignores_absolute_gold_path(tmp_path: Path) -> None:
+    (tmp_path / "g").mkdir()
+    (tmp_path / "g" / "scenario.toml").write_text(
+        '[scenario]\nid = "g"\n[scenario.gold]\npath = "/abs/gold.toml"\n')
+    assert eh.load_scenarios(tmp_path)[0].gold_path is None
+
+
+# --- run_scenario / run_suite ----------------------------------------------
+
+def test_run_scenario_isolates_a_raising_scorer(tmp_path: Path) -> None:
+    class _Boom:
+        name = "boom"
+        kind = eh.ScorerKind.DETERMINISTIC
+
+        def score(self, run, scenario):
+            raise RuntimeError("kaboom")
+
+    result = eh.run_scenario(_scenario(tmp_path), [_Boom()]).results[0]
+    assert result.verdict == eh.VERDICT_UNKNOWN
+    assert "kaboom" in result.findings[0]
+
+
+def test_run_suite_scores_the_fixture_suite() -> None:
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])
+    verdicts = {sr.scenario_id: sr.results[0].verdict for sr in report.scenarios}
+    assert verdicts == {"compliant-run": eh.VERDICT_PASS, "non-compliant-run": eh.VERDICT_FAIL}
+
+
+# --- compliance + the gate contract ----------------------------------------
+
+def test_structural_compliance_is_deterministic_pass_ratio() -> None:
+    assert eh.structural_compliance(eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])) == 0.5
+
+
+def test_advisory_verdicts_never_affect_compliance() -> None:
+    report = _report(_result(eh.ScorerKind.DETERMINISTIC, eh.VERDICT_PASS),
+                     _result(eh.ScorerKind.ADVISORY, eh.VERDICT_FAIL))
+    assert eh.structural_compliance(report) == 1.0            # advisory FAIL ignored
+    assert eh.gate_exit_code(eh.structural_compliance(report), True, 1.0) == 0
+
+
+def test_compliance_is_none_when_nothing_deterministic_scored() -> None:
+    report = _report(_result(eh.ScorerKind.DETERMINISTIC, eh.VERDICT_UNKNOWN))
+    assert eh.structural_compliance(report) is None
+
+
+def test_gate_is_opt_in_and_threshold_aware() -> None:
+    assert eh.gate_exit_code(0.5, False, 1.0) == 0     # no --check → never gates
+    assert eh.gate_exit_code(0.5, True, 1.0) == 2      # below floor → exit 2
+    assert eh.gate_exit_code(1.0, True, 1.0) == 0      # meets floor
+    assert eh.gate_exit_code(0.5, True, 0.4) == 0      # above a lower floor
+    assert eh.gate_exit_code(None, True, 1.0) == 0     # nothing scored never fails
+
+
+# --- report serialisation --------------------------------------------------
+
+def test_report_to_dict_shape_and_histogram() -> None:
+    payload = eh.report_to_dict(eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()]))
+    summary = payload["summary"]
+    assert payload["schema_version"] == eh.SCHEMA_VERSION
+    assert summary["scenarios"] == 2
+    assert summary["structural_compliance"] == 0.5
+    assert "reference-presence (deterministic)" in summary["coverage"]
+    assert payload["failing_checks"] == {"reference-presence": 1}   # the non-compliant one
+    per = {row["scenario"]: row for row in payload["per_scenario"]}
+    assert per["compliant-run"]["compliance"] == 1.0
+    assert per["compliant-run"]["expect"] == "compliant"
+    assert per["non-compliant-run"]["compliance"] == 0.0
+
+
+def test_report_counts_unknown_separately(tmp_path: Path) -> None:
+    (tmp_path / "u").mkdir()
+    (tmp_path / "u" / "scenario.toml").write_text('[scenario]\nid = "u"\n')  # run absent → UNKNOWN
+    payload = eh.report_to_dict(eh.run_suite(tmp_path, [eh.ReferencePresenceScorer()]))
+    assert payload["summary"]["scored"] == 0
+    assert payload["summary"]["unknown"] == 1
+    assert payload["summary"]["structural_compliance"] is None
+
+
+def test_report_notes_when_no_scorers_ran(tmp_path: Path) -> None:
+    (tmp_path / "s").mkdir()
+    (tmp_path / "s" / "scenario.toml").write_text('[scenario]\nid = "s"\n')
+    payload = eh.report_to_dict(eh.run_suite(tmp_path, []))
+    assert payload["summary"]["coverage"] == "no scorers ran"
+    assert payload["failing_checks"] == {}
+
+
+# --- bucketed regression diff ----------------------------------------------
+
+def test_diff_reports_flags_regression_and_removal() -> None:
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])   # compliant 1.0, non 0.0
+    baseline = {"summary": {"structural_compliance": 1.0}, "per_scenario": [
+        {"scenario": "compliant-run", "compliance": 1.0},
+        {"scenario": "non-compliant-run", "compliance": 1.0},   # 1.0 → 0.0 = regressed
+        {"scenario": "gone", "compliance": 1.0}]}               # removed = no-longer-scoreable
+    diff = eh.diff_reports(report, baseline)
+    assert [r["scenario"] for r in diff["regressed"]] == ["non-compliant-run"]
+    assert [r["scenario"] for r in diff["no_longer_scoreable"]] == ["gone"]
+    assert diff["has_regression"] is True
+    assert diff["aggregate_before"] == 1.0
+    assert diff["aggregate_after"] == 0.5
+
+
+def test_diff_reports_flags_improvement_and_newly_scoreable() -> None:
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])   # compliant 1.0, non 0.0
+    baseline = {"summary": {"structural_compliance": 0.0}, "per_scenario": [
+        {"scenario": "compliant-run", "compliance": 0.0}]}            # 0.0 → 1.0 = improved;
+    diff = eh.diff_reports(report, baseline)                           # non-compliant absent = newly
+    assert [r["scenario"] for r in diff["improved"]] == ["compliant-run"]
+    assert [r["scenario"] for r in diff["newly_scoreable"]] == ["non-compliant-run"]
+    assert diff["has_regression"] is False
+
+
+def test_diff_reports_became_unscoreable_is_a_regression(tmp_path: Path) -> None:
+    (tmp_path / "x").mkdir()
+    (tmp_path / "x" / "scenario.toml").write_text('[scenario]\nid = "x"\n')   # no run → UNKNOWN
+    report = eh.run_suite(tmp_path, [eh.ReferencePresenceScorer()])
+    baseline = {"summary": {"structural_compliance": 1.0},
+                "per_scenario": [{"scenario": "x", "compliance": 1.0}]}
+    diff = eh.diff_reports(report, baseline)
+    assert [r["scenario"] for r in diff["no_longer_scoreable"]] == ["x"]
+    assert diff["has_regression"]
+
+
+def test_diff_reports_identical_has_no_regression() -> None:
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])
+    diff = eh.diff_reports(report, eh.report_to_dict(report))
+    assert diff["has_regression"] is False
+    assert diff["regressed"] == []
+    assert diff["improved"] == []

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -357,6 +357,16 @@ def test_diff_reports_ignores_boolean_compliance() -> None:
     assert diff["regressed"] == []
 
 
+def test_diff_reports_skips_non_string_scenario_id() -> None:
+    # A baseline row whose scenario id is unhashable/non-string must not crash diff_reports.
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])
+    baseline = {"summary": {}, "per_scenario": [
+        {"scenario": [], "compliance": 0.5},        # unhashable id
+        {"scenario": 123, "compliance": 0.5}]}      # non-string id
+    diff = eh.diff_reports(report, baseline)
+    assert diff["has_regression"] is False
+
+
 def test_diff_reports_robust_to_bad_baseline_shape() -> None:
     # diff_reports is a public util; a wrong-shaped baseline must not crash it.
     report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -94,7 +94,7 @@ def test_load_run_non_string_file_does_not_crash(tmp_path: Path) -> None:
     assert run is not None
     assert run.phase_texts == {}
     result = eh.ReferencePresenceScorer().score(run, _scenario(tmp_path))
-    assert result.verdict == eh.VERDICT_PASS           # non-string file ignored, not a crash
+    assert result.verdict == eh.VERDICT_UNKNOWN        # no checkable file → UNKNOWN, not a crash
 
 
 def test_load_run_phase_file_traversal_is_blocked(tmp_path: Path) -> None:
@@ -152,6 +152,15 @@ def test_reference_scorer_ignores_fileless_phase(tmp_path: Path) -> None:
     assert result.verdict == eh.VERDICT_PASS
 
 
+def test_reference_scorer_unknown_when_no_checkable_file(tmp_path: Path) -> None:
+    # Every phase omits `file` → nothing verifiable → UNKNOWN, not a vacuous 100% pass.
+    (tmp_path / "plan.toml").write_text(
+        '[plan]\ntask = "t"\n[[phases]]\nnumber = 1\n[[phases]]\nnumber = 2\n')
+    result = eh.ReferencePresenceScorer().score(eh.load_run(tmp_path), _scenario(tmp_path))
+    assert result.verdict == eh.VERDICT_UNKNOWN
+    assert result.score_pct is None
+
+
 # --- load_scenarios --------------------------------------------------------
 
 def test_load_scenarios_discovers_fixture_suite() -> None:
@@ -166,6 +175,14 @@ def test_load_scenarios_skips_malformed_and_idless(tmp_path: Path) -> None:
     (tmp_path / "good").mkdir()
     (tmp_path / "good" / "scenario.toml").write_text('[scenario]\nid = "good"\n')
     assert [s.id for s in eh.load_scenarios(tmp_path)] == ["good"]
+
+
+def test_load_scenarios_skips_scalar_scenario_section(tmp_path: Path) -> None:
+    (tmp_path / "bad").mkdir()
+    (tmp_path / "bad" / "scenario.toml").write_text('scenario = "not a table"\n')
+    (tmp_path / "ok").mkdir()
+    (tmp_path / "ok" / "scenario.toml").write_text('[scenario]\nid = "ok"\n')
+    assert [s.id for s in eh.load_scenarios(tmp_path)] == ["ok"]
 
 
 def test_load_scenarios_reads_optional_gold_path(tmp_path: Path) -> None:
@@ -307,15 +324,35 @@ def test_diff_reports_flags_improvement_and_newly_scoreable() -> None:
     assert diff["has_regression"] is False
 
 
-def test_diff_reports_became_unscoreable_is_a_regression(tmp_path: Path) -> None:
+def test_diff_reports_broke_scenario_is_a_regression(tmp_path: Path) -> None:
+    # A scenario still in the suite but whose run no longer scores (broke) IS a regression.
     (tmp_path / "x").mkdir()
     (tmp_path / "x" / "scenario.toml").write_text('[scenario]\nid = "x"\n')   # no run → UNKNOWN
     report = eh.run_suite(tmp_path, [eh.ReferencePresenceScorer()])
     baseline = {"summary": {"structural_compliance": 1.0},
                 "per_scenario": [{"scenario": "x", "compliance": 1.0}]}
     diff = eh.diff_reports(report, baseline)
-    assert [r["scenario"] for r in diff["no_longer_scoreable"]] == ["x"]
-    assert diff["has_regression"]
+    assert [r["scenario"] for r in diff["regressed"]] == ["x"]
+    assert diff["has_regression"] is True
+
+
+def test_diff_reports_ignores_non_numeric_baseline_compliance(tmp_path: Path) -> None:
+    # A hand-corrupted baseline (string compliance) must not crash diff_reports.
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])
+    baseline = {"summary": {}, "per_scenario": [
+        {"scenario": "compliant-run", "compliance": "0.9"},   # non-numeric → no comparison
+        {"scenario": "non-compliant-run"}]}                   # missing key → no comparison
+    diff = eh.diff_reports(report, baseline)
+    assert diff["has_regression"] is False
+    assert diff["regressed"] == []
+
+
+def test_diff_reports_robust_to_bad_baseline_shape() -> None:
+    # diff_reports is a public util; a wrong-shaped baseline must not crash it.
+    report = eh.run_suite(FIXTURES, [eh.ReferencePresenceScorer()])
+    diff = eh.diff_reports(report, {"per_scenario": "nope", "summary": "nope"})
+    assert diff["has_regression"] is False
+    assert diff["aggregate_before"] is None
 
 
 def test_diff_reports_identical_has_no_regression() -> None:

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -12,6 +12,7 @@ from studio.commands.agents import _AgentEntry, _SkillEntry, _MergedComponents, 
 from studio.commands.kit import _read_conf_version
 from studio.commands.resolve_vars import assemble_component
 from studio.utils.context import LoadedKit
+from studio.utils.eval_harness import Scenario, ScorerKind
 from studio.utils.manifest import ManifestLayerState
 
 is_json = _UI.is_json  # staticmethod alias exposed on the ui singleton
@@ -30,6 +31,8 @@ _ProvenanceRecord  # used as string type hint in agents.py
 _read_conf_version  # re-exported compatibility helper used by tests and callers
 assemble_component  # public API for future use
 _ = LoadedKit.constraints_paths  # public context field for multi-constraints consumers
+_ = Scenario.gold_path  # part of the scenario format; consumed by the advisory judge
+_ = ScorerKind.ADVISORY  # public gate-contract value used by the advisory judge
 INCLUDE_ERROR = ManifestLayerState.INCLUDE_ERROR  # valid enum value for future use
 
 # cfs map module — symbols retained for layout/configuration completeness.


### PR DESCRIPTION
## Summary

Adds `cfs eval` — score completed workflow runs for how faithfully they followed their plan. This is the **scaffold** (a scenario format + a runner) that a deterministic structural scorer and an advisory LLM-judge plug into; it ships a labelled placeholder reference scorer so the seam and fixtures are exercised end-to-end.

Part of the advisory-additions direction proposed in #72.

## What it does

- **Scenario format** — a per-directory `scenario.toml` pointing at a completed run (`plan.toml` + `phase-*.md`), with an expected-outcome oracle and an optional gold-set reference.
- **Runner + Scorer seam** — pluggable scorers tagged `deterministic` or `advisory`. Only deterministic verdicts contribute to structural compliance; **advisory results are reported but never gate**.
- **Opt-in gating** — `--check` fails (exit 2) when structural compliance is below `--min`, or on a per-scenario regression vs `--baseline`; otherwise eval reports and exits 0. `--save` writes a report to reuse as a baseline.
- **Honest signal** — an unloadable run or a raising scorer degrades to `UNKNOWN` (never a silent zero or a crash); the report states its own coverage and a failing-check histogram; scenario/phase paths that escape their directory are rejected.

The real structural scorer and the LLM-judge are separate follow-ups; this PR is the scaffold + placeholder only.

## Example

```
$ cfs eval --scenarios-dir tests/fixtures/eval            # reports, exit 0
$ cfs eval --scenarios-dir tests/fixtures/eval --check    # exit 2 (compliance 0.5 < 1.0)
$ cfs eval --scenarios-dir tests/fixtures/eval --check --min 0.4   # exit 0 (0.5 >= 0.4)
```

## Testing

- `pytest` — full suite green; the two new modules at **100%** line coverage.
- `cfs validate` — 0 errors (CPT-traced: new feature doc + markers, `cfs toc` regenerated).
- `cfs spec-coverage` — thresholds met.
- pylint / vulture clean; stdlib-only; DCO signed-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `cfs eval` command for evaluating workflow scenarios.
  - Supports human-readable and JSON reports, baseline comparisons, and optional compliance or regression gating.
  - Provides deterministic pass, fail, and unknown results while isolating scorer failures.
  - Detects malformed evaluation data and unsafe scenario paths.
  - Saves reports safely and identifies regressions, including unusable baselines.

- **Documentation**
  - Added architecture and usage documentation for evaluation workflows, scoring, reporting, and acceptance criteria.

- **Tests**
  - Added comprehensive coverage for CLI behavior, scoring, reporting, gating, baselines, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->