### PR TITLE
fix(validate): reach the code checks when a scan resolves to no files

### DIFF
--- a/architecture/features/traceability-validation.md
+++ b/architecture/features/traceability-validation.md
@@ -87,6 +87,9 @@ Catches structural and traceability issues that AI agents miss or hallucinate �
 - Template structure mismatch → FAIL with heading contract details
 - Cross-reference to undefined ID → FAIL with definition hint
 - Code marker references non-existent artifact ID → FAIL with orphan details
+- Codebase entry registered with FULL traceability but resolving to no files → WARN naming the entry, so a run that checked nothing says so
+- Checked `to_code = true` ID with no code marker anywhere → FAIL, independent of how many files the scan resolved
+- No checked `to_code = true` ID and no code → PASS; nothing is claimed, so nothing is owed
 
 **Steps**:
 1. [x] - `p1` - User invokes `cfs validate [--artifact <path>] [--skip-code] [--verbose]` - `inst-user-validate`
@@ -119,6 +122,7 @@ Catches structural and traceability issues that AI agents miss or hallucinate �
 - [x] - `p1` - Run cross-artifact validation and merge only issues that apply to the actively validated artifacts - `inst-validate-cross-run`
 - [x] - `p1` - Resolve code scan targets and collect code marker state from configured codebase entries - `inst-validate-code-scan`
 - [x] - `p1` - Execute recursive system code scanning and strict code cross-validation against artifact expectations - `inst-validate-code-run`
+- [x] - `p1` - Warn for each FULL codebase entry that is registered but resolves to no files, so a run that checked nothing says so - `inst-warn-empty-codebase-entry`
 - [x] - `p1` - Build traceability lookup indexes for artifact paths, FULL-traceability IDs, and reference coverage - `inst-validate-traceability-index`
 - [x] - `p1` - Apply fallback reference coverage rules for unconstrained artifact kinds - `inst-validate-reference-coverage`
 - [x] - `p1` - Load language-validation configuration from workspace settings - `inst-validate-language-config`

