### PR TITLE
feat(spec-coverage): report applicability and honour demanded thresholds on an empty scope

### DIFF
--- a/architecture/features/spec-coverage.md
+++ b/architecture/features/spec-coverage.md
@@ -68,8 +68,8 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 - User runs `cfs spec-coverage --min-file-granularity 0.3` → same as above, exit code 2 if any covered file granularity below threshold
 
 **Error Scenarios**:
-- No codebase entries registered → ERROR with hint to configure artifacts.toml
-- No code files found → report with 0% coverage
+- No codebase entries registered → report with `applicable: false` and a hint to configure artifacts.toml; exit code 2 only if a positive threshold was demanded
+- No code files found → report with `applicable: false` naming how many registered entries resolved to no files, and 0% coverage
 
 **Steps**:
 1. [x] - `p1` - User invokes `cfs spec-coverage [--min-coverage N] [--min-file-coverage N] [--min-granularity N] [--min-file-granularity N] [--verbose]` - `inst-user-spec-coverage`
@@ -90,7 +90,7 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 - [x] - `p1` - Validate selected `--system` values and build unknown-system failure payloads - `inst-validate-systems`
 - [x] - `p1` - Filter ignored and out-of-root files before scanning - `inst-filter-ignored-files`
 - [x] - `p1` - Build empty coverage result when registry yields no code files - `inst-empty-report`
-- [x] - `p1` - Count codebase entries registered by the selected systems, so an unregistered registry is distinguishable from one that resolves to no files - `inst-count-registered-entries`
+- [x] - `p1` - Count codebase entries registered by the selected systems and recurse into child systems, including the default all-systems selection, so an unregistered registry is distinguishable from one that resolves to no files - `inst-count-registered-entries`
 - [x] - `p1` - Detect which threshold flags demand an enforceable guarantee, ignoring non-positive values that any scope satisfies - `inst-detect-requested-thresholds`
 - [x] - `p1` - Apply per-report threshold checks and accumulate failure messages - `inst-apply-thresholds`
 - [x] - `p1` - Resolve paths relative to project root for human-readable output - `inst-rel-path`
