### PR TITLE
spec-coverage: --min-file-granularity cannot be enabled, and whole-file scope claims are invisible

### DIFF
--- a/architecture/features/spec-coverage.md
+++ b/architecture/features/spec-coverage.md
@@ -65,7 +65,7 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 - User runs `cfs spec-coverage` → all registered codebase files scanned, coverage report generated with per-file and summary statistics
 - User runs `cfs spec-coverage --min-coverage 80` → same as above, exit code 2 if coverage below threshold
 - User runs `cfs spec-coverage --min-granularity 0.7` → same as above, exit code 2 if granularity below threshold
-- User runs `cfs spec-coverage --min-file-granularity 0.3` → same as above, exit code 2 if any covered file granularity below threshold
+- User runs `cfs spec-coverage --min-file-granularity 0.3` → same as above, exit code 2 if any **block-traced** file's granularity is below threshold. A file whose coverage rests on a whole-file scope marker scores 0.0 by definition rather than by measurement, so it is reported under its own heading instead of judged against this floor — judging it would make any positive floor reject every re-export module and entry point, which is what made this threshold unusable as a gate
 
 **Error Scenarios**:
 - No codebase entries registered → report with `applicable: false` and a hint to configure artifacts.toml; exit code 2 only if a positive threshold was demanded
@@ -96,6 +96,7 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 - [x] - `p1` - Resolve paths relative to project root for human-readable output - `inst-rel-path`
 - [x] - `p1` - Route JSON report to file or terminal UI - `inst-output-report`
 - [x] - `p1` - Format uncovered ranges and render human-friendly per-file/status sections - `inst-human-report-helpers`
+- [x] - `p1` - Name the files whose coverage rests on a whole-file scope marker, largest first, with their count and total claimed lines - `inst-human-report-claims`
 
 ## 3. Processes / Business Logic (CDSL)
 