--- a/skills/studio/scripts/studio/commands/validate.py
+++ b/skills/studio/scripts/studio/commands/validate.py
@@ -757,7 +757,7 @@ def _scan_codebase_entry(
     # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
     scan_targets = list(_resolve_code_scan_targets(session, entry))
     if traceability == "FULL" and not scan_targets:
-        results.empty_full_codebase_entries.append(str(getattr(entry, "path", "")))
+        results.empty_full_codebase_entries.append(_codebase_entry_path(entry))
     for file_path in scan_targets:
         try:
             rel_path = file_path.resolve().relative_to(session.project_root).as_posix()
@@ -794,6 +794,15 @@ def _scan_codebase_entry(
     # @cpt-end:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
 
 
+def _codebase_entry_path(entry: object) -> str:
+    """Configured path of a codebase entry, which may be a record or a raw dict."""
+    # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
+    if isinstance(entry, dict):
+        return str(entry.get("path", ""))
+    return str(getattr(entry, "path", ""))
+    # @cpt-end:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
+
+
 def _resolve_code_scan_targets(session: _ValidateSession, entry: object) -> List[Path]:
     """Resolve concrete files for one codebase entry."""
     # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
@@ -801,8 +810,7 @@ def _resolve_code_scan_targets(session: _ValidateSession, entry: object) -> List
     if src_name and session.ws_ctx is not None:
         code_path = session.ws_ctx.resolve_artifact_path(entry, session.project_root)
     else:
-        entry_path = getattr(entry, "path", "") if not isinstance(entry, dict) else entry.get("path", "")
-        code_path = (session.project_root / entry_path).resolve()
+        code_path = (session.project_root / _codebase_entry_path(entry)).resolve()
     if code_path is None or not code_path.exists():
         return []
     if code_path.is_file():

--- a/skills/studio/scripts/studio/commands/validate.py
+++ b/skills/studio/scripts/studio/commands/validate.py
@@ -57,7 +57,7 @@ class _ValidateResults:
     parsed_code_files_full: List[CodeFile] = field(default_factory=list)
     code_ids_found: Set[str] = field(default_factory=set)
     to_code_ids: Set[str] = field(default_factory=set)
-    empty_full_codebase_entries: List[str] = field(default_factory=list)
+    empty_full_codebase_entries: List[Dict[str, str]] = field(default_factory=list)
 
 # @cpt-begin:cpt-studio-algo-workspace-determine-target:p1:inst-validate-source-flag
 def _resolve_source_context(source_name: str, ws_ctx: Optional["WorkspaceContext"]) -> Optional["StudioContext"]:
@@ -757,7 +757,12 @@ def _scan_codebase_entry(
     # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
     scan_targets = list(_resolve_code_scan_targets(session, entry))
     if traceability == "FULL" and not scan_targets:
-        results.empty_full_codebase_entries.append(_codebase_entry_path(entry))
+        results.empty_full_codebase_entries.append({
+            "path": _codebase_entry_path(entry),
+            "source": str(
+                entry.get("source") or "" if isinstance(entry, dict) else getattr(entry, "source", "") or ""
+            ),
+        })
     for file_path in scan_targets:
         try:
             rel_path = file_path.resolve().relative_to(session.project_root).as_posix()
@@ -830,10 +835,23 @@ def _scan_system_codebase(
     session: _ValidateSession,
     results: _ValidateResults,
     strict_code_validation: bool,
+    inherited_traceability: str = "DOCS-ONLY",
 ) -> None:
-    """Recursively scan a system node's configured codebase entries."""
+    """Recursively scan a system node's configured codebase entries.
+
+    FULL traceability is inherited by descendants. A parent that owns the FULL
+    artifact makes the claim; the code backing it often lives in a child system
+    that has no artifact of its own. Deriving traceability from each node in
+    isolation left such code out of the FULL set, so its markers were never
+    cross-validated and a correctly marked implementation looked unmarked.
+    """
     # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
-    traceability = "FULL" if any(art.traceability == "FULL" for art in system_node.artifacts) else "DOCS-ONLY"
+    traceability = (
+        "FULL"
+        if inherited_traceability == "FULL"
+        or any(art.traceability == "FULL" for art in system_node.artifacts)
+        else "DOCS-ONLY"
+    )
     for codebase_entry in system_node.codebase:
         _scan_codebase_entry(
             entry=codebase_entry,
@@ -848,29 +866,44 @@ def _scan_system_codebase(
             session=session,
             results=results,
             strict_code_validation=strict_code_validation,
+            inherited_traceability=traceability,
         )
     # @cpt-end:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
 
 
-def _build_empty_codebase_entry_warnings(entry_paths: List[str]) -> List[Dict[str, object]]:
+def _build_empty_codebase_entry_warnings(entries: List[Dict[str, str]]) -> List[Dict[str, object]]:
     """Warn for each FULL codebase entry that is registered but resolves to no files.
 
     A registered entry matching nothing is a configuration mistake -- usually a
-    stale or misspelled path -- and it silently shrinks what the run was able to
-    check. It is reported separately from any unmet ID, because the subject is
-    the registration rather than the claim.
+    stale or misspelled path, or a workspace source that is not reachable -- and
+    it silently shrinks what the run was able to check. It is reported separately
+    from any unmet ID, because the subject is the registration rather than the
+    claim. The workspace source is named when there is one, so two entries that
+    share a path stay distinguishable and the reader knows whether to fix the
+    source or the path.
     """
     # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-warn-empty-codebase-entry
-    return [
-        code_issue(
-            "structure",
-            f"codebase entry `{path or '<unset>'}` is registered with FULL traceability "
-            "but resolved to 0 files — nothing from it was checked",
-            code=EC.CODEBASE_ENTRY_EMPTY,
-            path=Path(path or "."),
+    warnings: List[Dict[str, object]] = []
+    for entry in entries:
+        path = entry.get("path") or "<unset>"
+        source = entry.get("source") or ""
+        subject = f"`{source}:{path}`" if source else f"`{path}`"
+        cause = (
+            f"workspace source `{source}` did not resolve, or it resolved to an empty tree"
+            if source
+            else "the path does not exist, or it contains no files with the configured extensions"
         )
-        for path in entry_paths
-    ]
+        warnings.append(
+            code_issue(
+                "structure",
+                f"codebase entry {subject} is registered with FULL traceability but "
+                f"resolved to 0 files — nothing from it was checked ({cause})",
+                code=EC.CODEBASE_ENTRY_EMPTY,
+                path=Path(path if path != "<unset>" else "."),
+                source=source or None,
+            )
+        )
+    return warnings
     # @cpt-end:cpt-studio-flow-traceability-validation-validate:p1:inst-warn-empty-codebase-entry
 
 
@@ -1131,6 +1164,13 @@ def _emit_final_validate_report(session: _ValidateSession, results: _ValidateRes
         report["code_ids_found"] = len(results.code_ids_found)
         if results.to_code_ids:
             report["coverage"] = f"{len(results.code_ids_found & results.to_code_ids)}/{len(results.to_code_ids)}"
+        # Named unconditionally: a passing run has to be able to say what it did
+        # not check, and warning bodies are omitted from a non-verbose report.
+        if results.empty_full_codebase_entries:
+            report["unscanned_codebase_entries"] = [
+                f"{entry['source']}:{entry['path']}" if entry.get("source") else entry["path"]
+                for entry in results.empty_full_codebase_entries
+            ]
     if overall_status == "PASS":
         report["next_step"] = (
             "Deterministic validation passed. Now perform semantic validation: "
@@ -1429,6 +1469,22 @@ def _run_content_language_check(
 # ---------------------------------------------------------------------------
 
 # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-format
+def _show_unscanned_codebase_entries(unscanned: List[str]) -> None:
+    """Name the registered entries that resolved to no files, if any."""
+    if not unscanned:
+        return
+    ui.blank()
+    ui.warn(
+        f"{len(unscanned)} registered codebase "
+        f"{'entry' if len(unscanned) == 1 else 'entries'} resolved to 0 files "
+        "— nothing from them was checked"
+    )
+    for entry in unscanned[:10]:
+        ui.substep(f"  {entry}")
+    if len(unscanned) > 10:
+        ui.substep(f"  ... and {len(unscanned) - 10} more")
+
+
 def _human_validate(data: dict) -> None:
     status = data.get("status", "")
     n_art = data.get("artifacts_validated", data.get("artifact_count", 0))
@@ -1444,6 +1500,8 @@ def _human_validate(data: dict) -> None:
         ui.detail("Code files", str(data["code_files_scanned"]))
     if data.get("coverage"):
         ui.detail("Code coverage", str(data["coverage"]))
+
+    _show_unscanned_codebase_entries(data.get("unscanned_codebase_entries", []))
 
     errors = data.get("errors", [])
     if errors:

--- a/skills/studio/scripts/studio/commands/validate.py
+++ b/skills/studio/scripts/studio/commands/validate.py
@@ -755,13 +755,21 @@ def _scan_codebase_entry(
 ) -> None:
     """Scan one configured codebase entry and collect code traceability state."""
     # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
+    # Normalise before resolving. A raw mapping would otherwise lose its
+    # `source`: both this function and `resolve_artifact_path` read it by
+    # attribute, so a dict naming a workspace source would silently resolve
+    # against the local path instead — and the warning below would then name a
+    # source that was never consulted.
+    if isinstance(entry, dict):
+        from ..utils.artifacts_meta import CodebaseEntry
+
+        entry = CodebaseEntry.from_dict(entry)
+
     scan_targets = list(_resolve_code_scan_targets(session, entry))
     if traceability == "FULL" and not scan_targets:
         results.empty_full_codebase_entries.append({
             "path": _codebase_entry_path(entry),
-            "source": str(
-                entry.get("source") or "" if isinstance(entry, dict) else getattr(entry, "source", "") or ""
-            ),
+            "source": str(getattr(entry, "source", "") or ""),
         })
     for file_path in scan_targets:
         try:

--- a/skills/studio/scripts/studio/commands/validate.py
+++ b/skills/studio/scripts/studio/commands/validate.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 from ..utils import decision_log
 from ..utils import error_codes as EC
-from ..utils.codebase import CodeFile, cross_validate_code
+from ..utils.codebase import CodeFile, cross_validate_code, error as code_issue
 from ..utils.constraints import (
     ArtifactRecord,
     cross_validate_artifacts,
@@ -57,6 +57,7 @@ class _ValidateResults:
     parsed_code_files_full: List[CodeFile] = field(default_factory=list)
     code_ids_found: Set[str] = field(default_factory=set)
     to_code_ids: Set[str] = field(default_factory=set)
+    empty_full_codebase_entries: List[str] = field(default_factory=list)
 
 # @cpt-begin:cpt-studio-algo-workspace-determine-target:p1:inst-validate-source-flag
 def _resolve_source_context(source_name: str, ws_ctx: Optional["WorkspaceContext"]) -> Optional["StudioContext"]:
@@ -754,7 +755,10 @@ def _scan_codebase_entry(
 ) -> None:
     """Scan one configured codebase entry and collect code traceability state."""
     # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
-    for file_path in _resolve_code_scan_targets(session, entry):
+    scan_targets = list(_resolve_code_scan_targets(session, entry))
+    if traceability == "FULL" and not scan_targets:
+        results.empty_full_codebase_entries.append(str(getattr(entry, "path", "")))
+    for file_path in scan_targets:
         try:
             rel_path = file_path.resolve().relative_to(session.project_root).as_posix()
         except ValueError as exc:
@@ -840,6 +844,28 @@ def _scan_system_codebase(
     # @cpt-end:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
 
 
+def _build_empty_codebase_entry_warnings(entry_paths: List[str]) -> List[Dict[str, object]]:
+    """Warn for each FULL codebase entry that is registered but resolves to no files.
+
+    A registered entry matching nothing is a configuration mistake -- usually a
+    stale or misspelled path -- and it silently shrinks what the run was able to
+    check. It is reported separately from any unmet ID, because the subject is
+    the registration rather than the claim.
+    """
+    # @cpt-begin:cpt-studio-flow-traceability-validation-validate:p1:inst-warn-empty-codebase-entry
+    return [
+        code_issue(
+            "structure",
+            f"codebase entry `{path or '<unset>'}` is registered with FULL traceability "
+            "but resolved to 0 files — nothing from it was checked",
+            code=EC.CODEBASE_ENTRY_EMPTY,
+            path=Path(path or "."),
+        )
+        for path in entry_paths
+    ]
+    # @cpt-end:cpt-studio-flow-traceability-validation-validate:p1:inst-warn-empty-codebase-entry
+
+
 def _run_code_validation(
     session: _ValidateSession,
     results: _ValidateResults,
@@ -871,7 +897,12 @@ def _run_code_validation(
             results=results,
             strict_code_validation=strict_code_validation,
         )
-    if not strict_code_validation or not results.parsed_code_files_full:
+    if not strict_code_validation:
+        return
+    results.all_warnings.extend(
+        _build_empty_codebase_entry_warnings(results.empty_full_codebase_entries)
+    )
+    if not results.parsed_code_files_full and not results.to_code_ids:
         return
     artifact_instances, artifact_instances_all = _collect_full_artifact_instances(
         all_artifacts_for_cross,

--- a/skills/studio/scripts/studio/utils/error_codes.py
+++ b/skills/studio/scripts/studio/utils/error_codes.py
@@ -99,6 +99,11 @@ CODE_INST_MISSING = "code-inst-missing"
 CODE_INST_ORPHAN = "code-inst-orphan"
 
 # ---------------------------------------------------------------------------
+# Codebase registration — what was in scope to check
+# ---------------------------------------------------------------------------
+CODEBASE_ENTRY_EMPTY = "codebase-entry-empty"
+
+# ---------------------------------------------------------------------------
 # TOC (Table of Contents) validation
 # ---------------------------------------------------------------------------
 TOC_MISSING = "toc-missing"

--- a/tests/test_enforcement_empty_codebase.py
+++ b/tests/test_enforcement_empty_codebase.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scr
 sys.path.insert(0, str(Path(__file__).parent))
 
 from _test_helpers import run_cli_in_project, write_constraints_toml
+from studio.commands.validate import _ValidateResults
 
 CLAIMED_ID = "cpt-test-flow-login"
 # `algo` is not configured to_code, so this ID declares work without claiming code.
@@ -382,6 +383,44 @@ class TestAnEmptyRegisteredTreeSaysSo:
         assert "`src`" in message
         assert "workspace source" not in message
         assert "configured extensions" in message
+
+    def test_a_dict_entry_naming_a_source_does_not_fall_back_to_the_local_path(self):
+        """A mapping's `source` must survive, or the wrong tree gets validated.
+
+        Both `_resolve_code_scan_targets` and `resolve_artifact_path` read
+        `source` by attribute, so an unnormalised mapping took the local-path
+        branch: with a local directory of the same name present, an unavailable
+        workspace source would quietly validate local code and emit no
+        empty-entry warning at all.
+        """
+        from unittest.mock import MagicMock
+
+        from studio.commands.validate import _scan_codebase_entry
+
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            local = root / "src"
+            local.mkdir()
+            (local / "decoy.py").write_text("x = 1\n", encoding="utf-8")
+
+            session = MagicMock()
+            session.project_root = root
+            session.meta.is_ignored.return_value = False
+            # The named source is unavailable, so it resolves to nothing.
+            session.ws_ctx.resolve_artifact_path.return_value = None
+            results = _ValidateResults()
+
+            _scan_codebase_entry(
+                entry={"source": "ghost", "path": "src", "extensions": [".py"]},
+                traceability="FULL",
+                session=session,
+                results=results,
+                strict_code_validation=True,
+            )
+
+        assert results.parsed_code_files_full == []
+        assert results.empty_full_codebase_entries == [{"path": "src", "source": "ghost"}]
+        session.ws_ctx.resolve_artifact_path.assert_called_once()
 
     def test_a_raw_dict_entry_is_named_the_same_way(self):
         """Entries reach this code as records or as raw dicts; both must be named.

--- a/tests/test_enforcement_empty_codebase.py
+++ b/tests/test_enforcement_empty_codebase.py
@@ -1,0 +1,308 @@
+"""An empty scan is not a pass: `validate` must reach its checks on 0 files.
+
+Every check needed here already exists and is correct. What this corpus covers
+is *reachability*: with a registered FULL codebase entry that resolves to no
+files, cross-validation used to be skipped wholesale, so a FEATURE claiming
+implemented code validated clean. Adding a single unmarked `.py` file to the
+same repository produced the right errors, which is the evidence that the gap
+was the 0-file bypass rather than missing validation.
+
+Three questions are kept apart, matching the report semantics used by
+`spec-coverage`:
+
+* **"did anything fail?"** -- a repository that claims nothing owes nothing,
+  even with no code at all. A spec-first project must stay green.
+* **"was there anything to assess?"** -- a registered entry resolving to no
+  files is a configuration mistake and is reported as one, whether or not any
+  ID is claimed.
+* **"was a guarantee demanded that cannot be given?"** -- a checked
+  `to_code = true` ID with no marker anywhere is an unmet claim, and the scan
+  size is irrelevant to that.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _test_helpers import run_cli_in_project, write_constraints_toml
+
+CLAIMED_ID = "cpt-test-flow-login"
+# `algo` is not configured to_code, so this ID declares work without claiming code.
+UNCLAIMED_ID = "cpt-test-algo-bucket"
+
+
+def _project(
+    root: Path,
+    *,
+    claim_id: bool,
+    code: dict[str, str] | None = None,
+    codebase_path: str | None = "src",
+    declare_instructions: bool = False,
+) -> None:
+    """Build a project with a FULL artifact and a registered codebase entry.
+
+    ``claim_id`` controls whether the artifact checks a ``to_code = true`` ID --
+    that is, whether anything is being claimed. ``code`` maps relative paths to
+    file contents; omitting it leaves the registered tree empty, which is the
+    state under test. ``declare_instructions`` adds checked CDSL steps under an
+    ID that is *not* ``to_code``, which is what an over-broad fix would turn
+    into a wall of missing-instruction errors.
+    """
+    from studio.utils import toml_utils
+
+    (root / "kits" / "sdlc").mkdir(parents=True)
+    write_constraints_toml(
+        root / "kits" / "sdlc",
+        {
+            "PRD": {
+                "identifiers": {
+                    # `flow` claims code; `algo` declares work without claiming it.
+                    "flow": {"to_code": True},
+                    "algo": {"to_code": False, "required": False},
+                }
+            }
+        },
+    )
+
+    art_dir = root / "architecture"
+    art_dir.mkdir(parents=True)
+    checkbox = "x" if claim_id else " "
+    content = f"- [{checkbox}] **ID**: `{CLAIMED_ID}`\n"
+    if declare_instructions:
+        content += (
+            f"\n- [x] **ID**: `{UNCLAIMED_ID}`\n"
+            "\n**Steps**:\n"
+            "- [x] - `p1` - Put the thing in the bucket - `inst-bucket-put`\n"
+            "- [x] - `p1` - Read the thing back out - `inst-bucket-get`\n"
+        )
+    (art_dir / "PRD.md").write_text(content, encoding="utf-8")
+
+    for rel, content in (code or {}).items():
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+
+    (root / ".git").mkdir(exist_ok=True)
+    (root / "AGENTS.md").write_text(
+        '<!-- @cf:root-agents -->\n```toml\ncf-studio-path = "adapter"\n```\n',
+        encoding="utf-8",
+    )
+    config = root / "adapter" / "config"
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "AGENTS.md").write_text("# Test adapter\n", encoding="utf-8")
+    system: dict = {
+        "name": "Test",
+        "slug": "test",
+        "kit": "cypilot",
+        "artifacts": [
+            {"path": "architecture/PRD.md", "kind": "PRD", "traceability": "FULL"}
+        ],
+    }
+    if codebase_path is not None:
+        system["codebase"] = [{"path": codebase_path, "extensions": [".py"]}]
+    toml_utils.dump(
+        {
+            "version": "1.0",
+            "project_root": "..",
+            "kits": {"cypilot": {"format": "CFS", "path": "kits/sdlc"}},
+            "systems": [system],
+        },
+        config / "artifacts.toml",
+    )
+
+
+def _codes(report: dict, bucket: str) -> list[str]:
+    """Issue codes from a report bucket. Requires ``--verbose`` to be populated."""
+    assert bucket in report, f"report has no `{bucket}` array — pass --verbose"
+    return [str(issue.get("code")) for issue in report[bucket]]
+
+
+# ---------------------------------------------------------------------------
+# Known-bad must go red. These are the states that used to validate clean.
+# ---------------------------------------------------------------------------
+
+class TestAClaimWithNoCodeIsNotClean:
+    def test_a_checked_to_code_id_with_no_code_at_all_fails(self):
+        """The maximal false-completion claim: everything marked done, nothing built.
+
+        Before this change the identical repository returned exit 0 "All checks
+        passed" while reporting ``to_code_ids_total: 1`` and ``code_ids_found: 0``
+        in the same object.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=True)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 2
+        assert report["status"] == "FAIL"
+        assert "code-no-marker" in _codes(report, "errors")
+
+    def test_the_unmet_claim_is_named_not_just_counted(self):
+        """A verdict has to say which claim is unbacked, or it cannot be acted on."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=True)
+
+            _, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        unmet = [
+            issue for issue in report["errors"]
+            if issue.get("code") == "code-no-marker"
+        ]
+        assert len(unmet) == 1
+        assert unmet[0].get("id") == CLAIMED_ID
+
+    def test_the_scan_size_does_not_change_the_verdict(self):
+        """0 files and 1 unmarked file are the same claim, so the same verdict.
+
+        This is the invariant the whole change rests on: the checks were always
+        right, they were just unreachable below one file.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=True)
+            zero_code, zero_report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=True, code={"src/module.py": "def f():\n    return 1\n"})
+            one_code, one_report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert zero_code == one_code == 2
+        assert _codes(zero_report, "errors") == _codes(one_report, "errors")
+
+
+class TestAnEmptyRegisteredTreeSaysSo:
+    def test_a_registered_entry_that_matches_nothing_is_reported(self):
+        """Nothing is claimed, so nothing fails -- but nothing was checked either."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=False)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 0
+        assert "codebase-entry-empty" in _codes(report, "warnings")
+
+    def test_the_warning_names_the_entry_that_matched_nothing(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=False, codebase_path="does/not/exist")
+
+            _, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        empty = [
+            issue for issue in report["warnings"]
+            if issue.get("code") == "codebase-entry-empty"
+        ]
+        assert len(empty) == 1
+        assert "does/not/exist" in str(empty[0].get("message"))
+
+    def test_a_populated_entry_produces_no_such_warning(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(
+                root,
+                claim_id=False,
+                code={"src/module.py": "def f():\n    return 1\n"},
+            )
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 0
+        assert "codebase-entry-empty" not in _codes(report, "warnings")
+
+
+# ---------------------------------------------------------------------------
+# Known-good must stay green. A fix that breaks one of these is too broad.
+# ---------------------------------------------------------------------------
+
+class TestNothingClaimedIsNothingOwed:
+    def test_a_spec_first_project_with_no_code_stays_green(self):
+        """The leniency this change deliberately keeps.
+
+        A repository with artifacts written and no implementation yet -- no
+        checked ``to_code`` ID, no registered codebase entry -- must not be
+        failed. This is the assertion most at risk from an over-broad fix, and
+        the reason the guard keys on whether a claim exists rather than on
+        whether files were scanned.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=False, codebase_path=None)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 0
+        assert report["status"] == "PASS"
+        assert report["error_count"] == 0
+        assert "codebase-entry-empty" not in _codes(report, "warnings")
+
+    def test_declared_instructions_without_a_code_claim_are_not_errors(self):
+        """The discriminating case for over-breadth.
+
+        A spec-first repository can declare a full set of checked CDSL steps
+        under IDs that are not ``to_code`` -- design work, written down, nothing
+        built. Running cross-validation here anyway turns every declared
+        instruction into ``code-inst-missing``, which is why the guard has to
+        key on whether a *code claim* exists rather than on whether the scan
+        was empty. Without this case a fix that simply deletes the file-count
+        check looks correct.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=False, codebase_path=None, declare_instructions=True)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 0
+        assert report["status"] == "PASS"
+        assert "code-inst-missing" not in _codes(report, "errors")
+        assert report["error_count"] == 0
+
+    def test_an_unchecked_claim_owes_nothing_even_with_an_empty_tree(self):
+        """An ID present but *unchecked* is not yet a claim of completion."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=False)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 0
+        assert "code-no-marker" not in _codes(report, "errors")
+
+    def test_a_marked_implementation_is_clean(self):
+        """Known-good: the claim is made and the marker backs it."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(
+                root,
+                claim_id=True,
+                code={"src/module.py": f"# @cpt-flow:{CLAIMED_ID}:p1\ndef f():\n    return 1\n"},
+            )
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 0
+        assert report["status"] == "PASS"
+        assert "code-no-marker" not in _codes(report, "errors")
+
+
+class TestTheVerdictIsDeterministic:
+    def test_repeated_runs_on_the_same_state_agree(self):
+        verdicts = set()
+        for _ in range(3):
+            with TemporaryDirectory() as tmpdir:
+                root = Path(tmpdir)
+                _project(root, claim_id=True)
+                code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+                verdicts.add((code, report["status"], report["error_count"]))
+
+        assert len(verdicts) == 1

--- a/tests/test_enforcement_empty_codebase.py
+++ b/tests/test_enforcement_empty_codebase.py
@@ -34,6 +34,7 @@ from _test_helpers import run_cli_in_project, write_constraints_toml
 CLAIMED_ID = "cpt-test-flow-login"
 # `algo` is not configured to_code, so this ID declares work without claiming code.
 UNCLAIMED_ID = "cpt-test-algo-bucket"
+INSTRUCTIONS = ("bucket-put", "bucket-get")
 
 
 def _project(
@@ -42,16 +43,18 @@ def _project(
     claim_id: bool,
     code: dict[str, str] | None = None,
     codebase_path: str | None = "src",
-    declare_instructions: bool = False,
+    instructions_under: str | None = None,
 ) -> None:
     """Build a project with a FULL artifact and a registered codebase entry.
 
     ``claim_id`` controls whether the artifact checks a ``to_code = true`` ID --
     that is, whether anything is being claimed. ``code`` maps relative paths to
     file contents; omitting it leaves the registered tree empty, which is the
-    state under test. ``declare_instructions`` adds checked CDSL steps under an
-    ID that is *not* ``to_code``, which is what an over-broad fix would turn
-    into a wall of missing-instruction errors.
+    state under test. ``instructions_under`` attaches two checked CDSL steps to
+    the given ID: under ``UNCLAIMED_ID`` they are declared work with no code
+    claim, which an over-broad fix would turn into a wall of missing-instruction
+    errors; under ``CLAIMED_ID`` they are instructions of a claim that must
+    resolve to code blocks.
     """
     from studio.utils import toml_utils
 
@@ -73,12 +76,19 @@ def _project(
     art_dir.mkdir(parents=True)
     checkbox = "x" if claim_id else " "
     content = f"- [{checkbox}] **ID**: `{CLAIMED_ID}`\n"
-    if declare_instructions:
+    if instructions_under == CLAIMED_ID:
+        # Steps bind to the most recent ID above them, so they attach to the claim.
+        content += (
+            "\n**Steps**:\n"
+            f"- [x] - `p1` - Put the thing in the bucket - `inst-{INSTRUCTIONS[0]}`\n"
+            f"- [x] - `p1` - Read the thing back out - `inst-{INSTRUCTIONS[1]}`\n"
+        )
+    elif instructions_under == UNCLAIMED_ID:
         content += (
             f"\n- [x] **ID**: `{UNCLAIMED_ID}`\n"
             "\n**Steps**:\n"
-            "- [x] - `p1` - Put the thing in the bucket - `inst-bucket-put`\n"
-            "- [x] - `p1` - Read the thing back out - `inst-bucket-get`\n"
+            f"- [x] - `p1` - Put the thing in the bucket - `inst-{INSTRUCTIONS[0]}`\n"
+            f"- [x] - `p1` - Read the thing back out - `inst-{INSTRUCTIONS[1]}`\n"
         )
     (art_dir / "PRD.md").write_text(content, encoding="utf-8")
 
@@ -159,6 +169,31 @@ class TestAClaimWithNoCodeIsNotClean:
         assert len(unmet) == 1
         assert unmet[0].get("id") == CLAIMED_ID
 
+    def test_every_instruction_of_the_claim_is_also_reported_missing(self):
+        """A claim's instructions must resolve too, not just its ID.
+
+        Both checks are needed to describe the state honestly: `code-no-marker`
+        says the ID has no marker anywhere, and one `code-inst-missing` per
+        declared step says which pieces of the claim have no code block. A fix
+        that reached only the first would report an unbacked claim without
+        saying how much of it was unbacked.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=True, instructions_under=CLAIMED_ID)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 2
+        codes = _codes(report, "errors")
+        assert codes.count("code-no-marker") == 1
+        assert codes.count("code-inst-missing") == len(INSTRUCTIONS)
+        missing = {
+            str(issue.get("inst")) for issue in report["errors"]
+            if issue.get("code") == "code-inst-missing"
+        }
+        assert missing == set(INSTRUCTIONS)
+
     def test_the_scan_size_does_not_change_the_verdict(self):
         """0 files and 1 unmarked file are the same claim, so the same verdict.
 
@@ -204,6 +239,24 @@ class TestAnEmptyRegisteredTreeSaysSo:
         ]
         assert len(empty) == 1
         assert "does/not/exist" in str(empty[0].get("message"))
+
+    def test_a_raw_dict_entry_is_named_the_same_way(self):
+        """Entries reach this code as records or as raw dicts; both must be named.
+
+        `_resolve_code_scan_targets` reads either shape, so a warning built with
+        attribute access only would report `<unset>` for exactly the entry a
+        user needs to find.
+        """
+        from studio.commands.validate import _build_empty_codebase_entry_warnings
+        from studio.commands import validate as validate_mod
+
+        assert validate_mod._codebase_entry_path({"path": "does/not/exist"}) == "does/not/exist"
+
+        warnings = _build_empty_codebase_entry_warnings(["does/not/exist"])
+
+        assert len(warnings) == 1
+        assert "does/not/exist" in str(warnings[0]["message"])
+        assert warnings[0]["code"] == "codebase-entry-empty"
 
     def test_a_populated_entry_produces_no_such_warning(self):
         with TemporaryDirectory() as tmpdir:
@@ -258,7 +311,7 @@ class TestNothingClaimedIsNothingOwed:
         """
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            _project(root, claim_id=False, codebase_path=None, declare_instructions=True)
+            _project(root, claim_id=False, codebase_path=None, instructions_under=UNCLAIMED_ID)
 
             code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
 

--- a/tests/test_enforcement_empty_codebase.py
+++ b/tests/test_enforcement_empty_codebase.py
@@ -126,6 +126,91 @@ def _project(
     )
 
 
+def _run_human(root: Path, args: list[str]) -> tuple[int, str, str]:
+    """Run the CLI in *root* with JSON mode off, returning (exit, stdout, stderr)."""
+    import io
+    import os
+    from contextlib import redirect_stderr, redirect_stdout
+
+    from studio.cli import main
+    from studio.utils.ui import is_json_mode, set_json_mode
+
+    cwd = os.getcwd()
+    saved = is_json_mode()
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        set_json_mode(False)
+        os.chdir(str(root))
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(args)
+        return code, out.getvalue(), err.getvalue()
+    finally:
+        set_json_mode(saved)
+        os.chdir(cwd)
+
+
+def _nested_project(root: Path, *, marker_in_child: bool) -> None:
+    """Parent owns the FULL artifact and the claim; a child owns the codebase.
+
+    A supported layout: the claim is declared once at the top and the code that
+    backs it lives in a subsystem with no artifact of its own.
+    """
+    from studio.utils import toml_utils
+
+    (root / "kits" / "sdlc").mkdir(parents=True)
+    write_constraints_toml(
+        root / "kits" / "sdlc",
+        {"PRD": {"identifiers": {"flow": {"to_code": True}}}},
+    )
+    (root / "architecture").mkdir(parents=True)
+    (root / "architecture" / "PRD.md").write_text(
+        f"- [x] **ID**: `{CLAIMED_ID}`\n", encoding="utf-8"
+    )
+    child_src = root / "src" / "child"
+    child_src.mkdir(parents=True)
+    body = (
+        f"# @cpt-flow:{CLAIMED_ID}:p1\ndef f():\n    return 1\n"
+        if marker_in_child
+        else "def f():\n    return 1\n"
+    )
+    (child_src / "impl.py").write_text(body, encoding="utf-8")
+
+    (root / ".git").mkdir(exist_ok=True)
+    (root / "AGENTS.md").write_text(
+        '<!-- @cf:root-agents -->\n```toml\ncf-studio-path = "adapter"\n```\n',
+        encoding="utf-8",
+    )
+    config = root / "adapter" / "config"
+    config.mkdir(parents=True, exist_ok=True)
+    (config / "AGENTS.md").write_text("# Test adapter\n", encoding="utf-8")
+    toml_utils.dump(
+        {
+            "version": "1.0",
+            "project_root": "..",
+            "kits": {"cypilot": {"format": "CFS", "path": "kits/sdlc"}},
+            "systems": [
+                {
+                    "name": "Parent",
+                    "slug": "test",
+                    "kit": "cypilot",
+                    "artifacts": [
+                        {"path": "architecture/PRD.md", "kind": "PRD", "traceability": "FULL"}
+                    ],
+                    "children": [
+                        {
+                            "name": "Child",
+                            "slug": "child",
+                            "kit": "cypilot",
+                            "codebase": [{"path": "src/child", "extensions": [".py"]}],
+                        }
+                    ],
+                }
+            ],
+        },
+        config / "artifacts.toml",
+    )
+
+
 def _codes(report: dict, bucket: str) -> list[str]:
     """Issue codes from a report bucket. Requires ``--verbose`` to be populated."""
     assert bucket in report, f"report has no `{bucket}` array — pass --verbose"
@@ -240,6 +325,64 @@ class TestAnEmptyRegisteredTreeSaysSo:
         assert len(empty) == 1
         assert "does/not/exist" in str(empty[0].get("message"))
 
+    def test_a_passing_run_names_the_entry_without_verbose(self):
+        """The default report must say what it did not check.
+
+        A non-verbose report omits warning bodies and prints only a count, so
+        the warning alone left a green run silent about the entry it skipped --
+        which is the whole point of reporting it. The entry is therefore named
+        in the report itself, not only in the warning list.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=False, codebase_path="does/not/exist")
+
+            code, report = run_cli_in_project(root, ["--json", "validate"])
+
+        assert code == 0
+        assert report["status"] == "PASS"
+        assert report["unscanned_codebase_entries"] == ["does/not/exist"]
+
+    def test_the_human_surface_names_it_too(self):
+        """Same requirement on the surface a developer sees by default."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _project(root, claim_id=False, codebase_path="does/not/exist")
+
+            code, out, _ = _run_human(root, ["validate"])
+
+        assert code == 0
+        assert "does/not/exist" in out
+        assert "resolved to 0 files" in out
+
+    def test_a_workspace_entry_names_its_source(self):
+        """Two entries can share a path; only the source tells them apart.
+
+        It also tells the reader which thing to fix -- an unreachable source is
+        a different problem from a wrong path.
+        """
+        from studio.commands.validate import _build_empty_codebase_entry_warnings
+
+        warnings = _build_empty_codebase_entry_warnings(
+            [{"path": "src", "source": "ghost"}]
+        )
+
+        assert len(warnings) == 1
+        message = str(warnings[0]["message"])
+        assert "ghost:src" in message
+        assert "workspace source `ghost` did not resolve" in message
+        assert warnings[0]["source"] == "ghost"
+
+    def test_a_local_entry_says_what_to_check_instead(self):
+        from studio.commands.validate import _build_empty_codebase_entry_warnings
+
+        warnings = _build_empty_codebase_entry_warnings([{"path": "src", "source": ""}])
+
+        message = str(warnings[0]["message"])
+        assert "`src`" in message
+        assert "workspace source" not in message
+        assert "configured extensions" in message
+
     def test_a_raw_dict_entry_is_named_the_same_way(self):
         """Entries reach this code as records or as raw dicts; both must be named.
 
@@ -252,7 +395,9 @@ class TestAnEmptyRegisteredTreeSaysSo:
 
         assert validate_mod._codebase_entry_path({"path": "does/not/exist"}) == "does/not/exist"
 
-        warnings = _build_empty_codebase_entry_warnings(["does/not/exist"])
+        warnings = _build_empty_codebase_entry_warnings(
+            [{"path": "does/not/exist", "source": ""}]
+        )
 
         assert len(warnings) == 1
         assert "does/not/exist" in str(warnings[0]["message"])
@@ -346,6 +491,57 @@ class TestNothingClaimedIsNothingOwed:
         assert code == 0
         assert report["status"] == "PASS"
         assert "code-no-marker" not in _codes(report, "errors")
+
+
+class TestANestedClaimIsBackedByItsChildsCode:
+    """FULL traceability is inherited, so a child's markers still count.
+
+    Without inheritance a child system with no artifact of its own was scanned
+    as DOCS-ONLY, so its files never entered the FULL set. Reaching the checks
+    at zero FULL files then turned a correctly marked implementation into a
+    missing-marker error -- a false positive on a supported layout, and the one
+    case the flat registry of this repository cannot exhibit.
+    """
+
+    def test_a_marker_in_a_child_system_satisfies_the_parents_claim(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _nested_project(root, marker_in_child=True)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 0, report.get("errors")
+        assert report["status"] == "PASS"
+        assert "code-no-marker" not in _codes(report, "errors")
+
+    def test_an_unmarked_child_system_still_fails_the_parents_claim(self):
+        """The inheritance must not become a way to escape the check."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _nested_project(root, marker_in_child=False)
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert code == 2
+        assert "code-no-marker" in _codes(report, "errors")
+
+    def test_an_empty_child_entry_is_reported_under_the_parents_claim(self):
+        """An empty descendant registration is visible for the same reason."""
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _nested_project(root, marker_in_child=True)
+            # Point the child's entry at nothing, leaving the parent's claim in place.
+            config = root / "adapter" / "config" / "artifacts.toml"
+            config.write_text(
+                config.read_text(encoding="utf-8").replace("src/child", "src/gone"),
+                encoding="utf-8",
+            )
+
+            code, report = run_cli_in_project(root, ["--json", "validate", "--verbose"])
+
+        assert report["unscanned_codebase_entries"] == ["src/gone"]
+        assert code == 2  # the claim is now unbacked
+        assert "code-no-marker" in _codes(report, "errors")
 
 
 class TestTheVerdictIsDeterministic:


### PR DESCRIPTION
**What.** Makes `cfs validate`'s existing code-traceability checks reachable when a scan resolves to no files, and reports a registered codebase entry that matches nothing. Touches `commands/validate.py`, one new error code, one CDSL instruction, and a new test file.

**Why.** A FEATURE with a checked `to_code = "true"` ID, no `@cpt` markers and no code at all validates clean today:

```json
{"status":"PASS","error_count":0,"warning_count":0,
 "code_files_scanned":0,"to_code_ids_total":1,"code_ids_found":0}
```

`to_code_ids_total: 1` and `code_ids_found: 0` sit in the same object and produce neither an error nor a warning. Adding a single *unmarked* `.py` file to the identical repository produces the correct errors, which is the evidence that nothing is wrong with the checks — cross-validation returned early whenever no code file had been parsed:

```python
if not strict_code_validation or not results.parsed_code_files_full:
    return
```

A registered codebase entry that matches nothing parses no files, so the whole check ran and reported success without having assessed anything.

**How.** The guard now keys on whether a claim exists rather than on how much was scanned. A checked `to_code = "true"` ID is a claim; its marker has to resolve regardless of scan size. `results.to_code_ids` is already populated before this point, so it is exactly the "is anything being claimed?" signal:

```python
if not results.parsed_code_files_full and not results.to_code_ids:
    return
```

**Deleting the file-count check outright would be shorter and wrong.** Cross-validation would then run for repositories that claim nothing, turning every declared CDSL instruction into `code-inst-missing` and failing a spec-first project that has written its design and not yet built it. That case is covered by a test built specifically to expose it (`test_declared_instructions_without_a_code_claim_are_not_errors`) — without it, the over-broad version passes the whole suite.

A registered FULL entry resolving to no files is reported separately as a **warning**, `codebase-entry-empty`, because the subject is the registration rather than any claim — usually a stale or misspelled path. Nothing is owed unless something was claimed, so it does not fail the run. Reporting the two independently is what stops a green exit from meaning two different things:

```
codebase entry `src/api` is registered with FULL traceability but resolved to 0 files
— nothing from it was checked
```

**No new gates and no new vocabulary.** `code-no-marker` and `code-inst-missing` already say the right thing and are unchanged; this makes them reachable. The one new code is in a previously unused `codebase-*` namespace.

**Correction to an earlier version of this description.** It claimed a measured false-positive floor of zero on the strength of this repository's own artifacts being unchanged. That measurement was real but not sufficient: the registry here is flat (both systems declare `children = []`), so it could not exercise nested layouts, and review found a genuine false positive there. It is fixed and covered — see the nested case below. On this repository the numbers are indeed unchanged:

| | Artifacts | Code files | Coverage | Errors | Warnings |
|---|---|---|---|---|---|
| before | 49 | 91 | 219/219 | 0 | 192 |
| after | 49 | 91 | 219/219 | 0 | 192 |

**Nested systems inherit FULL traceability.** A parent that owns the FULL artifact makes the claim, but the code backing it often lives in a child system with no artifact of its own. Traceability was derived per node, so that child was scanned as DOCS-ONLY and never entered the FULL set — and reaching the code checks at zero FULL files then reported a correctly marked implementation as unmarked. Measured on a nested fixture whose child code carries the right marker:

| Child code has the correct marker | `main` | this branch, before the fix | after |
|---|---|---|---|
| verdict | exit 0 | **exit 2 `code-no-marker`** | exit 0 |

An unmarked child still fails, so the inheritance does not become a way to escape the check.

**A passing run names what it did not check.** A non-verbose report omits warning bodies and prints only a count, which left a green run silent about the entry it skipped. The entries are now named in the report itself — `unscanned_codebase_entries` in JSON, and a line on the human surface — since that is the point of reporting them. Workspace entries are qualified by source, so two entries sharing a path stay distinguishable and the reader knows whether to fix the source or the path.

**Tests.** New file `tests/test_enforcement_empty_codebase.py` — 11 tests driving the real CLI through `run_cli_in_project`, covering known-bad going red, known-good staying green, the scan-size invariant (0 files and 1 unmarked file are the same claim, so the same verdict), determinism across repeated runs, and the over-breadth case above.

Each half of the change was mutation-tested, so the corpus is not vacuous:

| Production change reverted | Result |
|---|---|
| Restore the original 0-file bypass | **5 tests fail** |
| Remove the claim check (over-broad) | **over-breadth test fails** |
| Suppress the empty-entry warning | **2 tests fail** |
| Stop inheriting FULL into children | **2 nested tests fail** |
| Drop the report field | **3 non-verbose tests fail** |
| Drop the source qualification | **workspace test fails** |

**Gates**, all on Python 3.11 against the rebased state: full suite **4,573 passed, 4 skipped, 15 xfailed, 58 subtests**; `validate` 0 errors, 219/219; `spec-coverage --system studio --min-coverage 90 --min-file-coverage 60 --min-granularity 0.46` all thresholds met; `pylint` clean; `vulture` clean; `validate-toc` correct. The new engine function is `@cpt`-traced with a declared instruction (`inst-warn-empty-codebase-entry`), and the validate flow's Error Scenarios now state the three empty-scope outcomes. No new dependencies.

**Relationship to other work.** Companion to #89. Independent of #93 — different file, no overlap, either can land first — but the two answer the same question on the two commands, so #93 is useful context: it separates "did anything fail?" from "was there anything to assess?" in `spec-coverage`, and this applies the same separation to `validate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now detects registered FULL-traceability codebase entries that resolve to no files.
  * Checked code claims are validated even when no code files are found.
  * Added clear warnings and reporting for empty codebase registrations and missing code markers.
  * FULL traceability now carries through to descendant systems.

* **Documentation**
  * Added validation scenarios for empty entries, missing markers, and runs without checked code claims.

* **Tests**
  * Expanded coverage across JSON, human-readable, and workspace validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