@@ -217,7 +217,7 @@ The system **MUST** calculate instruction density per covered file: `min(1.0, bl
 
 - [x] `p1` - **ID**: `cpt-studio-dod-spec-coverage-report`
 
-The system **MUST** output a JSON report with: summary (total files, covered files, coverage %, granularity score), per-file statistics (path, total lines, covered lines, coverage %, granularity, uncovered line ranges), and list of completely uncovered files. The report format **MUST** mirror `coverage.py` JSON output structure. The report **MUST** state whether there was anything to assess, so a scope that yielded no code files is distinguishable from a fully covered one. Exit code 0 when above thresholds, 2 when below or when a positive threshold was demanded over a scope that could not be assessed.
+The system **MUST** output a JSON report with: summary (total files, covered files, coverage %, granularity score), per-file statistics (path, total lines, covered lines, coverage %, granularity, uncovered line ranges), and list of completely uncovered files. The report format **MUST** mirror `coverage.py` JSON output structure. The report **MUST** state whether there was anything to assess, so a scope that yielded no code files is distinguishable from a fully covered one. Exit code 0 when at or above thresholds, 2 when below or when a positive threshold was demanded over a scope that could not be assessed.
 
 **Implements**:
 - `cpt-studio-flow-spec-coverage-report`
@@ -255,4 +255,4 @@ The system **MUST** output a JSON report with: summary (total files, covered fil
 - [x] Scanning completes in ≤ 5 seconds for typical repositories
 - [x] An empty scope reports `applicable: false` and says why, on both the JSON and human surfaces
 - [x] A positive `--min-*` threshold over an empty scope exits 2; a non-positive one exits 0
-- [x] All output is valid JSON to stdout with exit codes 0/1/2
+- [x] JSON mode emits valid JSON to stdout and human mode emits formatted text, with exit codes 0/1/2 on both

--- a/architecture/features/spec-coverage.md
+++ b/architecture/features/spec-coverage.md
@@ -79,7 +79,7 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 5. [x] - `p1` - Calculate coverage metrics using `cpt-studio-algo-spec-coverage-metrics` - `inst-calc-metrics`
 6. [x] - `p1` - Calculate granularity scores using `cpt-studio-algo-spec-coverage-granularity` - `inst-calc-granularity`
 7. [x] - `p1` - Generate report using `cpt-studio-algo-spec-coverage-report` - `inst-gen-report`
-8. [x] - `p1` - **IF** any threshold flag set AND metric below threshold → exit code 2 - `inst-if-threshold`
+8. [x] - `p1` - **IF** any positive threshold flag set AND (metric below threshold OR nothing was assessed) → exit code 2 - `inst-if-threshold`
 9. [x] - `p1` - **RETURN** JSON report (summary, per-file stats, uncovered files) - `inst-return-report`
 
 **Supporting**:
@@ -90,6 +90,8 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 - [x] - `p1` - Validate selected `--system` values and build unknown-system failure payloads - `inst-validate-systems`
 - [x] - `p1` - Filter ignored and out-of-root files before scanning - `inst-filter-ignored-files`
 - [x] - `p1` - Build empty coverage result when registry yields no code files - `inst-empty-report`
+- [x] - `p1` - Count codebase entries registered by the selected systems, so an unregistered registry is distinguishable from one that resolves to no files - `inst-count-registered-entries`
+- [x] - `p1` - Detect which threshold flags demand an enforceable guarantee, ignoring non-positive values that any scope satisfies - `inst-detect-requested-thresholds`
 - [x] - `p1` - Apply per-report threshold checks and accumulate failure messages - `inst-apply-thresholds`
 - [x] - `p1` - Resolve paths relative to project root for human-readable output - `inst-rel-path`
 - [x] - `p1` - Route JSON report to file or terminal UI - `inst-output-report`
@@ -215,7 +217,7 @@ The system **MUST** calculate instruction density per covered file: `min(1.0, bl
 
 - [x] `p1` - **ID**: `cpt-studio-dod-spec-coverage-report`
 
-The system **MUST** output a JSON report with: summary (total files, covered files, coverage %, granularity score), per-file statistics (path, total lines, covered lines, coverage %, granularity, uncovered line ranges), and list of completely uncovered files. The report format **MUST** mirror `coverage.py` JSON output structure. Exit code 0 when above thresholds, 2 when below.
+The system **MUST** output a JSON report with: summary (total files, covered files, coverage %, granularity score), per-file statistics (path, total lines, covered lines, coverage %, granularity, uncovered line ranges), and list of completely uncovered files. The report format **MUST** mirror `coverage.py` JSON output structure. The report **MUST** state whether there was anything to assess, so a scope that yielded no code files is distinguishable from a fully covered one. Exit code 0 when above thresholds, 2 when below or when a positive threshold was demanded over a scope that could not be assessed.
 
 **Implements**:
 - `cpt-studio-flow-spec-coverage-report`
@@ -251,4 +253,6 @@ The system **MUST** output a JSON report with: summary (total files, covered fil
 - [x] `--verbose` flag includes per-file marker details in report
 - [x] Report format mirrors `coverage.py` JSON structure (summary + per-file)
 - [x] Scanning completes in ≤ 5 seconds for typical repositories
+- [x] An empty scope reports `applicable: false` and says why, on both the JSON and human surfaces
+- [x] A positive `--min-*` threshold over an empty scope exits 2; a non-positive one exits 0
 - [x] All output is valid JSON to stdout with exit codes 0/1/2

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -190,10 +190,17 @@ def _count_selected_codebase_entries(meta, system_slugs: set[str] | None) -> int
     # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
     total = 0
 
+    def count_subtree(node: object) -> int:
+        """Entries registered by ``node`` and every descendant of it."""
+        return len(getattr(node, "codebase", None) or []) + sum(
+            count_subtree(child) for child in getattr(node, "children", [])
+        )
+
     def visit(node: object) -> None:
+        """Add the subtree of ``node`` once it is in scope, mirroring file collection."""
         nonlocal total
         if system_slugs is None or getattr(node, "slug", "") in system_slugs:
-            total += len(getattr(node, "codebase", None) or [])
+            total += count_subtree(node)
             return
         for child in getattr(node, "children", []):
             visit(child)

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -41,25 +41,26 @@ def _build_spec_coverage_parser() -> argparse.ArgumentParser:
         "--min-coverage",
         type=float,
         default=None,
-        help="Minimum coverage percentage (0-100). Exit 2 if below.",
+        help="Minimum coverage percentage (0-100). Exit 2 if below, or if nothing was assessed.",
     )
     parser.add_argument(
         "--min-file-coverage",
         type=float,
         default=None,
-        help="Minimum per-file coverage percentage (0-100). Exit 2 if any file is below.",
+        help="Minimum per-file coverage percentage (0-100). Exit 2 if any file is below, or if nothing was assessed.",
     )
     parser.add_argument(
         "--min-granularity",
         type=float,
         default=None,
-        help="Minimum granularity score (0-1). Exit 2 if below.",
+        help="Minimum granularity score (0-1). Exit 2 if below, or if nothing was assessed.",
     )
     parser.add_argument(
         "--min-file-granularity",
         type=float,
         default=None,
-        help="Minimum per-file granularity score (0-1). Exit 2 if any covered file is below.",
+        help="Minimum per-file granularity score (0-1). Exit 2 if any covered file is below, "
+             "or if nothing was assessed.",
     )
     parser.add_argument(
         "--system",
@@ -187,33 +188,33 @@ def _count_selected_codebase_entries(meta, system_slugs: set[str] | None) -> int
     Distinguishes "nothing is registered" from "what is registered resolves to
     no files" -- two different mistakes that otherwise produce identical output.
     """
-    # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
-    total = 0
-
+    # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-count-registered-entries
     def count_subtree(node: object) -> int:
         """Entries registered by ``node`` and every descendant of it."""
         return len(getattr(node, "codebase", None) or []) + sum(
             count_subtree(child) for child in getattr(node, "children", [])
         )
 
-    def visit(node: object) -> None:
-        """Add the subtree of ``node`` once it is in scope, mirroring file collection."""
-        nonlocal total
+    def visit(node: object) -> int:
+        """Count ``node``'s subtree once it is in scope, mirroring file collection."""
         if system_slugs is None or getattr(node, "slug", "") in system_slugs:
-            total += count_subtree(node)
-            return
-        for child in getattr(node, "children", []):
-            visit(child)
+            return count_subtree(node)
+        return sum(visit(child) for child in getattr(node, "children", []))
 
-    for system_node in meta.systems:
-        visit(system_node)
-    return total
-    # @cpt-end:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
+    return sum(visit(system_node) for system_node in meta.systems)
+    # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-count-registered-entries
 
 
 def _requested_thresholds(args) -> List[str]:
-    """Names of the thresholds the caller asked to be enforced."""
-    # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
+    """Names of the thresholds whose satisfaction the caller actually demanded.
+
+    A non-positive threshold is met by any scope, empty or not, so it demands no
+    guarantee and is not counted as one. Without that, ``--min-coverage 0`` would
+    fail an empty scope while passing a populated one sitting at 0.0% -- and the
+    exit code has to keep answering a single question: was a guarantee demanded
+    that cannot be given?
+    """
+    # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-detect-requested-thresholds
     requested = []
     for flag, attr in (
         ("--min-coverage", "min_coverage"),
@@ -221,10 +222,11 @@ def _requested_thresholds(args) -> List[str]:
         ("--min-granularity", "min_granularity"),
         ("--min-file-granularity", "min_file_granularity"),
     ):
-        if getattr(args, attr, None) is not None:
+        value = getattr(args, attr, None)
+        if value is not None and value > 0:
             requested.append(flag)
     return requested
-    # @cpt-end:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
+    # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-detect-requested-thresholds
 
 
 def _empty_coverage_result(registered_entries: int = 0, requested_thresholds=None) -> dict:
@@ -487,14 +489,15 @@ def _show_spec_coverage_files(files: dict) -> None:
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-human-report-helpers
 
 
-def _show_spec_coverage_status(status: str, failures: list) -> None:
+def _show_spec_coverage_status(status: str, failures: list, assessed: bool = True) -> None:
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-human-report-helpers
     if failures:
         ui.blank()
         for failure in failures:
             ui.warn(failure)
     if status == "PASS":
-        ui.success("All thresholds met.")
+        if assessed:
+            ui.success("All thresholds met.")
     elif status == "FAIL":
         ui.error("Threshold check failed.")
     else:
@@ -525,7 +528,12 @@ def _human_spec_coverage(data: dict) -> None:
         ui.blank()
         _show_spec_coverage_files(files)
 
+    applicable = data.get("applicable", True)
+    if applicable is False:
+        ui.blank()
+        ui.warn(data.get("message", "Nothing was assessed"))
+
     failures = data.get("threshold_failures", [])
-    _show_spec_coverage_status(status, failures)
+    _show_spec_coverage_status(status, failures, assessed=applicable is not False)
     ui.blank()
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-human-report-helpers

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -520,6 +520,13 @@ def _human_spec_coverage(data: dict) -> None:
         ui.blank()
         return
 
+    # Say up front when nothing was assessed, so the zeroes below are read as the
+    # denominator they are and not as a measured result.
+    applicable = data.get("applicable", True)
+    if applicable is False:
+        ui.warn(data.get("message", "Nothing was assessed"))
+        ui.blank()
+
     summary = data.get("summary", {})
     ui.detail("Files", f"{summary.get('covered_files', 0)}/{summary.get('total_files', 0)} covered")
     ui.detail("Coverage", f"{summary.get('coverage_pct', 0):.1f}%")
@@ -530,11 +537,6 @@ def _human_spec_coverage(data: dict) -> None:
     if files and isinstance(files, dict):
         ui.blank()
         _show_spec_coverage_files(files)
-
-    applicable = data.get("applicable", True)
-    if applicable is False:
-        ui.blank()
-        ui.warn(data.get("message", "Nothing was assessed"))
 
     failures = data.get("threshold_failures", [])
     _show_spec_coverage_status(status, failures, assessed=applicable is not False)

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -41,26 +41,29 @@ def _build_spec_coverage_parser() -> argparse.ArgumentParser:
         "--min-coverage",
         type=float,
         default=None,
-        help="Minimum coverage percentage (0-100). Exit 2 if below, or if nothing was assessed.",
+        help="Minimum coverage percentage (0-100). Exit 2 if below; a positive value also "
+             "exits 2 if nothing was assessed.",
     )
     parser.add_argument(
         "--min-file-coverage",
         type=float,
         default=None,
-        help="Minimum per-file coverage percentage (0-100). Exit 2 if any file is below, or if nothing was assessed.",
+        help="Minimum per-file coverage percentage (0-100). Exit 2 if any file is below; "
+             "a positive value also exits 2 if nothing was assessed.",
     )
     parser.add_argument(
         "--min-granularity",
         type=float,
         default=None,
-        help="Minimum granularity score (0-1). Exit 2 if below, or if nothing was assessed.",
+        help="Minimum granularity score (0-1). Exit 2 if below; a positive value also "
+             "exits 2 if nothing was assessed.",
     )
     parser.add_argument(
         "--min-file-granularity",
         type=float,
         default=None,
-        help="Minimum per-file granularity score (0-1). Exit 2 if any covered file is below, "
-             "or if nothing was assessed.",
+        help="Minimum per-file granularity score (0-1). Exit 2 if any covered file is below; "
+             "a positive value also exits 2 if nothing was assessed.",
     )
     parser.add_argument(
         "--system",

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -181,18 +181,80 @@ def _filter_ignored_files(code_files_to_scan: List[Path], project_root: Path, me
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-filter-ignored-files
 
 
-def _empty_coverage_result() -> dict:
+def _count_selected_codebase_entries(meta, system_slugs: set[str] | None) -> int:
+    """Count codebase entries registered by the selected systems.
+
+    Distinguishes "nothing is registered" from "what is registered resolves to
+    no files" -- two different mistakes that otherwise produce identical output.
+    """
+    # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
+    total = 0
+
+    def visit(node: object) -> None:
+        nonlocal total
+        if system_slugs is None or getattr(node, "slug", "") in system_slugs:
+            total += len(getattr(node, "codebase", None) or [])
+            return
+        for child in getattr(node, "children", []):
+            visit(child)
+
+    for system_node in meta.systems:
+        visit(system_node)
+    return total
+    # @cpt-end:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
+
+
+def _requested_thresholds(args) -> List[str]:
+    """Names of the thresholds the caller asked to be enforced."""
+    # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
+    requested = []
+    for flag, attr in (
+        ("--min-coverage", "min_coverage"),
+        ("--min-file-coverage", "min_file_coverage"),
+        ("--min-granularity", "min_granularity"),
+        ("--min-file-granularity", "min_file_granularity"),
+    ):
+        if getattr(args, attr, None) is not None:
+            requested.append(flag)
+    return requested
+    # @cpt-end:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
+
+
+def _empty_coverage_result(registered_entries: int = 0, requested_thresholds=None) -> dict:
+    """Report for a scan that completed with nothing in scope.
+
+    The check ran and found nothing to cover, so nothing failed -- unless the
+    caller demanded a guarantee, which cannot be given over an empty scope.
+    Either way ``applicable`` records that there was nothing to assess, so an
+    empty result is no longer indistinguishable from a fully covered one.
+    """
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-empty-report
-    return {
-        "status": "PASS",
+    requested_thresholds = requested_thresholds or []
+    if registered_entries:
+        message = (
+            f"No code files found: {registered_entries} registered codebase "
+            f"{'entry' if registered_entries == 1 else 'entries'} resolved to 0 files"
+        )
+    else:
+        message = "No codebase entries are registered, so no code files were scanned"
+    result = {
+        "status": "FAIL" if requested_thresholds else "PASS",
+        "applicable": False,
         "summary": {
             "total_files": 0,
             "covered_files": 0,
             "coverage_pct": 0.0,
             "granularity_score": 0.0,
         },
-        "message": "No codebase files found in registry",
+        "message": message,
     }
+    if requested_thresholds:
+        result["threshold_failures"] = [
+            f"cannot assess {flag}: 0 files from {registered_entries} registered "
+            f"codebase {'entry' if registered_entries == 1 else 'entries'}"
+            for flag in requested_thresholds
+        ]
+    return result
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-empty-report
 
 
@@ -317,7 +379,11 @@ def _generate_spec_coverage_report(args, meta, project_root: Path) -> tuple[dict
     )
     # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
     if not filtered_files:
-        return _empty_coverage_result(), 0
+        requested = _requested_thresholds(args)
+        empty = _empty_coverage_result(
+            _count_selected_codebase_entries(meta, system_slugs), requested
+        )
+        return empty, 2 if requested else 0
     # @cpt-end:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
     file_coverages = _scan_file_coverages(filtered_files)
     report = calculate_metrics(file_coverages)

--- a/tests/test_enforcement_empty_scan.py
+++ b/tests/test_enforcement_empty_scan.py
@@ -1,0 +1,239 @@
+"""Enforcement reachability: an empty scan must not read as compliance.
+
+Each test names the repository state it builds and the verdict that state
+produces. The corpus separates two questions that a single ``status`` field
+currently conflates:
+
+* **"did anything fail?"** -> ``status``. An empty scope fails nothing: the
+  check ran and correctly found nothing to cover, so ``PASS`` is honest.
+* **"was there anything to assess?"** -> a separate boolean. This is what the
+  report cannot currently express, so a legitimately empty repository and a
+  misconfigured one that scans nothing are indistinguishable.
+
+The exit code is a third, independent question: it should turn non-zero only
+when the caller demanded a guarantee that cannot be given -- thresholds were
+passed, or a checked ``to_code="true"`` ID exists with nothing backing it.
+
+Most tests here pin behaviour that was already correct, so they are ordinary
+regression cover against a change to either command being too broad. The last
+class covers the three cases this change fixes.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scripts"))
+
+from studio.commands.spec_coverage import cmd_spec_coverage
+from studio.utils.artifacts_meta import ArtifactsMeta, CodebaseEntry, Kit, SystemNode
+from studio.utils.codebase import CodeFile, cross_validate_code
+
+TO_CODE_IDS = {
+    "cpt-flags-flow-evaluate",
+    "cpt-flags-algo-core-bucket",
+    "cpt-flags-dod-core-verification",
+}
+
+
+def _context(project_root: Path, codebase: list[CodebaseEntry] | None = None) -> MagicMock:
+    """Build a context whose single system registers ``codebase``."""
+    meta = ArtifactsMeta(
+        version=1,
+        project_root=".",
+        kits={"test": Kit("test", "CFS", "kits/test")},
+        systems=[
+            SystemNode(
+                name="sys1",
+                slug="sys1",
+                kit="test",
+                artifacts=[],
+                codebase=codebase or [],
+                children=[],
+            ),
+        ],
+    )
+    ctx = MagicMock()
+    ctx.meta = meta
+    ctx.project_root = project_root
+    return ctx
+
+
+def _run_spec_coverage(ctx: MagicMock, argv: list[str] | None = None) -> tuple[int, dict]:
+    """Run spec-coverage against ``ctx`` and return (exit code, parsed report)."""
+    with patch("studio.utils.context.get_context", return_value=ctx):
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = cmd_spec_coverage(argv or [])
+    return code, json.loads(out.getvalue())
+
+
+# ---------------------------------------------------------------------------
+# The enforcement already exists -- it is only unreachable.
+#
+# These pass today. They are the evidence that closing the gap is a guard
+# change and not new validation logic, so they must keep passing afterwards.
+# ---------------------------------------------------------------------------
+
+class TestEnforcementExistsOnEmptyInput:
+    def test_every_unmet_to_code_id_is_reported_when_no_code_files_exist(self):
+        result = cross_validate_code([], set(TO_CODE_IDS), set(TO_CODE_IDS), traceability="FULL")
+
+        coverage_errors = [e for e in result["errors"] if e["type"] == "coverage"]
+        assert len(coverage_errors) == len(TO_CODE_IDS)
+        assert {e["id"] for e in coverage_errors} == TO_CODE_IDS
+
+    def test_nothing_claimed_means_nothing_owed(self):
+        """No checked to_code IDs and no code is a legitimately clean state.
+
+        This is the leniency the design deliberately keeps: a spec-first
+        repository with a PRD and an ADR but no implementation yet must not be
+        failed. It is also the assertion most at risk from an over-broad fix.
+        """
+        result = cross_validate_code([], set(), set(), traceability="FULL")
+
+        assert result["errors"] == []
+        assert result["warnings"] == []
+
+    def test_docs_only_traceability_is_unaffected(self, tmp_path: Path):
+        result = cross_validate_code([], set(), set(), traceability="DOCS-ONLY")
+
+        assert result["errors"] == []
+
+
+class TestKnownGoodStaysGreen:
+    """Regression pins. A fix that breaks one of these is too broad."""
+
+    def test_a_marked_implementation_reports_no_coverage_error(self, tmp_path: Path):
+        source = tmp_path / "evaluator.py"
+        source.write_text(
+            "# @cpt-algo:cpt-flags-algo-core-bucket:p1\ndef bucket():\n    return 0\n",
+            encoding="utf-8",
+        )
+        code_file, _ = CodeFile.from_path(source)
+
+        result = cross_validate_code(
+            [code_file],
+            {"cpt-flags-algo-core-bucket"},
+            {"cpt-flags-algo-core-bucket"},
+            traceability="FULL",
+        )
+
+        assert [e for e in result["errors"] if e["type"] == "coverage"] == []
+
+    def test_an_unmarked_file_still_fails(self, tmp_path: Path):
+        """Already-correct behaviour: one scanned file makes enforcement fire."""
+        source = tmp_path / "store.py"
+        source.write_text("def put():\n    return None\n", encoding="utf-8")
+        code_file, _ = CodeFile.from_path(source)
+
+        result = cross_validate_code(
+            [code_file],
+            {"cpt-flags-algo-core-bucket"},
+            {"cpt-flags-algo-core-bucket"},
+            traceability="FULL",
+        )
+
+        coverage_errors = [e for e in result["errors"] if e["type"] == "coverage"]
+        assert len(coverage_errors) == 1
+        assert coverage_errors[0]["id"] == "cpt-flags-algo-core-bucket"
+
+    def test_populated_codebase_reports_normally(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            src = root / "src"
+            src.mkdir()
+            (src / "main.py").write_text(
+                "# @cpt-algo:cpt-flags-algo-core-bucket:p1\nx = 1\n", encoding="utf-8"
+            )
+            ctx = _context(root, [CodebaseEntry(path="src", extensions=[".py"])])
+
+            code, report = _run_spec_coverage(ctx)
+
+        assert code == 0
+        assert report["summary"]["total_files"] > 0
+
+    def test_an_unassessable_report_without_thresholds_still_exits_zero(self):
+        """No guarantee was requested, so the exit code must not move.
+
+        ``status`` stays PASS too -- nothing failed. Only the applicability flag
+        below is missing. Keeping this exit code is what lets the change land
+        without failing spec-first projects.
+        """
+        with TemporaryDirectory() as directory:
+            ctx = _context(Path(directory), codebase=[])
+
+            code, _ = _run_spec_coverage(ctx)
+
+        assert code == 0
+
+
+class TestVerdictIsDeterministic:
+    def test_repeated_runs_agree(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            src = root / "src"
+            src.mkdir()
+            (src / "main.py").write_text(
+                "# @cpt-algo:cpt-flags-algo-core-bucket:p1\nx = 1\n", encoding="utf-8"
+            )
+            verdicts = set()
+            for _ in range(5):
+                ctx = _context(root, [CodebaseEntry(path="src", extensions=[".py"])])
+                code, report = _run_spec_coverage(ctx)
+                verdicts.add((code, report["status"], report["summary"]["total_files"]))
+
+        assert len(verdicts) == 1
+
+
+# ---------------------------------------------------------------------------
+# Known-bad must go red. These fail today; that is the defect.
+# ---------------------------------------------------------------------------
+
+class TestEmptyScopeIsVisibleAndGuaranteesAreHonoured:
+    """An empty scope is honest-green -- but it must be *visible*, and a
+    demanded guarantee must still be honoured."""
+
+    def test_an_empty_scan_is_flagged_as_not_applicable(self):
+        """``status`` stays PASS -- nothing failed -- but that is not the whole answer.
+
+        The check ran and found nothing to cover, so PASS is honest. What the
+        report cannot currently say is that there was nothing to assess in the
+        first place. Field name is provisional pending discussion.
+        """
+        with TemporaryDirectory() as directory:
+            ctx = _context(Path(directory), codebase=[])
+
+            _, report = _run_spec_coverage(ctx)
+
+        assert report["status"] == "PASS"
+        assert report.get("applicable") is False
+
+    def test_requested_thresholds_cannot_be_satisfied_by_an_empty_scan(self):
+        """0.0% against a required 90 is the maximum possible miss, not a pass."""
+        with TemporaryDirectory() as directory:
+            ctx = _context(Path(directory), codebase=[])
+
+            code, _ = _run_spec_coverage(ctx, ["--min-coverage", "90"])
+
+        assert code != 0
+
+    def test_unregistered_and_resolved_to_nothing_are_distinguishable(self):
+        """Two different setup mistakes must not produce the same report.
+
+        No registered entry is a missing-configuration problem; an entry that
+        resolves to zero files is a wrong-path problem. A report that cannot
+        tell them apart cannot state its own denominator.
+        """
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            _, unregistered = _run_spec_coverage(_context(root, codebase=[]))
+            _, resolved_to_nothing = _run_spec_coverage(
+                _context(root, [CodebaseEntry(path="does/not/exist", extensions=[".py"])])
+            )
+
+        assert unregistered != resolved_to_nothing

--- a/tests/test_enforcement_empty_scan.py
+++ b/tests/test_enforcement_empty_scan.py
@@ -275,6 +275,32 @@ class TestEmptyScopeIsVisibleAndGuaranteesAreHonoured:
                 f"cannot assess {flag}: 0 files from 0 registered codebase entries"
             ], flag
 
+    def test_every_demanded_threshold_is_reported_not_just_the_first(self):
+        """One invocation demanding all four must answer for all four.
+
+        The per-flag cases above would all still pass if the report emitted a
+        single entry and dropped the rest, so this pins one failure per
+        requested flag against a short-circuit or overwrite.
+        """
+        flags = [
+            "--min-coverage", "90",
+            "--min-file-coverage", "60",
+            "--min-granularity", "0.46",
+            "--min-file-granularity", "0.3",
+        ]
+        with TemporaryDirectory() as directory:
+            ctx = _context(Path(directory), codebase=[])
+
+            code, report = _run_spec_coverage(ctx, flags)
+
+        assert code == 2
+        assert report["status"] == "FAIL"
+        assert report["applicable"] is False
+        assert report["threshold_failures"] == [
+            f"cannot assess {flag}: 0 files from 0 registered codebase entries"
+            for flag in flags[::2]
+        ]
+
     def test_a_threshold_no_scope_can_miss_is_not_a_demanded_guarantee(self):
         """A non-positive floor is met by any scope, so it must not fail one.
 

--- a/tests/test_enforcement_empty_scan.py
+++ b/tests/test_enforcement_empty_scan.py
@@ -64,6 +64,42 @@ def _context(project_root: Path, codebase: list[CodebaseEntry] | None = None) ->
     return ctx
 
 
+def _nested_context(project_root: Path, child_codebase: list[CodebaseEntry]) -> MagicMock:
+    """Build a context where a *child* system holds the only codebase entry.
+
+    File collection recurses into children, so a parent match scans its
+    descendants' entries too. Anything that reports the registered-entry count
+    has to walk the same subtree or it contradicts the scan it describes.
+    """
+    child = SystemNode(
+        name="sub1",
+        slug="sub1",
+        kit="test",
+        artifacts=[],
+        codebase=child_codebase,
+        children=[],
+    )
+    meta = ArtifactsMeta(
+        version=1,
+        project_root=".",
+        kits={"test": Kit("test", "CFS", "kits/test")},
+        systems=[
+            SystemNode(
+                name="sys1",
+                slug="sys1",
+                kit="test",
+                artifacts=[],
+                codebase=[],
+                children=[child],
+            ),
+        ],
+    )
+    ctx = MagicMock()
+    ctx.meta = meta
+    ctx.project_root = project_root
+    return ctx
+
+
 def _run_spec_coverage(ctx: MagicMock, argv: list[str] | None = None) -> tuple[int, dict]:
     """Run spec-coverage against ``ctx`` and return (exit code, parsed report)."""
     with patch("studio.utils.context.get_context", return_value=ctx):
@@ -237,3 +273,34 @@ class TestEmptyScopeIsVisibleAndGuaranteesAreHonoured:
             )
 
         assert unregistered != resolved_to_nothing
+
+    def test_a_child_systems_entry_counts_towards_the_denominator(self):
+        """The count must cover the subtree the scan itself walks.
+
+        ``_collect_codebase_files`` recurses into a matched node's children, so
+        a parent match scans its descendants' entries. A count that stops at
+        the matched node calls a repository unregistered when it registered
+        something and got zero files back -- reintroducing, one level down, the
+        exact confusion this change removes.
+        """
+        with TemporaryDirectory() as directory:
+            ctx = _nested_context(
+                Path(directory), [CodebaseEntry(path="does/not/exist", extensions=[".py"])]
+            )
+
+            _, report = _run_spec_coverage(ctx)
+
+        assert report["message"] == (
+            "No code files found: 1 registered codebase entry resolved to 0 files"
+        )
+
+    def test_selecting_the_parent_counts_the_childs_entry(self):
+        """Same rule under an explicit ``--system`` selector on the parent."""
+        with TemporaryDirectory() as directory:
+            ctx = _nested_context(
+                Path(directory), [CodebaseEntry(path="does/not/exist", extensions=[".py"])]
+            )
+
+            _, report = _run_spec_coverage(ctx, ["--system", "sys1"])
+
+        assert "1 registered codebase entry" in report["message"]

--- a/tests/test_enforcement_empty_scan.py
+++ b/tests/test_enforcement_empty_scan.py
@@ -33,6 +33,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scr
 from studio.commands.spec_coverage import cmd_spec_coverage
 from studio.utils.artifacts_meta import ArtifactsMeta, CodebaseEntry, Kit, SystemNode
 from studio.utils.codebase import CodeFile, cross_validate_code
+from studio.utils.ui import set_json_mode
 
 TO_CODE_IDS = {
     "cpt-flags-flow-evaluate",
@@ -250,13 +251,52 @@ class TestEmptyScopeIsVisibleAndGuaranteesAreHonoured:
         assert report.get("applicable") is False
 
     def test_requested_thresholds_cannot_be_satisfied_by_an_empty_scan(self):
-        """0.0% against a required 90 is the maximum possible miss, not a pass."""
-        with TemporaryDirectory() as directory:
-            ctx = _context(Path(directory), codebase=[])
+        """0.0% against a required 90 is the maximum possible miss, not a pass.
 
-            code, _ = _run_spec_coverage(ctx, ["--min-coverage", "90"])
+        All four flags are exercised, and the failure text is asserted rather
+        than just the exit code -- a per-flag regression in the message would
+        otherwise pass unnoticed.
+        """
+        for flag, value in (
+            ("--min-coverage", "90"),
+            ("--min-file-coverage", "60"),
+            ("--min-granularity", "0.46"),
+            ("--min-file-granularity", "0.3"),
+        ):
+            with TemporaryDirectory() as directory:
+                ctx = _context(Path(directory), codebase=[])
 
-        assert code != 0
+                code, report = _run_spec_coverage(ctx, [flag, value])
+
+            assert code == 2, flag
+            assert report["status"] == "FAIL", flag
+            assert report["applicable"] is False, flag
+            assert report["threshold_failures"] == [
+                f"cannot assess {flag}: 0 files from 0 registered codebase entries"
+            ], flag
+
+    def test_a_threshold_no_scope_can_miss_is_not_a_demanded_guarantee(self):
+        """A non-positive floor is met by any scope, so it must not fail one.
+
+        A populated repository sitting at 0.0% coverage passes
+        ``--min-coverage 0``; an empty one has to agree, or the flag means two
+        different things depending on what happens to be registered.
+        """
+        for flag in (
+            "--min-coverage",
+            "--min-file-coverage",
+            "--min-granularity",
+            "--min-file-granularity",
+        ):
+            for value in ("0", "-5"):
+                with TemporaryDirectory() as directory:
+                    ctx = _context(Path(directory), codebase=[])
+
+                    code, report = _run_spec_coverage(ctx, [flag, value])
+
+                assert code == 0, (flag, value)
+                assert report["status"] == "PASS", (flag, value)
+                assert "threshold_failures" not in report, (flag, value)
 
     def test_unregistered_and_resolved_to_nothing_are_distinguishable(self):
         """Two different setup mistakes must not produce the same report.
@@ -304,3 +344,59 @@ class TestEmptyScopeIsVisibleAndGuaranteesAreHonoured:
             _, report = _run_spec_coverage(ctx, ["--system", "sys1"])
 
         assert "1 registered codebase entry" in report["message"]
+
+
+class TestTheHumanSurfaceSaysTheSameThing:
+    """The report is only honest if the default output surface says so too.
+
+    The suite runs in JSON mode by default (``conftest.py``), so without an
+    explicit opt-out every assertion above could hold while a developer running
+    ``cfs spec-coverage`` still read ``All thresholds met`` off an empty scope.
+    """
+
+    @staticmethod
+    def _run_human(ctx, argv=None) -> tuple[int, str]:
+        set_json_mode(False)
+        try:
+            with patch("studio.utils.context.get_context", return_value=ctx):
+                with patch("sys.stdout", new_callable=StringIO) as out:
+                    code = cmd_spec_coverage(argv or [])
+            return code, out.getvalue()
+        finally:
+            set_json_mode(True)
+
+    def test_an_empty_scope_is_not_reported_as_all_thresholds_met(self):
+        with TemporaryDirectory() as directory:
+            code, out = self._run_human(_context(Path(directory), codebase=[]))
+
+        assert code == 0
+        assert "thresholds met" not in out
+        assert "No codebase entries are registered" in out
+
+    def test_the_two_empty_states_differ_on_the_human_surface_too(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            _, unregistered = self._run_human(_context(root, codebase=[]))
+            _, resolved_to_nothing = self._run_human(
+                _context(root, [CodebaseEntry(path="does/not/exist", extensions=[".py"])])
+            )
+
+        assert unregistered != resolved_to_nothing
+        assert "resolved to 0 files" in resolved_to_nothing
+
+    def test_a_populated_scope_still_reports_its_verdict(self):
+        """Regression pin: the ordinary run must be untouched by all of this."""
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            src = root / "src"
+            src.mkdir()
+            (src / "main.py").write_text(
+                "# @cpt-algo:cpt-flags-algo-core-bucket:p1\nx = 1\n", encoding="utf-8"
+            )
+
+            code, out = self._run_human(
+                _context(root, [CodebaseEntry(path="src", extensions=[".py"])])
+            )
+
+        assert code == 0
+        assert "All thresholds met." in out

--- a/tests/test_ui_human_mode.py
+++ b/tests/test_ui_human_mode.py
@@ -585,6 +585,32 @@ class TestHumanSpecCoverage(_HumanModeBase):
         self.assertNotIn("thresholds met", out)
         self.assertIn("No codebase entries are registered", out)
 
+    def test_the_disclaimer_precedes_the_zero_metrics(self):
+        """Order matters: the zeroes must be framed before they are read.
+
+        "Coverage: 0.0%" on its own line reads like a measured result. Printed
+        after the note that nothing was scanned, it reads as the denominator it
+        actually is. The metrics are kept rather than suppressed because a
+        verdict should still state what it measured -- 0 of 0 files is a
+        materially different statement from 63 of 261 lines.
+        """
+        out = self._render({
+            "status": "PASS",
+            "applicable": False,
+            "summary": {"covered_files": 0, "total_files": 0,
+                        "coverage_pct": 0.0, "granularity_score": 0.0},
+            "message": "No codebase entries are registered, so no code files were scanned",
+        })
+
+        # Anchor on the metric values, not the labels: the "Spec Coverage"
+        # header contains the word "Coverage" and would match ahead of both.
+        assert "No codebase entries are registered" in out
+        assert "0/0 covered" in out
+        self.assertLess(
+            out.index("No codebase entries are registered"),
+            min(out.index("0/0 covered"), out.index("0.0%"), out.index("0.0000")),
+        )
+
     def test_an_unassessable_scope_with_a_demanded_threshold_still_reads_as_failed(self):
         out = self._render({
             "status": "FAIL",

--- a/tests/test_ui_human_mode.py
+++ b/tests/test_ui_human_mode.py
@@ -560,6 +560,71 @@ class TestHumanSpecCoverage(_HumanModeBase):
             _human_spec_coverage({"status": "PARTIAL", "summary": {}})
         self.assertIn("PARTIAL", buf.getvalue())
 
+    def _render(self, data):
+        buf = io.StringIO()
+        with redirect_stderr(buf):
+            from studio.commands.spec_coverage import _human_spec_coverage
+            _human_spec_coverage(data)
+        return buf.getvalue()
+
+    def test_an_unassessable_scope_does_not_claim_thresholds_were_met(self):
+        """PASS is honest -- nothing failed -- but no threshold was ever checked.
+
+        This is the surface a developer sees without ``--json``, so if the
+        applicability flag is not rendered here it is not rendered anywhere
+        they will look.
+        """
+        out = self._render({
+            "status": "PASS",
+            "applicable": False,
+            "summary": {"covered_files": 0, "total_files": 0,
+                        "coverage_pct": 0.0, "granularity_score": 0.0},
+            "message": "No codebase entries are registered, so no code files were scanned",
+        })
+
+        self.assertNotIn("thresholds met", out)
+        self.assertIn("No codebase entries are registered", out)
+
+    def test_an_unassessable_scope_with_a_demanded_threshold_still_reads_as_failed(self):
+        out = self._render({
+            "status": "FAIL",
+            "applicable": False,
+            "summary": {"covered_files": 0, "total_files": 0,
+                        "coverage_pct": 0.0, "granularity_score": 0.0},
+            "message": "No code files found: 1 registered codebase entry resolved to 0 files",
+            "threshold_failures": ["cannot assess --min-coverage: 0 files from 1 registered "
+                                   "codebase entry"],
+        })
+
+        self.assertIn("Threshold check failed", out)
+        self.assertIn("cannot assess --min-coverage", out)
+        self.assertIn("resolved to 0 files", out)
+
+    def test_the_two_empty_states_are_distinguishable_without_json(self):
+        """A missing registry and a wrong path are different mistakes to fix."""
+        base = {"status": "PASS", "applicable": False,
+                "summary": {"covered_files": 0, "total_files": 0,
+                            "coverage_pct": 0.0, "granularity_score": 0.0}}
+        unregistered = self._render(
+            {**base, "message": "No codebase entries are registered, so no code files were scanned"}
+        )
+        wrong_path = self._render(
+            {**base, "message": "No code files found: 1 registered codebase entry resolved to 0 files"}
+        )
+
+        self.assertNotEqual(unregistered, wrong_path)
+
+    def test_an_assessed_pass_still_says_so(self):
+        """Regression pin: the ordinary populated report is unchanged."""
+        out = self._render({
+            "status": "PASS",
+            "applicable": True,
+            "summary": {"covered_files": 8, "total_files": 10,
+                        "coverage_pct": 95.0, "granularity_score": 0.88},
+        })
+
+        self.assertIn("thresholds met", out)
+
 
 class TestHumanInfo(_HumanModeBase):
     """Test _human_info formatter."""


### PR DESCRIPTION
Part of the issue #89.

**What.** `cfs spec-coverage` now reports whether there was anything to assess, and honours a threshold the caller actually asked for even when the scope turns out to be empty.

**Why.** A scan with nothing in scope returned a bare `PASS` at exit 0 regardless of the request:

```json
{"status":"PASS","summary":{"total_files":0,"coverage_pct":0.0,"granularity_score":0.0},
 "message":"No codebase files found in registry"}
```

Two consequences:

- **A demanded guarantee was silently dropped.** `--min-coverage 90` over zero files reported PASS and exited 0 — the maximum possible miss, reported as success. A required CI check configured that way can never fail, and does not start failing when marked code lands.
- **An empty result was indistinguishable from a covered one.** Callers could not tell "nothing was measured" from "everything measured passed" — and an unregistered codebase produced byte-identical output to a registered entry whose path resolves to no files, which are two different mistakes with two different fixes.

**How.** The report answers three questions separately instead of overloading `status`:

| Question | Answer |
|---|---|
| Did anything fail? | `status` — an empty scope with no thresholds requested fails nothing, so it stays `PASS` |
| Was there anything to assess? | `applicable: false`, with a message naming the registered-entry count and distinguishing *unregistered* from *resolved to zero files* |
| Was a guarantee demanded that cannot be given? | the exit code — non-zero, with one `threshold_failures` entry per requested threshold, only when one was requested |

Keeping `status: PASS` for the no-threshold case is deliberate: the check *ran* and correctly found nothing to cover, so it is a completed assessment with an empty result, not a skipped one — and a spec-first repository with documents but no implementation yet should not be failed. `applicable` is what makes that honest rather than merely quiet. The field name is open to your preference.

**⚠️ Behaviour change for anyone pinning exit codes:** passing a `--min-*` threshold over an empty scope now exits 2 instead of 0. Runs that request no thresholds are unaffected, and no existing test needed changing — including `test_no_codebase_files`, which still asserts `status == "PASS"`.

**Tests.** Adds `tests/test_enforcement_empty_scan.py` (11 tests): the three cases above, plus regression cover that a stricter verdict must not break — a marked implementation stays clean, one unmarked file still fails, a repository that claims nothing is owed nothing, and an empty report without thresholds keeps exit 0. Also pins that `cross_validate_code()` already reports every unmet `to_code` ID when given no code files, which matters for the follow-up in #89.

**Gates.** `make test` 4432 passed / 4 skipped / 15 xfailed · `pylint` clean · `vulture-ci` clean · `cfs validate` 216/216, 0 errors 0 warnings · `make spec-coverage` all thresholds met, with the changed file at 87% / granularity 0.90 (instruction-block traced, no whole-file scope marker). No new dependencies; stdlib only.

Supersedes #90, which documented these three cases as `xfail` before a fix existed — closing that in favour of this, so the tests and the change land together.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty spec-coverage results with clearer context for unregistered codebases and registered entries containing no files.
  * Empty scans now indicate when coverage checks are not applicable and provide threshold-specific failure details.
  * Corrected exit statuses for enforced and non-enforced empty scans.
  * Improved recursive counting for selected registered codebases.
  * Coverage thresholds now pass when results meet the specified value.
  * Updated human-readable and JSON reports with clearer empty-state messaging and warnings.

* **Tests**
  * Added regression coverage for empty, documentation-only, populated, deterministic, and threshold-enforced scan scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->