@@ -248,7 +249,8 @@ The system **MUST** output a JSON report with: summary (total files, covered fil
 - [x] Granularity metric correctly penalizes files with few instructions relative to their size
 - [x] `--min-coverage N` flag causes exit code 2 when coverage is below threshold
 - [x] `--min-granularity N` flag causes exit code 2 when granularity is below threshold
-- [x] `--min-file-granularity N` flag causes exit code 2 when any covered file's granularity is below threshold
+- [x] `--min-file-granularity N` flag causes exit code 2 when any block-traced file's granularity is below threshold; files whose coverage rests on a whole-file scope marker are outside this floor and are listed under "Whole-file scope claims" instead
+- [x] Whole-file scope claims are reported with their count, total claimed lines, and paths ordered largest first, so an untraced claim is visible rather than averaged away
 - [x] `--min-file-coverage N` flag causes exit code 2 when any file's coverage is below threshold
 - [x] `--verbose` flag includes per-file marker details in report
 - [x] Report format mirrors `coverage.py` JSON structure (summary + per-file)

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -335,6 +335,14 @@ def _check_min_file_granularity(
     for file_coverage in report.per_file:
         if not file_coverage.effective_lines or not file_coverage.covered_lines:
             continue
+        # A scope-only file scores 0.0 by definition rather than by measurement:
+        # the metric deliberately refuses to credit a whole-file claim. Reading
+        # that sentinel as a low score makes any positive floor reject every
+        # re-export module and entry point in the tree, which is why this
+        # threshold is currently unusable as a gate. Those files are reported
+        # under their own heading instead, so exempting them here hides nothing.
+        if file_coverage.has_scope_only:
+            continue
         if file_coverage.granularity >= args.min_file_granularity:
             continue
         failed = True
@@ -489,7 +497,33 @@ def _show_spec_coverage_files(files: dict) -> None:
         ui.step(f"Uncovered files ({len(uncovered)})")
         for path, entry in uncovered.items():
             ui.substep(f"  {path}  ({entry.get('total_lines', 0)} lines)")
+    _show_whole_file_claims(files)
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-human-report-helpers
+
+
+def _show_whole_file_claims(files: dict) -> None:
+    """Name the files whose coverage rests on a whole-file scope marker.
+
+    These are counted as covered but carry no instruction block, so they raise
+    the coverage percentage without being traced to anything. Some are
+    structurally unmarkable -- an entry point, a re-export module -- and some are
+    implementations that were never traced, and the two are indistinguishable
+    from the summary line alone. Listing them by size puts the largest claims in
+    front of the reader instead of leaving them inside an average.
+    """
+    # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-human-report-claims
+    claims = {
+        path: entry for path, entry in files.items()
+        if entry.get("scope_only") and entry.get("covered_lines", 0)
+    }
+    if not claims:
+        return
+    lines_claimed = sum(entry.get("total_lines", 0) for entry in claims.values())
+    ui.blank()
+    ui.step(f"Whole-file scope claims ({len(claims)} files, {lines_claimed} lines, no instruction tracing)")
+    for path, entry in sorted(claims.items(), key=lambda kv: -kv[1].get("total_lines", 0)):
+        ui.substep(f"  {path}  ({entry.get('total_lines', 0)} lines)")
+    # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-human-report-claims
 
 
 def _show_spec_coverage_status(status: str, failures: list, assessed: bool = True) -> None:

--- a/skills/studio/scripts/studio/utils/coverage.py
+++ b/skills/studio/scripts/studio/utils/coverage.py
@@ -245,6 +245,18 @@ def _scan_scope_markers(lines: List[str]) -> List[int]:
 
 
 # @cpt-begin:cpt-studio-algo-spec-coverage-scan:p1:inst-scan-block-markers
+def _has_block_marker(lines: List[str]) -> bool:
+    """Whether any block marker appears, matched or not.
+
+    Separates "no block tracing here" from "block tracing that did not close",
+    which closed-pair counting cannot tell apart.
+    """
+    return any(
+        _BLOCK_BEGIN_RE.search(line) or _BLOCK_END_RE.search(line)
+        for line in lines
+    )
+
+
 def _scan_block_ranges(lines: List[str]) -> List[Tuple[int, int]]:
     """Scan closed block-marker ranges in a file."""
     return _collect_block_ranges(lines)
@@ -357,7 +369,13 @@ def scan_file_coverage(path: Path) -> Optional[FileCoverage]:
 
     scope_count = len(scope_markers)
     block_count = len(block_ranges)
-    has_scope_only = scope_count > 0 and not block_count
+    # "Scope-only" means no block tracing was attempted, not that none of it
+    # closed. Deriving it from closed pairs alone made a file with a scope
+    # marker and an unmatched @cpt-begin indistinguishable from a deliberate
+    # whole-file claim -- so broken tracing inherited whatever treatment the
+    # deliberate case gets. Granularity stays 0.0 for both, since no pair
+    # closed; only the classification differs.
+    has_scope_only = scope_count > 0 and not block_count and not _has_block_marker(lines)
     # @cpt-end:cpt-studio-algo-spec-coverage-scan:p1:inst-scan-init
 
     # @cpt-begin:cpt-studio-algo-spec-coverage-scan:p1:inst-scan-calc-ranges

--- a/tests/test_spec_coverage.py
+++ b/tests/test_spec_coverage.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import unittest
+from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -52,6 +53,28 @@ class TestCmdSpecCoverage(unittest.TestCase):
         ctx.meta = meta
         ctx.project_root = project_root
         return ctx
+
+    def _run_over_src(self, sources: dict, args: list) -> tuple:
+        """Write *sources* into `src/`, register it, run spec-coverage with *args*.
+
+        Returns (exit_code, parsed_json). Shared so a threshold case is one
+        fixture and one assertion rather than a repeated scaffold.
+        """
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            src = root / "src"
+            src.mkdir()
+            for name, body in sources.items():
+                (src / name).write_text(body, encoding="utf-8")
+            ctx = self._make_context(root, systems=[
+                SystemNode(name="sys1", slug="sys1", kit="test",
+                           artifacts=[], children=[],
+                           codebase=[CodebaseEntry(path="src", extensions=[".py"])]),
+            ])
+            with patch("studio.utils.context.get_context", return_value=ctx):
+                with patch("sys.stdout", new_callable=StringIO) as mock_out:
+                    ret = cmd_spec_coverage(args)
+            return ret, json.loads(mock_out.getvalue())
 
     def test_no_context(self):
         with patch("studio.utils.context.get_context", return_value=None):
@@ -478,6 +501,67 @@ class TestFormatRanges(unittest.TestCase):
         self.assertEqual(_format_ranges([]), "")
 
 
+class TestWholeFileClaimsAreReported(unittest.TestCase):
+    """The exemption is only defensible because the exempted files are named.
+
+    Without this, deleting the claims section would leave every other test
+    passing and the visibility this change advertises would regress silently.
+    """
+
+    def _render(self, files: dict) -> str:
+        from studio.commands.spec_coverage import _show_spec_coverage_files
+        from studio.utils.ui import is_json_mode, set_json_mode
+
+        saved = is_json_mode()
+        out = StringIO()
+        try:
+            set_json_mode(False)
+            with redirect_stdout(out):
+                _show_spec_coverage_files(files)
+        finally:
+            set_json_mode(saved)
+        return out.getvalue()
+
+    def test_claims_are_named_with_counts_and_largest_first(self):
+        output = self._render({
+            "pkg/small.py": {
+                "total_lines": 10, "covered_lines": 10, "coverage_pct": 100.0,
+                "granularity": 0.0, "scope_only": True,
+            },
+            "pkg/huge.py": {
+                "total_lines": 1154, "covered_lines": 1154, "coverage_pct": 100.0,
+                "granularity": 0.0, "scope_only": True,
+            },
+            "pkg/traced.py": {
+                "total_lines": 40, "covered_lines": 40, "coverage_pct": 100.0,
+                "granularity": 0.9, "scope_only": False,
+            },
+        })
+
+        assert "Whole-file scope claims" in output
+        assert "2 files" in output, "the count is part of the claim"
+        assert "1164 lines" in output, "claimed lines must be aggregated"
+        # Scoped to the claims section: both files also appear under "Covered
+        # files" above, so asserting order across the whole output passes
+        # whichever way the section is sorted.
+        claims = output.split("Whole-file scope claims")[1]
+        assert "pkg/huge.py" in claims and "pkg/small.py" in claims
+        assert "pkg/traced.py" not in claims, "a block-traced file is not a whole-file claim"
+        assert claims.index("pkg/huge.py") < claims.index("pkg/small.py"), (
+            "largest first, so the biggest untraced claim is read first"
+        )
+
+    def test_no_claims_section_when_there_are_none(self):
+        output = self._render({
+            "pkg/traced.py": {
+                "total_lines": 40, "covered_lines": 40, "coverage_pct": 100.0,
+                "granularity": 0.9, "scope_only": False,
+            },
+        })
+
+        assert "Whole-file scope claims" not in output
+
+
 class TestMinFileGranularity(TestCmdSpecCoverage):
     """Cover min_file_granularity threshold logic."""
 
@@ -500,6 +584,72 @@ class TestMinFileGranularity(TestCmdSpecCoverage):
             parsed = json.loads(mock_out.getvalue())
             if parsed["status"] == "FAIL":
                 self.assertTrue(any("granularity" in f for f in parsed.get("threshold_failures", [])))
+
+    def test_scope_only_file_is_exempt_from_the_per_file_floor(self):
+        """A whole-file scope claim scores 0.0 by definition, not by measurement.
+
+        Reading that sentinel as a low score makes any positive floor reject
+        every re-export module and entry point, which is what made this
+        threshold unusable as a gate.
+        """
+        ret, parsed = self._run_over_src(
+            {"reexport.py": "# @cpt-scope:cpt-my-algo:p1\nfrom .a import b\n"},
+            ["--min-file-granularity", "0.5"],
+        )
+
+        self.assertEqual(ret, 0, f"exit code must agree with status: {parsed}")
+        self.assertEqual(parsed["status"], "PASS")
+        self.assertEqual(parsed.get("threshold_failures", []), [])
+
+    def test_the_exemption_holds_with_per_file_coverage_also_requested(self):
+        """The narrowed floor must not be an accident of running one flag alone."""
+        ret, parsed = self._run_over_src(
+            {"reexport.py": "# @cpt-scope:cpt-my-algo:p1\nfrom .a import b\n"},
+            ["--min-file-granularity", "0.5", "--min-file-coverage", "50"],
+        )
+
+        self.assertEqual(ret, 0, f"exit code must agree with status: {parsed}")
+        self.assertEqual(parsed["status"], "PASS")
+
+    def test_a_scope_marker_with_malformed_block_tracing_is_not_exempt(self):
+        """Broken tracing must not inherit the deliberate claim's treatment.
+
+        An unmatched `@cpt-begin` closes no pair, so counting pairs alone made
+        this file look like a whole-file claim and handed it the exemption.
+        """
+        ret, parsed = self._run_over_src(
+            {"broken.py": (
+                "# @cpt-scope:cpt-my-algo:p1\n"
+                "# @cpt-begin:cpt-my-algo:p1:inst-unclosed\n"
+                "x = 1\n"
+            )},
+            ["--min-file-granularity", "0.5"],
+        )
+
+        self.assertFalse(
+            parsed["files"]["src/broken.py"].get("scope_only", False),
+            "malformed tracing is not a whole-file claim",
+        )
+        self.assertEqual(ret, 2, f"it must be judged against the floor: {parsed}")
+        self.assertTrue([f for f in parsed.get("threshold_failures", []) if "broken.py" in f])
+
+    def test_a_block_traced_file_is_still_judged(self):
+        """The exemption must not become a way past the floor for traced files."""
+        body = "\n".join(f"x{n} = {n}" for n in range(60))
+        ret, parsed = self._run_over_src(
+            {"thin.py": (
+                "# @cpt-begin:cpt-my-algo:p1:inst-one\n"
+                f"{body}\n"
+                "# @cpt-end:cpt-my-algo:p1:inst-one\n"
+            )},
+            ["--min-file-granularity", "0.9"],
+        )
+
+        self.assertTrue(
+            [f for f in parsed.get("threshold_failures", []) if "thin.py" in f],
+            f"a block-traced file below the floor must still fail: {parsed}",
+        )
+        self.assertEqual(ret, 2)
 
     def test_min_file_coverage_with_zero_total(self):
         """File with 0 total_lines is skipped in per-file coverage check."""


### PR DESCRIPTION
Related to #76.

**What.** Makes `--min-file-granularity` usable as a gate, and names the files whose coverage rests on a whole-file scope marker. No threshold changes, no metric changes.

**Why.** A file carrying only a scope marker scores granularity **0.0 by definition rather than by measurement** — the metric deliberately refuses to credit a whole-file claim (`utils/coverage.py`: *"Files with only scope markers get granularity 0"*). `_check_min_file_granularity` read that sentinel as a low score, so any positive floor rejected every re-export module and entry point in the tree. The flag is registered, documented in `specs/cli.md`, declared in `features/spec-coverage.md` and covered by tests — and could not be turned on.

Measured here: **10 of 86 files** score 0.0 that way. `--min-file-granularity 0.05` failed all ten before this change; it passes after. A block-traced file below the floor still fails either way — `utils/artifacts_meta.py` at 0.0843 is rejected at 0.10.

**Why the exemption is paired with reporting.** Skipping those files silently would hide the part worth seeing. They are counted as covered and carry no instruction block, so they raise the coverage percentage without being traced to anything, and the summary line cannot tell an entry point from an untraced implementation:

```
  ▸ Whole-file scope claims (10 files, 1612 lines, no instruction tracing)
      skills/studio/scripts/studio/ralphex_export.py  (1154 lines)
      src/studio_proxy/telemetry.py  (165 lines)
      skills/studio/scripts/studio/utils/__init__.py  (127 lines)
      src/studio_proxy/mirrors.py  (113 lines)
      ...
```

The largest is **1,154 lines reported as fully covered with no instruction tracing**, which is the shape this metric exists to discourage. Whether that is worth acting on is the reader's call; the point is that it was not visible.

**Why a per-file floor is worth having at all.** It is judged per file, so adding a well-traced module cannot lower another file's score. A system-wide floor behaves as a shared budget: at zero margin, whichever change rebases last fails regardless of its own tracing quality. See #76 for measurements of that effect.

**Deliberately not attempted.** Classifying which whole-file claims are structurally unmarkable and which are untraced implementations. **Size does not separate them** — the 127-line `utils/__init__.py` has zero functions and zero classes (a pure re-export, nothing to instrument), while the 113-line `mirrors.py` has fourteen. Definition-counting would separate them but needs a parser per language, and the scanner is language-agnostic by design. Naming the files lets a reader decide with the evidence in front of them; a rule that misclassifies on this repository's own data seemed worse than no rule.

**Non-goals.** No change to any threshold default, to the granularity formula, or to what counts as covered. Not excluding structural files from the coverage denominator — that is a separate question.

**Tests.** Two in `TestMinFileGranularity`: a scope-only file is exempt from the per-file floor, and a block-traced file below the floor still fails, so the exemption cannot become a way past the gate. Both mutation-checked — removing the exemption fails the first with `granularity 0.0000 < 0.5000` and leaves the second passing.

**Gates.** `make test` 4652 passed / 4 skipped / 15 xfailed / 58 subtests · `pylint` clean · `vulture-ci` clean · `cfs validate` **0 errors 0 warnings, 220/220** · `validate-toc` correct · per-file line coverage ≥90%.

**This repository's own verdict does not move.** Under the gate `make spec-coverage` runs — `--system studio --min-coverage 90 --min-file-coverage 60 --min-granularity 0.46` — the result is coverage 90.4%, granularity 0.4600, all thresholds met, identical to `main`. A change here that altered the existing verdict would be a behaviour change in disguise, so that is asserted rather than assumed.

No new dependencies; stdlib only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spec coverage reports now list files covered solely by whole-file scope markers, including claimed line counts.
  * These files are ordered by descending claimed line count and clearly identified as lacking instruction tracing.

* **Bug Fixes**
  * Whole-file scope files no longer incorrectly fail minimum per-file granularity checks.

* **Tests**
  * Added coverage for exempt whole-file scope files and low-granularity traced files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->