### PR TITLE
feat(eval): add a deterministic structural compliance scorer

### DIFF
--- a/architecture/features/eval-harness.md
+++ b/architecture/features/eval-harness.md
@@ -11,6 +11,7 @@
   - [Run Eval Harness](#run-eval-harness)
 - [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
   - [Run Eval Suite](#run-eval-suite)
+  - [Score Structural Compliance](#score-structural-compliance)
 - [4. States (CDSL)](#4-states-cdsl)
   - [Eval Report Lifecycle](#eval-report-lifecycle)
 - [5. Definitions of Done](#5-definitions-of-done)
@@ -80,7 +81,7 @@ advisory verdict can never gate a build.
 **Steps**:
 1. [x] - `p1` - User invokes `cfs eval [--scenarios-dir DIR] [--baseline FILE]` - `inst-user-eval`
 2. [x] - `p1` - Load project context; if absent, emit ERROR and exit 1 - `inst-load-context`
-3. [x] - `p1` - Resolve the scenarios directory, run the suite through the reference scorer, attach an optional regression diff, emit the JSON report, and return the harness exit code - `inst-run-and-report`
+3. [x] - `p1` - Resolve the scenarios directory, run the suite through the deterministic structural scorer, attach an optional regression diff, emit the JSON report, and return the harness exit code - `inst-run-and-report`
 
 **Supporting**:
 - [x] - `p1` - Imports and module setup for the eval command - `inst-eval-imports`
@@ -113,6 +114,35 @@ under the gate contract (only deterministic verdicts affect the exit code).
 - [x] - `p1` - Scorer kinds, verdicts, the scorer protocol, and the result/scenario/report data model - `inst-eval-datamodel`
 - [x] - `p1` - A placeholder deterministic reference scorer that checks run presence, used to exercise the seam - `inst-reference-scorer`
 
+### Score Structural Compliance
+
+- [x] `p1` - **ID**: `cpt-studio-algo-eval-structural`
+
+The real deterministic scorer plugged into the `Scorer` seam. It reads a completed run's
+`plan.toml` manifest plus each phase file's `[phase]` frontmatter and runs a registry of
+independent structural checks (numbering, manifest agreement, dependency order, declared
+outputs, required sections). Verdict is `PASS` when every active check passes, `FAIL` when
+any fails, and `UNKNOWN` when the run cannot be loaded or no phase carries parseable
+frontmatter — "unscoreable is not zero". The scorer is pure over the in-memory run
+artifacts: it touches no filesystem.
+
+**Steps**:
+1. [x] - `p1` - Parse each phase file's `[phase]` frontmatter into a number-keyed table, recording files that re-declare a number as duplicates - `inst-structural-parse`
+2. [x] - `p1` - Run the phase-file validity and numbering-uniqueness checks over the parsed phases - `inst-structural-checks`
+3. [x] - `p1` - Run the manifest-agreement and numbering checks over the parsed phases - `inst-structural-checks-manifest`
+4. [x] - `p1` - Aggregate into a `ScorerResult`: compliance %, per-check findings, and the UNKNOWN discipline when nothing is scoreable - `inst-structural-scorer`
+
+**Supporting**:
+- [x] - `p1` - Module imports and the logger - `inst-structural-imports`
+- [x] - `p1` - The frontmatter pattern and the per-workflow required-sections configuration - `inst-structural-config`
+- [x] - `p1` - The `StructuralInput` data model the checks read from - `inst-structural-datamodel`
+- [x] - `p1` - Shared reducers over the manifest and phases (declared numbers, totals, capped detail formatting) that the checks build on - `inst-structural-check-helpers`
+- [x] - `p1` - Dependency-graph helpers: resolve/forward problems and misspelled-key detection - `inst-structural-deps`
+- [x] - `p1` - The per-phase checks — total consistency, dependency order, declared outputs - `inst-structural-checks-phase`
+- [x] - `p1` - Reduce a phase body to real Markdown prose (frontmatter and fenced code blocks removed) before heading detection - `inst-structural-prose`
+- [x] - `p1` - The required-body-sections check over that prose - `inst-structural-checks-sections`
+- [x] - `p1` - The check dataclass and the registry list binding each check name and tags to its predicate - `inst-structural-registry`
+
 ## 4. States (CDSL)
 
 ### Eval Report Lifecycle
@@ -143,6 +173,7 @@ yields a per-scenario regression diff without changing the exit code.
 |--------|------|----------------|
 | Eval Command | `skills/studio/scripts/studio/commands/eval.py` | CLI entry point, arg parsing, context, exit code |
 | Eval Harness | `skills/studio/scripts/studio/utils/eval_harness.py` | Scenario/run loading, scorer seam, runner, report, regression diff |
+| Structural Scorer | `skills/studio/scripts/studio/utils/eval_structural.py` | Deterministic structural checks over a run's manifest + phase frontmatter |
 
 ## 7. Acceptance Criteria
 
@@ -151,3 +182,5 @@ yields a per-scenario regression diff without changing the exit code.
 - [x] `p1` - A run that cannot be loaded, or whose phases declare no checkable file, scores `UNKNOWN` with a `null` score, never `0`, and is counted separately in the summary
 - [x] `p1` - `--baseline` alone (without `--check`) produces a per-scenario regression diff without changing the exit code; a removed/unavailable scenario is surfaced but does not gate
 - [x] `p1` - When `--baseline` is given, the `regression` key is always present (a diff object, or an `error` object when the baseline is unusable)
+- [x] `p1` - `cfs eval` scores structural compliance via a registry of deterministic checks over each run's manifest and phase frontmatter; any failing check makes the scenario verdict `FAIL` while the per-scenario `score_pct` still reports the fraction of checks passed
+- [x] `p1` - A run whose phase files carry no parseable `[phase]` frontmatter scores `UNKNOWN`, never 0; the scorer touches no filesystem and is a pure function of the in-memory run artifacts

--- a/skills/studio/scripts/studio/commands/eval.py
+++ b/skills/studio/scripts/studio/commands/eval.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from ..utils import eval_harness
+from ..utils.eval_structural import StructuralScorer
 from ..utils.ui import ui
 
 logger = logging.getLogger(__name__)
@@ -150,7 +151,7 @@ def cmd_eval(argv: List[str]) -> int:
         # A missing directory is an error, not a vacuous green pass.
         ui.result({"status": "ERROR", "message": f"Scenarios directory not found: {scenarios_dir}"})
         return 1
-    report = eval_harness.run_suite(scenarios_dir, [eval_harness.ReferencePresenceScorer()])
+    report = eval_harness.run_suite(scenarios_dir, [StructuralScorer()])
     payload = eval_harness.report_to_dict(report)
     if args.baseline:
         baseline = _load_baseline(Path(args.baseline))

--- a/skills/studio/scripts/studio/utils/eval_structural.py
+++ b/skills/studio/scripts/studio/utils/eval_structural.py
@@ -1,0 +1,506 @@
+"""Deterministic structural scorer for the workflow eval-harness.
+
+The real ``DETERMINISTIC`` scorer that plugs into the ``Scorer`` seam the scaffold
+(:mod:`studio.utils.eval_harness`) defines. It reads a completed run's ``plan.toml``
+manifest and the ``[phase]`` frontmatter carried by each ``phase-*.md`` file, runs a
+**registry** of independent structural checks (numbering, manifest agreement, dependency
+order, declared outputs, required sections), and returns a ``ScorerResult`` with a
+compliance %, per-check findings, and the scaffold's UNKNOWN discipline.
+
+Design commitments, inherited from the scaffold's gate contract: **unscoreable is not
+zero** (a run that will not load, or whose phases carry no parseable ``[phase]``
+frontmatter, scores ``UNKNOWN`` with a ``None`` score, never a false 0%); and **the
+registry is the unit of extension** — each check is a small tagged callable, skippable by
+name or tag and testable in isolation, rather than one hardcoded function. The scorer is a
+pure function of the in-memory run artifacts: no filesystem, no model call, no way to add
+either to a score.
+
+@cpt-algo:cpt-studio-algo-eval-structural:p1
+"""
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-imports
+from __future__ import annotations
+
+import logging
+import re
+import tomllib
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Set, Tuple
+
+from .eval_harness import (RunArtifacts, Scenario, ScorerKind, ScorerResult,
+                           VERDICT_FAIL, VERDICT_PASS, VERDICT_UNKNOWN)
+
+logger = logging.getLogger(__name__)
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-imports
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-config
+#: The fenced TOML block at the head of a phase file, carrying its ``[phase]`` table.
+#: Only *horizontal* whitespace is allowed after the opening fence (``[ \t]`` not ``\s``):
+#: letting ``\s`` swallow newlines makes an unterminated fence backtrack quadratically.
+_FRONTMATTER_RE = re.compile(r"^```toml[ \t]*\r?\n(?P<body>.*?)\r?\n```", re.DOTALL)
+
+#: Body sections a self-contained phase file is expected to carry, by default. Measured
+#: against the real plans, not invented: the common shape is ``## Preamble`` / ``## What`` /
+#: ``## Rules``. A workflow whose phases legitimately differ overrides this below.
+DEFAULT_SECTIONS: Tuple[str, ...] = ("Preamble", "What", "Rules")
+
+#: Per-workflow required-section overrides. A verification-style workflow legitimately
+#: carries no ``## Rules`` block, so scoring it against the universal set would be a
+#: false-fail; a workflow absent from this map uses ``DEFAULT_SECTIONS``.
+WORKFLOW_SECTIONS: Dict[str, Tuple[str, ...]] = {
+    "verify": ("Preamble", "What"),
+    "verification": ("Preamble", "What"),
+}
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-config
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-datamodel
+@dataclass
+class StructuralInput:
+    """Everything the checks read: the manifest plus the parsed phase frontmatter."""
+
+    plan_meta: Dict[str, object]                    # plan.toml [plan] table
+    manifest_phases: List[Dict[str, object]]        # plan.toml [[phases]] entries
+    phases: Dict[int, Dict[str, object]]            # phase number -> parsed [phase] frontmatter
+    bodies: Dict[int, str]                          # phase number -> raw phase-file body
+    by_file: Dict[str, int]                         # phase filename -> the number it declares
+    duplicates: List[str]                           # files that re-declare an already-seen number
+    invalid: List[str]                              # files WITH a [phase] block that is broken
+    no_frontmatter: List[str]                       # files with no [phase] block at all
+    required_sections: Tuple[str, ...]              # sections this workflow's phases must carry
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-datamodel
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-parse
+def _as_phase_int(value: object) -> Optional[int]:
+    """A phase number/total as a plain ``int``, or ``None`` when it is not one.
+
+    TOML already types its scalars, so this is a *type check*, not a parse — there is no
+    exception path to swallow. ``bool`` is excluded on purpose (it is an ``int`` subclass,
+    but a flag is never a phase number).
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+#: Leading bytes tolerated before the fence: a UTF-8 BOM and any blank lines / indentation.
+#: Editors and templating commonly prepend these, and rejecting them would look like a
+#: "missing frontmatter" false-negative rather than the near-miss it is.
+_LEADING_NOISE = "﻿ \t\r\n"
+
+
+def _match_frontmatter(text: str):
+    """Match the ``[phase]`` fence, tolerating a leading BOM / blank lines. Returns the match
+    and the normalised text it was matched against (so callers can slice by ``.end()``)."""
+    normalised = text.lstrip(_LEADING_NOISE)
+    return _FRONTMATTER_RE.match(normalised), normalised
+
+
+def _parse_phase_table(body: str) -> Optional[Dict[str, object]]:
+    """Parse an already-extracted fenced ``[phase]`` TOML *body* into its table, or ``None``
+    when the TOML is malformed (surfaced as a warning, not swallowed) or carries no ``[phase]``.
+    """
+    try:
+        data = tomllib.loads(body)
+    except tomllib.TOMLDecodeError as exc:
+        logger.warning("eval: phase file has a malformed [phase] frontmatter block: %s", exc)
+        return None
+    phase = data.get("phase")
+    return phase if isinstance(phase, dict) else None
+
+
+def _collect_phases(phase_texts: Dict[str, str]) -> Tuple[Dict[int, Dict[str, object]],
+                                                          Dict[int, str], Dict[str, int],
+                                                          List[str], List[str], List[str]]:
+    """Parse phase bodies into ``(by_number, bodies, by_file, duplicates, invalid, no_block)``.
+
+    Keying phases by their declared ``number`` (not by filename) is deliberate: it lets the
+    checks reason about ordering and dependencies. ``by_file`` retains the filename→number
+    pairing so a check can verify the manifest maps each number to the right file. A file that
+    cannot contribute a phase is *retained as a finding*, never silently dropped, and the two
+    failure modes are kept apart: a file that **has** a ``[phase]`` block but is broken
+    (unparseable TOML, or a bad number) goes to ``invalid`` — that is a *failing* run; a file
+    with **no** fenced block at all goes to ``no_block`` — that may just be a different workflow
+    shape. A second file re-declaring a number is recorded in ``duplicates``.
+    """
+    phases: Dict[int, Dict[str, object]] = {}
+    bodies: Dict[int, str] = {}
+    by_file: Dict[str, int] = {}
+    duplicates: List[str] = []
+    invalid: List[str] = []
+    no_block: List[str] = []
+    for name in sorted(phase_texts):
+        text = phase_texts[name]
+        match, _ = _match_frontmatter(text)
+        if match is None:
+            no_block.append(f"{name}: no [phase] frontmatter block")
+            continue
+        front = _parse_phase_table(match.group("body"))
+        if front is None:
+            invalid.append(f"{name}: [phase] frontmatter present but unparseable")
+            continue
+        number = _as_phase_int(front.get("number"))
+        if not number or number <= 0:
+            invalid.append(f"{name}: missing or non-positive phase number")
+            continue
+        by_file[name] = number
+        if number in phases:
+            duplicates.append(f"{name} re-declares phase {number}")
+            continue
+        phases[number] = front
+        bodies[number] = text
+    return phases, bodies, by_file, duplicates, invalid, no_block
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-parse
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-check-helpers
+def _capped(items: List[str], cap: int = 3) -> str:
+    """Join the first ``cap`` items, appending ``(+N more)`` so a truncated detail never hides
+    the true count from a reader."""
+    shown = "; ".join(items[:cap])
+    extra = len(items) - cap
+    return f"{shown} (+{extra} more)" if extra > 0 else shown
+
+
+def _manifest_numbers(inp: StructuralInput) -> List[int]:
+    """Every positive phase number the manifest lists, **duplicates preserved** (order kept)."""
+    numbers: List[int] = []
+    for entry in inp.manifest_phases:
+        number = _as_phase_int(entry.get("number"))
+        if number and number > 0:
+            numbers.append(number)
+    return numbers
+
+
+def _manifest_declared(inp: StructuralInput) -> Set[int]:
+    """The set of positive phase numbers the ``plan.toml`` manifest declares."""
+    return set(_manifest_numbers(inp))
+
+
+def _phase_totals(inp: StructuralInput) -> Set[int]:
+    """The distinct ``total`` values the phase frontmatter declares.
+
+    A missing or non-integer ``total`` counts as ``0`` (not dropped), so an absent total
+    lands in the set and trips ``phase-total-consistent`` rather than vanishing.
+    """
+    totals: Set[int] = set()
+    for front in inp.phases.values():
+        total = _as_phase_int(front.get("total"))
+        totals.add(total if total is not None else 0)
+    return totals
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-check-helpers
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-deps
+#: Keys that normalise to a plausible misspelling of ``depends_on`` — flagged so a typo
+#: (e.g. ``dependsOn``) is reported, not silently read as "no dependencies".
+_DEP_KEY_ALIASES = frozenset({"dependson", "dependencies", "depends", "dependency",
+                              "dependsupon", "dependon", "dependenton", "dependings"})
+
+
+def _misspelled_dep_key(front: Dict[str, object]) -> Optional[str]:
+    """A frontmatter key that looks like a misspelled ``depends_on`` (when the real key is
+    absent), or ``None``. Normalises case/underscores/hyphens before comparing."""
+    if "depends_on" in front:
+        return None
+    for key in front:
+        if isinstance(key, str) and key.lower().replace("_", "").replace("-", "") in _DEP_KEY_ALIASES:
+            return key
+    return None
+
+
+def _dependency_problems(inp: StructuralInput) -> Tuple[List[str], List[str]]:
+    """Return ``(unresolved, forward)`` dependency problems across all phases."""
+    unresolved: List[str] = []
+    forward: List[str] = []
+    for number, front in sorted(inp.phases.items()):
+        misspelled = _misspelled_dep_key(front)
+        if misspelled is not None:
+            unresolved.append(f"phase {number}: '{misspelled}' looks like a misspelled depends_on")
+        deps = front.get("depends_on")
+        if deps is None:
+            deps = []
+        elif not isinstance(deps, list):
+            # A present-but-non-list depends_on is a malformed declaration, not "no deps" —
+            # flag it rather than silently treating it as empty (which would vacuously pass).
+            unresolved.append(f"phase {number}: depends_on must be an array")
+            continue
+        for dep in deps:
+            dep_no = _as_phase_int(dep)
+            if dep_no is None:
+                unresolved.append(f"phase {number} -> {dep!r}")
+            elif dep_no not in inp.phases:
+                unresolved.append(f"phase {number} -> {dep_no} (missing)")
+            elif dep_no >= number:
+                forward.append(f"phase {number} -> {dep_no}")
+    return unresolved, forward
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-deps
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-checks
+def _check_phase_frontmatter_valid(inp: StructuralInput) -> Tuple[bool, str]:
+    # Once a run is scoreable (some phase parsed), every other declared phase file must too —
+    # whether it has a broken block (``invalid``) or none at all (``no_frontmatter``), it is a
+    # broken phase and fails here, so it can never be silently dropped into a vacuous pass.
+    problems = inp.invalid + inp.no_frontmatter
+    return not problems, _capped(problems)
+
+
+def _check_phase_numbers_unique(inp: StructuralInput) -> Tuple[bool, str]:
+    return not inp.duplicates, _capped(inp.duplicates)
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-checks
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-checks-manifest
+def _check_manifest_numbers_unique(inp: StructuralInput) -> Tuple[bool, str]:
+    numbers = _manifest_numbers(inp)
+    dupes = sorted({n for n in numbers if numbers.count(n) > 1})
+    return not dupes, f"manifest re-declares phase(s): {dupes}" if dupes else ""
+
+
+def _check_manifest_entries_valid(inp: StructuralInput) -> Tuple[bool, str]:
+    # A [[phases]] entry with a missing or non-positive number is malformed. Other manifest
+    # checks quietly drop such entries (they reduce to the set of *valid* numbers), so without
+    # this a broken manifest entry would never surface — flag each one explicitly.
+    bad = []
+    for index, entry in enumerate(inp.manifest_phases):
+        number = _as_phase_int(entry.get("number"))
+        if number is None or number <= 0:
+            bad.append(f"entry {index}: number={entry.get('number')!r}")
+    return not bad, _capped(bad)
+
+
+def _check_manifest_present(inp: StructuralInput) -> Tuple[bool, str]:
+    # The scaffold already turns an unreadable/`[plan]`-less plan.toml into UNKNOWN before a
+    # scorer runs, so this checks the *other* half — that the [[phases]] manifest actually
+    # lists the phases the files carry. It fails when a plan.toml has a [plan] table but no
+    # numbered [[phases]] entries, a real and distinct defect (not a vacuous always-pass).
+    ok = bool(_manifest_declared(inp))
+    return ok, "" if ok else "plan.toml [[phases]] declares no numbered phase"
+
+
+def _check_manifest_total_matches_entries(inp: StructuralInput) -> Tuple[bool, str]:
+    declared = _manifest_declared(inp)
+    total_declared = _as_phase_int(inp.plan_meta.get("total_phases")) or 0
+    ok = total_declared == len(declared)
+    return ok, f"total_phases={total_declared}, entries={len(declared)}"
+
+
+def _check_manifest_matches_files(inp: StructuralInput) -> Tuple[bool, str]:
+    # Two things must agree, not just the number *set*: (1) the declared and found number sets
+    # match, and (2) each manifest entry's number->file pairing matches the file's own declared
+    # number — a manifest that maps phase 1 to phase-2.md must not pass on set equality alone.
+    problems: List[str] = []
+    declared = _manifest_declared(inp)
+    found = set(inp.phases)
+    if declared != found:
+        problems.append(f"declared={sorted(declared)}, found={sorted(found)}")
+    for entry in inp.manifest_phases:
+        number = _as_phase_int(entry.get("number"))
+        file = entry.get("file")
+        if not isinstance(file, str) or number is None:
+            continue
+        actual = inp.by_file.get(file)
+        if actual is None:
+            problems.append(f"{file} (manifest phase {number}) has no valid phase")
+        elif actual != number:
+            problems.append(f"manifest pairs {file}->{number} but the file declares {actual}")
+    return not problems, _capped(problems, 3)
+
+
+def _check_numbering_contiguous(inp: StructuralInput) -> Tuple[bool, str]:
+    numbers = sorted(inp.phases)
+    ok = numbers == list(range(1, len(numbers) + 1))
+    return ok, f"numbers={numbers}"
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-checks-manifest
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-checks-phase
+def _check_phase_total_consistent(inp: StructuralInput) -> Tuple[bool, str]:
+    totals = _phase_totals(inp)
+    ok = len(totals) == 1 and totals != {0}
+    return ok, f"declared totals={sorted(totals)}"
+
+
+def _check_phase_total_matches_count(inp: StructuralInput) -> Tuple[bool, str]:
+    totals = _phase_totals(inp)
+    count = len(inp.phases)
+    ok = totals == {count}
+    return ok, f"total={sorted(totals)}, count={count}"
+
+
+def _check_dependencies_resolve(inp: StructuralInput) -> Tuple[bool, str]:
+    unresolved, _ = _dependency_problems(inp)
+    return not unresolved, _capped(unresolved)
+
+
+def _check_dependencies_not_forward(inp: StructuralInput) -> Tuple[bool, str]:
+    _, forward = _dependency_problems(inp)
+    return not forward, _capped(forward)
+
+
+def _check_every_phase_declares_output(inp: StructuralInput) -> Tuple[bool, str]:
+    missing = [str(n) for n, front in sorted(inp.phases.items())
+               if not (front.get("outputs") or front.get("output_files"))]
+    return not missing, (f"phases without outputs: {_capped(missing, 5)}" if missing else "")
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-checks-phase
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-prose
+def _prose_headings(raw_body: str) -> str:
+    """The phase body reduced to its real Markdown prose — the leading ``[phase]`` frontmatter
+    and every fenced code block removed — so a ``## Section``-looking line inside TOML or a
+    code sample is not mistaken for a real heading (which would inflate compliance).
+
+    A simple line-based fence toggle, not a Markdown parser: no regex over the whole body, so
+    no backtracking, and it covers the fenced ` ``` ` blocks phase files actually use.
+    """
+    front, normalised = _match_frontmatter(raw_body)
+    body = normalised[front.end():] if front else normalised
+    visible: List[str] = []
+    in_fence = False
+    for line in body.splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            visible.append(line)
+    return "\n".join(visible)
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-prose
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-checks-sections
+def _check_required_sections(inp: StructuralInput) -> Tuple[bool, str]:
+    missing: List[str] = []
+    for number in sorted(inp.phases):
+        body = _prose_headings(inp.bodies.get(number, ""))
+        for section in inp.required_sections:
+            if not re.search(rf"^##\s+{re.escape(section)}\b", body, re.MULTILINE):
+                missing.append(f"phase {number}: {section}")
+    return not missing, _capped(missing)
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-checks-sections
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-registry
+@dataclass(frozen=True)
+class Check:
+    """One structural check: a name, tags (for grouped skipping), and a pure predicate."""
+
+    name: str
+    tags: Tuple[str, ...]
+    run: Callable[[StructuralInput], Tuple[bool, str]]   # -> (passed, detail)
+
+
+#: The registry. Each check is independent — order affects only the findings list, not any
+#: verdict. Extending the scorer means appending a ``Check`` here, not editing a function.
+#: Two invariants the tests enforce: check names are **unique** (pass/total aggregation and
+#: skip-by-name rely on it) and contain **no colon** (findings serialise as ``name: detail``,
+#: which consumers split on the first colon).
+CHECKS: List[Check] = [
+    Check("phase-frontmatter-valid", ("phase",), _check_phase_frontmatter_valid),
+    Check("phase-numbers-unique", ("phase",), _check_phase_numbers_unique),
+    Check("manifest-present", ("manifest",), _check_manifest_present),
+    Check("manifest-entries-valid", ("manifest",), _check_manifest_entries_valid),
+    Check("manifest-numbers-unique", ("manifest",), _check_manifest_numbers_unique),
+    Check("manifest-total-matches-entries", ("manifest",), _check_manifest_total_matches_entries),
+    Check("manifest-matches-files", ("manifest",), _check_manifest_matches_files),
+    Check("numbering-contiguous-from-1", ("numbering",), _check_numbering_contiguous),
+    Check("phase-total-consistent", ("phase",), _check_phase_total_consistent),
+    Check("phase-total-matches-count", ("phase",), _check_phase_total_matches_count),
+    Check("dependencies-resolve", ("deps",), _check_dependencies_resolve),
+    Check("dependencies-not-forward", ("deps",), _check_dependencies_not_forward),
+    Check("every-phase-declares-an-output", ("outputs",), _check_every_phase_declares_output),
+    Check("required-sections-present", ("sections",), _check_required_sections),
+]
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-registry
+
+
+# @cpt-begin:cpt-studio-algo-eval-structural:p1:inst-structural-scorer
+class StructuralScorer:  # pylint: disable=too-few-public-methods
+    """Score a run's structural compliance against the check registry.
+
+    Deterministic: its verdict may reach the exit code (the runner enforces that; this
+    class only declares ``kind``). ``skip`` disables checks by name *or* tag, so a suite can
+    turn off a family of checks (e.g. all ``manifest`` checks) without editing the registry.
+    The scorer touches no filesystem — it is a pure function of the in-memory run artifacts.
+    """
+
+    name = "structural"
+    kind = ScorerKind.DETERMINISTIC
+
+    def __init__(self, skip: Tuple[str, ...] = ()) -> None:
+        self._skip = frozenset(skip)
+        # A skip token matching no check name or tag is almost always a typo — warn rather
+        # than silently no-op (which would leave the caller thinking a check was disabled).
+        known = {check.name for check in CHECKS} | {tag for check in CHECKS for tag in check.tags}
+        unknown = self._skip - known
+        if unknown:
+            logger.warning("eval: StructuralScorer(skip=...) has unrecognized name(s)/tag(s): %s",
+                           sorted(unknown))
+
+    def _active_checks(self) -> List[Check]:
+        """The registry minus any check whose name or tag is in the skip-set."""
+        return [check for check in CHECKS
+                if check.name not in self._skip and not set(check.tags) & self._skip]
+
+    def _evaluate(self, inp: StructuralInput,
+                  active: List[Check]) -> Tuple[int, List[str]]:
+        """Run every active check; return ``(passed, findings)`` for the failed ones."""
+        findings: List[str] = []
+        passed = 0
+        for check in active:
+            ok, detail = check.run(inp)
+            if ok:
+                passed += 1
+            else:
+                findings.append(f"{check.name}: {detail}" if detail else check.name)
+        return passed, findings
+
+    def _unknown(self, finding: str, coverage: str) -> ScorerResult:
+        """A UNKNOWN result — unscoreable, never a 0."""
+        return ScorerResult(self.name, self.kind, VERDICT_UNKNOWN, None, [finding], coverage)
+
+    def score(self, run: Optional[RunArtifacts], scenario: Scenario) -> ScorerResult:
+        """PASS if every active check passes, FAIL if any fails, UNKNOWN if unscoreable."""
+        if run is None:
+            return self._unknown("run artifacts could not be loaded",
+                                 "unscoreable: no readable plan.toml")
+
+        phases, bodies, by_file, duplicates, invalid, no_block = _collect_phases(run.phase_texts)
+        if not phases:
+            if invalid:
+                # Phase files carry a [phase] block that is broken — a *failing* run, not a
+                # different shape: score FAIL, don't hide it as UNKNOWN.
+                return ScorerResult(
+                    self.name, self.kind, VERDICT_FAIL, 0.0,
+                    [f"phase-frontmatter-valid: {_capped(invalid)}"],
+                    f"{len(invalid)} phase file(s) with broken [phase] frontmatter")
+            return self._unknown(
+                "no phase file carries a parseable [phase] frontmatter block",
+                "unscoreable: a different workflow shape, not a failing one")
+
+        active = self._active_checks()
+        if not active:
+            # Every check was skipped — nothing was assessed, which is UNKNOWN, not a pass.
+            return self._unknown("all structural checks were skipped",
+                                 "unscoreable: no checks ran")
+
+        inp = StructuralInput(
+            plan_meta=run.plan_meta,
+            manifest_phases=run.phases,
+            phases=phases,
+            bodies=bodies,
+            by_file=by_file,
+            duplicates=duplicates,
+            invalid=invalid,
+            no_frontmatter=no_block,
+            required_sections=WORKFLOW_SECTIONS.get(scenario.workflow, DEFAULT_SECTIONS),
+        )
+        passed, findings = self._evaluate(inp, active)
+        return ScorerResult(
+            self.name, self.kind,
+            VERDICT_PASS if passed == len(active) else VERDICT_FAIL,
+            round(passed / len(active) * 100, 2), findings,
+            f"{len(active)} structural check(s) over {len(phases)} phase(s)")
+# @cpt-end:cpt-studio-algo-eval-structural:p1:inst-structural-scorer

--- a/tests/fixtures/eval/compliant/run/phase-1.md
+++ b/tests/fixtures/eval/compliant/run/phase-1.md
@@ -1,3 +1,22 @@
+```toml
+[phase]
+number = 1
+total = 2
+depends_on = []
+input_files = ["plan.toml"]
+output_files = ["step-1.out"]
+```
+
 # Phase 1
 
-A present phase file.
+## Preamble
+
+A fully structurally-compliant first phase.
+
+## What
+
+Produce the first artifact.
+
+## Rules
+
+Follow the recipe; declare the output.

--- a/tests/fixtures/eval/compliant/run/phase-2.md
+++ b/tests/fixtures/eval/compliant/run/phase-2.md
@@ -1,0 +1,22 @@
+```toml
+[phase]
+number = 2
+total = 2
+depends_on = [1]
+input_files = ["plan.toml"]
+output_files = ["step-2.out"]
+```
+
+# Phase 2
+
+## Preamble
+
+A compliant second phase that depends only on an earlier phase.
+
+## What
+
+Produce the second artifact.
+
+## Rules
+
+Depend backward; declare the output.

--- a/tests/fixtures/eval/compliant/run/plan.toml
+++ b/tests/fixtures/eval/compliant/run/plan.toml
@@ -1,6 +1,11 @@
 [plan]
 task = "demo compliant run"
+total_phases = 2
 
 [[phases]]
 number = 1
 file = "phase-1.md"
+
+[[phases]]
+number = 2
+file = "phase-2.md"

--- a/tests/fixtures/eval/non_compliant/run/phase-1.md
+++ b/tests/fixtures/eval/non_compliant/run/phase-1.md
@@ -1,3 +1,23 @@
+```toml
+[phase]
+number = 1
+total = 2
+depends_on = []
+output_files = ["step-1.out"]
+```
+
 # Phase 1
 
-Present; phase-2.md is deliberately absent so the reference scorer FAILs.
+## Preamble
+
+Structurally scoreable, but the manifest declares two phases while only phase-1.md is
+present — so both the reference scorer (missing `phase-2.md`) and the structural scorer
+(manifest vs. files, phase total vs. count) report the run as non-compliant.
+
+## What
+
+Produce the first artifact.
+
+## Rules
+
+The missing declared phase is the deliberate defect.

--- a/tests/fixtures/eval/non_compliant/run/plan.toml
+++ b/tests/fixtures/eval/non_compliant/run/plan.toml
@@ -1,5 +1,6 @@
 [plan]
 task = "demo non-compliant run"
+total_phases = 2
 
 [[phases]]
 number = 1

--- a/tests/test_eval_cli.py
+++ b/tests/test_eval_cli.py
@@ -26,8 +26,14 @@ def _write_compliant(root: Path, sid: str = "ok") -> None:
     run.mkdir(parents=True)
     (root / sid / "scenario.toml").write_text(
         f'[scenario]\nid = "{sid}"\nworkflow = "w"\nrun_dir = "run"\nexpect = "compliant"\n')
-    (run / "plan.toml").write_text('[plan]\ntask = "t"\n[[phases]]\nnumber = 1\nfile = "p.md"\n')
-    (run / "p.md").write_text("# p\n")
+    (run / "plan.toml").write_text(
+        '[plan]\ntask = "t"\ntotal_phases = 1\n[[phases]]\nnumber = 1\nfile = "p.md"\n')
+    # A single, fully structurally-compliant phase: numbered 1 of 1, no forward deps, a
+    # declared output, and the default required sections — so StructuralScorer scores PASS.
+    (run / "p.md").write_text(
+        '```toml\n[phase]\nnumber = 1\ntotal = 1\ndepends_on = []\n'
+        'output_files = ["out.txt"]\n```\n\n'
+        "# P\n\n## Preamble\n\nContext.\n\n## What\n\nDo it.\n\n## Rules\n\nFollow them.\n")
 
 
 # --- wiring + errors -------------------------------------------------------
@@ -112,6 +118,24 @@ def test_cmd_eval_check_gates_on_broke_scenario(capsys, tmp_path: Path) -> None:
     out = json.loads(capsys.readouterr().out)
     assert rc == 2
     assert out["regression"]["has_regression"] is True
+
+
+def test_cmd_eval_zero_parseable_frontmatter_is_unknown_not_gated(capsys, tmp_path: Path) -> None:
+    # plan.toml loads, but every phase file lacks a parseable [phase] block → UNKNOWN, never a
+    # gate failure (the real-world "different workflow shape" path, exercised end-to-end).
+    scenarios = tmp_path / "scenarios"
+    run = scenarios / "z" / "run"
+    run.mkdir(parents=True)
+    (scenarios / "z" / "scenario.toml").write_text(
+        '[scenario]\nid = "z"\nworkflow = "coding-gen"\nrun_dir = "run"\nexpect = "unknown"\n')
+    (run / "plan.toml").write_text('[plan]\ntask = "t"\n[[phases]]\nnumber = 1\nfile = "p.md"\n')
+    (run / "p.md").write_text("# Phase 1\n\nno frontmatter block here\n")
+    with patch(_GET_CONTEXT, return_value=_ctx(tmp_path)):
+        rc = cmd_eval(["--scenarios-dir", str(scenarios), "--check", "--min", "0.0"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["summary"]["structural_compliance"] is None
+    assert out["summary"]["unknown"] >= 1
 
 
 # --- reporting + opt-in gating ---------------------------------------------

--- a/tests/test_eval_structural.py
+++ b/tests/test_eval_structural.py
@@ -1,0 +1,375 @@
+"""Tests for the deterministic ``StructuralScorer`` (utils.eval_structural)."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+
+from studio.utils.eval_harness import (RunArtifacts, Scenario, ScorerKind,
+                                       VERDICT_FAIL, VERDICT_PASS, VERDICT_UNKNOWN)
+from studio.utils.eval_structural import CHECKS, StructuralScorer, _capped
+
+
+# --- fixture builders ------------------------------------------------------
+
+def _phase_body(number: int, total: int, *, depends_on: Optional[List[int]] = None,
+                outputs: bool = True,
+                sections: Tuple[str, ...] = ("Preamble", "What", "Rules")) -> str:
+    """A phase file body with a valid ``[phase]`` frontmatter block and ``##`` sections."""
+    lines = ["```toml", "[phase]", f"number = {number}", f"total = {total}",
+             f"depends_on = {depends_on if depends_on is not None else []}"]
+    if outputs:
+        lines.append('output_files = ["step.out"]')
+    lines += ["```", "", f"# Phase {number}", ""]
+    for section in sections:
+        lines += [f"## {section}", "", "body", ""]
+    return "\n".join(lines)
+
+
+def _run(plan_meta: Optional[Dict[str, object]] = None,
+         manifest_phases: Optional[List[Dict[str, object]]] = None,
+         phase_texts: Optional[Dict[str, str]] = None) -> RunArtifacts:
+    """A compliant two-phase run by default; callers override one piece to craft a defect."""
+    if phase_texts is None:
+        phase_texts = {"phase-1.md": _phase_body(1, 2),
+                       "phase-2.md": _phase_body(2, 2, depends_on=[1])}
+    if manifest_phases is None:
+        manifest_phases = [{"number": 1, "file": "phase-1.md"},
+                           {"number": 2, "file": "phase-2.md"}]
+    if plan_meta is None:
+        plan_meta = {"task": "t", "total_phases": len(manifest_phases)}
+    return RunArtifacts(plan_meta=plan_meta, phases=manifest_phases, phase_texts=phase_texts)
+
+
+def _scenario(workflow: str = "coding-gen") -> Scenario:
+    return Scenario(id="s", workflow=workflow, run_dir=Path("run"), expect="compliant")
+
+
+def _score(run: Optional[RunArtifacts], **kwargs):
+    return StructuralScorer(**kwargs).score(run, _scenario())
+
+
+def _findings_for(run: RunArtifacts) -> Dict[str, str]:
+    """Map failed check name -> its finding string, for asserting exactly which check tripped."""
+    result = _score(run)
+    return {finding.split(":", 1)[0]: finding for finding in result.findings}
+
+
+# --- the happy path + the two UNKNOWN gates --------------------------------
+
+def test_fully_compliant_run_passes_100() -> None:
+    result = _score(_run())
+    assert result.verdict == VERDICT_PASS
+    assert result.score_pct == 100.0
+    assert result.findings == []
+    assert result.kind is ScorerKind.DETERMINISTIC
+
+
+def test_run_none_is_unknown_not_zero() -> None:
+    result = _score(None)
+    assert result.verdict == VERDICT_UNKNOWN
+    assert result.score_pct is None
+
+
+def test_no_parseable_frontmatter_is_unknown() -> None:
+    # A different workflow shape (plain markdown phases) is unscoreable, never a 0.
+    run = _run(phase_texts={"phase-1.md": "# Phase 1\n\nNo frontmatter here.\n"})
+    result = _score(run)
+    assert result.verdict == VERDICT_UNKNOWN
+    assert result.score_pct is None
+
+
+# --- one crafted known-bad per check ---------------------------------------
+
+def test_phase_numbers_unique_fails_on_duplicate() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2),
+                            "phase-1-copy.md": _phase_body(1, 2)})
+    # Two files both declare phase 1 → duplicate; the manifest still lists 1 & 2.
+    assert "phase-numbers-unique" in _findings_for(run)
+
+
+def test_manifest_present_fails_when_manifest_lists_no_phase() -> None:
+    run = _run(manifest_phases=[])           # [plan] present, but no [[phases]] entries
+    assert "manifest-present" in _findings_for(run)
+
+
+def test_manifest_total_matches_entries_fails_on_mismatch() -> None:
+    run = _run(plan_meta={"task": "t", "total_phases": 5})   # says 5, lists 2
+    assert "manifest-total-matches-entries" in _findings_for(run)
+
+
+def test_manifest_matches_files_fails_when_sets_differ() -> None:
+    run = _run(manifest_phases=[{"number": 1}, {"number": 3}])   # declares {1,3}, files give {1,2}
+    assert "manifest-matches-files" in _findings_for(run)
+
+
+def test_numbering_contiguous_fails_on_gap() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2),
+                            "phase-3.md": _phase_body(3, 2)},
+               manifest_phases=[{"number": 1}, {"number": 3}],
+               plan_meta={"task": "t", "total_phases": 2})
+    assert "numbering-contiguous-from-1" in _findings_for(run)
+
+
+def test_phase_total_consistent_fails_when_totals_disagree() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2),
+                            "phase-2.md": _phase_body(2, 3, depends_on=[1])})   # 2 vs 3
+    assert "phase-total-consistent" in _findings_for(run)
+
+
+def test_phase_total_matches_count_fails_when_total_wrong() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 9),
+                            "phase-2.md": _phase_body(2, 9, depends_on=[1])})   # total 9, count 2
+    assert "phase-total-matches-count" in _findings_for(run)
+
+
+def test_dependencies_resolve_fails_on_missing_target() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[7])})   # 7 does not exist
+    assert "dependencies-resolve" in _findings_for(run)
+
+
+def test_dependencies_not_forward_fails_on_forward_dep() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2, depends_on=[2]),   # forward
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1])})
+    assert "dependencies-not-forward" in _findings_for(run)
+
+
+def test_every_phase_declares_output_fails_when_missing() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2, outputs=False),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1])})
+    assert "every-phase-declares-an-output" in _findings_for(run)
+
+
+def test_required_sections_fails_when_section_missing() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2, sections=("Preamble", "What")),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1])})   # phase 1 lacks Rules
+    assert "required-sections-present" in _findings_for(run)
+
+
+def test_heading_inside_frontmatter_does_not_satisfy_required_sections() -> None:
+    # A '## Rules' line inside the TOML frontmatter must NOT count as the real Markdown section.
+    body = ('```toml\n[phase]\nnumber = 1\ntotal = 1\noutput_files = ["x"]\n'
+            'notes = """\n## Rules\ninside the toml block, not a real section\n"""\n```\n\n'
+            '## Preamble\n\nx\n\n## What\n\nx\n')   # no real ## Rules in the body
+    run = _run(phase_texts={"phase-1.md": body},
+               manifest_phases=[{"number": 1}], plan_meta={"task": "t", "total_phases": 1})
+    finding = _findings_for(run)["required-sections-present"]
+    assert "Rules" in finding
+
+
+def test_heading_inside_a_code_fence_does_not_satisfy_required_sections() -> None:
+    # '## Rules' inside a fenced code block is a sample, not a real heading — must not count.
+    body = ('```toml\n[phase]\nnumber = 1\ntotal = 1\noutput_files = ["x"]\n```\n\n'
+            '## Preamble\n\nx\n\n## What\n\n'
+            '```\n## Rules\nthis is a code sample, not a real section\n```\n')
+    run = _run(phase_texts={"phase-1.md": body},
+               manifest_phases=[{"number": 1}], plan_meta={"task": "t", "total_phases": 1})
+    finding = _findings_for(run)["required-sections-present"]
+    assert "Rules" in finding
+
+
+def test_a_single_defect_leaves_the_other_checks_passing() -> None:
+    # The forward-dep fixture must trip exactly one check, not cascade into others.
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2, depends_on=[2]),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1])})
+    result = _score(run)
+    assert result.verdict == VERDICT_FAIL
+    assert list(_findings_for(run)) == ["dependencies-not-forward"]
+    assert result.score_pct == round((len(CHECKS) - 1) / len(CHECKS) * 100, 2)
+
+
+def test_invalid_phase_file_is_flagged_not_silently_dropped() -> None:
+    # phase-2 is present but declares an invalid number; the manifest lists only phase 1, so
+    # no other check catches it. phase-frontmatter-valid must fail — no vacuous pass.
+    run = _run(
+        phase_texts={"phase-1.md": _phase_body(1, 1),
+                     "phase-2.md": _phase_body(2, 1).replace("number = 2", "number = 0")},
+        manifest_phases=[{"number": 1, "file": "phase-1.md"}],
+        plan_meta={"task": "t", "total_phases": 1})
+    result = _score(run)
+    assert result.verdict == VERDICT_FAIL
+    assert "phase-frontmatter-valid" in _findings_for(run)
+
+
+def test_unparseable_phase_file_alongside_a_valid_one_fails() -> None:
+    # A present-but-frontmatter-less phase file must be retained and flagged, not dropped.
+    run = _run(
+        phase_texts={"phase-1.md": _phase_body(1, 1),
+                     "phase-2.md": "# Phase 2\n\nno frontmatter block here\n"},
+        manifest_phases=[{"number": 1, "file": "phase-1.md"}],
+        plan_meta={"task": "t", "total_phases": 1})
+    assert "phase-frontmatter-valid" in _findings_for(run)
+
+
+def test_manifest_duplicate_number_is_flagged() -> None:
+    run = _run(manifest_phases=[{"number": 1}, {"number": 1}, {"number": 2}],
+               plan_meta={"task": "t", "total_phases": 2})
+    assert "manifest-numbers-unique" in _findings_for(run)
+
+
+# --- registry: skip by name and by tag -------------------------------------
+
+def test_skip_by_name_removes_a_check() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2, depends_on=[2]),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1])})
+    result = _score(run, skip=("dependencies-not-forward",))
+    assert result.verdict == VERDICT_PASS      # the only failing check was skipped
+    assert result.score_pct == 100.0
+
+
+def test_skip_by_tag_removes_a_family() -> None:
+    run = _run(manifest_phases=[])             # trips manifest-present (a "manifest" check)
+    result = _score(run, skip=("manifest",))
+    assert result.verdict == VERDICT_PASS
+
+
+def test_skipping_every_check_is_unknown_not_pass() -> None:
+    all_tags = {tag for check in CHECKS for tag in check.tags}
+    result = _score(_run(), skip=tuple(all_tags))
+    assert result.verdict == VERDICT_UNKNOWN
+    assert result.score_pct is None
+
+
+# --- per-workflow required sections ----------------------------------------
+
+def test_verification_workflow_does_not_require_rules() -> None:
+    # A "verify" workflow legitimately omits ## Rules — that must not be a false-fail.
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2, sections=("Preamble", "What")),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1],
+                                                      sections=("Preamble", "What"))})
+    result = StructuralScorer().score(run, _scenario(workflow="verify"))
+    assert result.verdict == VERDICT_PASS
+
+
+# --- detail is preserved in the finding ------------------------------------
+
+def test_finding_detail_names_the_offending_phase() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2, depends_on=[2]),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1])})
+    finding = _findings_for(run)["dependencies-not-forward"]
+    assert "phase 1 -> 2" in finding
+
+
+def test_malformed_toml_block_scores_fail_not_unknown() -> None:
+    # A phase that *has* a ```toml block but broken TOML is a failing run, not a different
+    # shape — it must score FAIL, never hide as UNKNOWN.
+    run = _run(phase_texts={"phase-1.md": "```toml\nthis is = = broken !!!\n```\n\n# P\n"})
+    result = _score(run)
+    assert result.verdict == VERDICT_FAIL
+    assert "phase-frontmatter-valid" in result.findings[0]
+
+
+def test_present_but_invalid_phase_number_scores_fail() -> None:
+    # A [phase] block that parses but declares number = 0 is broken → FAIL, not UNKNOWN.
+    body = ('```toml\n[phase]\nnumber = 0\ntotal = 1\noutput_files = ["x"]\n```\n\n'
+            "## Preamble\n\nx\n\n## What\n\nx\n\n## Rules\n\nx\n")
+    result = _score(_run(phase_texts={"phase-1.md": body}))
+    assert result.verdict == VERDICT_FAIL
+
+
+def test_no_frontmatter_block_at_all_is_unknown() -> None:
+    # No ```toml block anywhere → a genuinely different workflow shape → UNKNOWN, not FAIL.
+    run = _run(phase_texts={"phase-1.md": "# Phase 1\n\njust prose, no fenced block\n"})
+    result = _score(run)
+    assert result.verdict == VERDICT_UNKNOWN
+    assert result.score_pct is None
+
+
+def test_non_integer_dependency_is_unresolved() -> None:
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2),
+                            "phase-2.md": _phase_body(2, 2, depends_on=["one"])})
+    assert "dependencies-resolve" in _findings_for(run)
+
+
+def test_non_list_depends_on_is_unresolved() -> None:
+    # A scalar depends_on is a malformed declaration; it must fail, not vacuously pass.
+    body = ('```toml\n[phase]\nnumber = 2\ntotal = 2\ndepends_on = "one"\n'
+            'output_files = ["x"]\n```\n\n## Preamble\n\nx\n\n## What\n\nx\n\n## Rules\n\nx\n')
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2), "phase-2.md": body})
+    finding = _findings_for(run)["dependencies-resolve"]
+    assert "must be an array" in finding
+
+
+def test_absent_depends_on_is_treated_as_no_dependencies() -> None:
+    # A phase that omits depends_on entirely has no dependency problems (absent != malformed).
+    body = ('```toml\n[phase]\nnumber = 1\ntotal = 1\noutput_files = ["x"]\n```\n\n'
+            '## Preamble\n\nx\n\n## What\n\nx\n\n## Rules\n\nx\n')
+    run = _run(phase_texts={"phase-1.md": body},
+               manifest_phases=[{"number": 1}], plan_meta={"task": "t", "total_phases": 1})
+    assert _score(run).verdict == VERDICT_PASS
+
+
+@pytest.mark.parametrize("bad_total", ["oops", None])
+def test_unparseable_phase_total_is_handled_not_crashed(bad_total: object) -> None:
+    # A non-integer `total` must degrade the consistency checks, never raise.
+    body = ("```toml\n[phase]\nnumber = 1\n"
+            + (f'total = "{bad_total}"\n' if bad_total is not None else "")
+            + 'depends_on = []\noutput_files = ["x"]\n```\n\n'
+            "## Preamble\n\nx\n\n## What\n\nx\n\n## Rules\n\nx\n")
+    result = _score(_run(phase_texts={"phase-1.md": body},
+                         manifest_phases=[{"number": 1}],
+                         plan_meta={"task": "t", "total_phases": 1}))
+    assert result.verdict == VERDICT_FAIL          # inconsistent total, but no crash
+
+
+# --- ainetx review remediations --------------------------------------------
+
+def test_manifest_number_to_file_pairing_is_checked_not_just_the_set() -> None:
+    # Files declare 1 and 2, but the manifest swaps which file carries which number: set-equal
+    # yet the pairing is wrong, so manifest-matches-files must still fail.
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2),
+                            "phase-2.md": _phase_body(2, 2, depends_on=[1])},
+               manifest_phases=[{"number": 1, "file": "phase-2.md"},
+                                {"number": 2, "file": "phase-1.md"}])
+    finding = _findings_for(run)["manifest-matches-files"]
+    assert "declares" in finding or "pairs" in finding
+
+
+@pytest.mark.parametrize("typo", ["dependsOn", "depend_on", "dependencies"])
+def test_misspelled_depends_on_key_is_flagged(typo: str) -> None:
+    # A typo'd dependency key must be reported, not silently read as "no dependencies".
+    body = (f'```toml\n[phase]\nnumber = 2\ntotal = 2\n{typo} = [1]\n'
+            'output_files = ["x"]\n```\n\n## Preamble\n\nx\n\n## What\n\nx\n\n## Rules\n\nx\n')
+    run = _run(phase_texts={"phase-1.md": _phase_body(1, 2), "phase-2.md": body})
+    assert "misspelled depends_on" in _findings_for(run)["dependencies-resolve"]
+
+
+def test_malformed_manifest_entry_is_flagged() -> None:
+    # A [[phases]] entry with a non-integer number is malformed — other manifest checks drop it
+    # quietly, so manifest-entries-valid must surface it.
+    run = _run(manifest_phases=[{"number": 1, "file": "phase-1.md"},
+                                {"number": 2, "file": "phase-2.md"},
+                                {"number": "bad", "file": "x.md"}],
+               plan_meta={"task": "t", "total_phases": 2})
+    assert "manifest-entries-valid" in _findings_for(run)
+
+
+def test_leading_bom_frontmatter_still_parses() -> None:
+    run = _run(phase_texts={"phase-1.md": "﻿" + _phase_body(1, 1)},
+               manifest_phases=[{"number": 1, "file": "phase-1.md"}],
+               plan_meta={"task": "t", "total_phases": 1})
+    assert _score(run).verdict == VERDICT_PASS     # a BOM is tolerated, not a false UNKNOWN
+
+
+def test_unrecognized_skip_token_warns(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        StructuralScorer(skip=("no-such-check-or-tag",))
+    assert "unrecognized" in caplog.text
+
+
+def test_capped_reports_the_remaining_count() -> None:
+    assert _capped(["a", "b", "c", "d"], 3) == "a; b; c (+1 more)"
+    assert _capped(["a", "b"], 3) == "a; b"        # no "(+N more)" when nothing is hidden
+
+
+def test_registry_check_names_are_unique() -> None:
+    names = [check.name for check in CHECKS]
+    assert len(names) == len(set(names))
+
+
+def test_registry_check_names_contain_no_colon() -> None:
+    # Findings serialise as "name: detail"; a colon in a name would break that contract.
+    assert all(":" not in check.name for check in CHECKS)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -12,7 +12,7 @@ from studio.commands.agents import _AgentEntry, _SkillEntry, _MergedComponents, 
 from studio.commands.kit import _read_conf_version
 from studio.commands.resolve_vars import assemble_component
 from studio.utils.context import LoadedKit
-from studio.utils.eval_harness import Scenario, ScorerKind
+from studio.utils.eval_harness import ReferencePresenceScorer, Scenario, ScorerKind
 from studio.utils.manifest import ManifestLayerState
 
 is_json = _UI.is_json  # staticmethod alias exposed on the ui singleton
@@ -33,6 +33,7 @@ assemble_component  # public API for future use
 _ = LoadedKit.constraints_paths  # public context field for multi-constraints consumers
 _ = Scenario.gold_path  # part of the scenario format; consumed by the advisory judge
 _ = ScorerKind.ADVISORY  # public gate-contract value used by the advisory judge
+ReferencePresenceScorer  # minimal seam example + gate-contract test fixture (see tests)
 INCLUDE_ERROR = ManifestLayerState.INCLUDE_ERROR  # valid enum value for future use
 
 # cfs map module — symbols retained for layout/configuration completeness.


### PR DESCRIPTION
## What
Adds the real deterministic structural scorer to the workflow eval-harness, plugged into the `Scorer` seam from #92. `cfs eval --check` now gates on genuine structural compliance instead of the placeholder reference scorer.

## How it works
`StructuralScorer` (kind = DETERMINISTIC) reads a completed run's `plan.toml` manifest and each phase file's `[phase]` frontmatter, then runs a **registry** of independent structural checks: phase numbering (unique, contiguous from 1), manifest agreement (declared totals/entries/files vs. the phase files), phase-total consistency, dependency order (resolve, not forward), declared outputs, and required body sections (per-workflow-configurable).

It returns a compliance %, per-check findings, and the harness's UNKNOWN discipline — a run that can't be loaded or carries no parseable frontmatter scores `UNKNOWN`, never a false 0% ("unscoreable is not zero").

## Notes
- Pure function of the in-memory run artifacts — **no filesystem access, no model call**.
- Checks are tagged callables, skippable by name or tag; the reference scorer stays as the seam's minimal example / gate-contract test fixture.
- CPT-traced; new files at 100% coverage; pylint / vulture / validate / spec-coverage green.

Follows #92; part of the eval-harness track under #72.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic structural evaluation for workflow runs.
  * Validates phase metadata, numbering, dependencies, declared inputs and outputs, required sections, and manifest consistency.
  * Reports PASS, FAIL, or UNKNOWN outcomes with compliance percentages, findings, and coverage details.
  * Supports workflow-specific requirements and selectively skipping checks by name or category.
  * Identifies malformed or incomplete run data that cannot be scored.
  * Updated evaluations to use structural scoring.

* **Documentation**
  * Updated evaluation harness documentation to explain structural scoring, result interpretation, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->