### PR TITLE
feat(spec-coverage): add an advisory semantic-coverage engine

### DIFF
--- a/architecture/features/eval-harness.md
+++ b/architecture/features/eval-harness.md
@@ -13,6 +13,7 @@
   - [Run Eval Suite](#run-eval-suite)
   - [Score Structural Compliance](#score-structural-compliance)
   - [Score Rule Compliance (Advisory Judge)](#score-rule-compliance-advisory-judge)
+  - [Assess Semantic Coverage](#assess-semantic-coverage)
 - [4. States (CDSL)](#4-states-cdsl)
   - [Eval Report Lifecycle](#eval-report-lifecycle)
 - [5. Definitions of Done](#5-definitions-of-done)
@@ -209,6 +210,40 @@ or unreadable gold file is *excluded* from calibration rather than counted as a 
 - [x] - `p1` - A deterministic reference-stub `JudgeFn` for tests and calibration wiring (not a model) - `inst-judge-stub`
 - [x] - `p1` - The `Calibration` result model (accuracy, consistency, coverage) - `inst-judge-calibrate`
 
+### Assess Semantic Coverage
+
+- [x] `p1` - **ID**: `cpt-studio-algo-eval-semantic`
+
+The semantic-coverage engine: it asks whether a marked block *implements the requirement it
+cites*, which marker density cannot. A deterministic stdlib token-overlap pre-filter scores
+every block against its requirement text and surfaces the weak links; only those go to a
+pluggable `SemanticJudgeFn` (the model call lives out-of-tree). It is advisory throughout —
+no verdict here touches an exit code — and honest: a block with no retrievable requirement, or
+too little text to compare, is reported `unjudgeable`, never a silent "covered". Files a human
+declared `excluded` in the coverage report are skipped; files flagged `whole_file_claims` are
+prioritised. Every model verdict carries an evidence check: a quote absent from the code is not
+trusted.
+
+**Steps**:
+1. [x] - `p1` - Tokenise code and requirement (camelCase + Unicode word-boundary split, stopwords dropped) and score their overlap against the requirement set, or `None` below the token floor - `inst-semantic-tokenize`
+2. [x] - `p1` - Rank every pairing weakest-first, marking below-threshold blocks as weak links and below-floor blocks as unjudgeable, and marking every block in a whole-file-claim file a weak link regardless of overlap (always judged) - `inst-semantic-prefilter`
+3. [x] - `p1` - Judge only the weak links through the injected `SemanticJudgeFn`, degrading a raising or malformed reply to unjudgeable and evidence-checking every quote - `inst-semantic-finding`
+4. [x] - `p1` - Assess pairings end-to-end — scope, rank, judge weak links, and report unjudgeable coverage gaps — advisory throughout - `inst-semantic-report`
+
+**Supporting**:
+- [x] - `p1` - Module imports, verdict constants, and the provisional calibration constants + stopword set - `inst-semantic-imports`
+- [x] - `p1` - The pairing, ranked (with a whole-file-claim `forced` flag), request, reply data model and the `SemanticJudgeFn` seam — the seam is called synchronously and unbounded, so a judge that can hang must enforce its own timeout - `inst-semantic-datamodel`
+- [x] - `p1` - Blank character spans in place (spaces, newlines preserved) so a verbatim quote of the untouched text still matches - `inst-semantic-blank`
+- [x] - `p1` - Derive two code views in one grammar-aware `tokenize` pass — an overlap view (comments and all strings blanked, so prose cannot inflate the score) and an evidence view (comments and docstrings blanked, inline strings kept) — falling back to a plain comment strip for a non-tokenisable fragment - `inst-semantic-strip`
+- [x] - `p1` - Read the frozen coverage-report contract (`excluded[]` / `whole_file_claims[]`, path-separator normalised, `excluded` taking precedence), degrading to an empty scope - `inst-semantic-scope`
+- [x] - `p1` - Build the deterministic judge prompt (bounded fields) and parse a reply to a verdict - `inst-semantic-prompt`
+- [x] - `p1` - The evidence-present hallucination guard: a quote must occur in the evidence view (comments/docstrings stripped), so a quote matching only a comment is not evidence - `inst-semantic-evidence`
+- [x] - `p1` - The `SemanticGap` coverage-gap record (block_id, path, start_line, reason), located like a finding so a report consumer can point at every gap - `inst-semantic-gap`
+- [x] - `p1` - The reference stub judge (deterministic overlap buckets) and its best-evidence-line quote - `inst-semantic-stub`
+- [x] - `p1` - The requirement resolver adapter over `get_content_scoped` - `inst-semantic-resolve`
+- [x] - `p1` - Read a `[gold]` verdict label for calibration, or `None` when absent/malformed - `inst-semantic-gold`
+- [x] - `p1` - Calibrate the judge over gold-backed pairings: report accuracy, consistency, and effective sample size per case, excluding unscoreable / crashed / strict-tie cases — accuracy over cases with a majority, consistency over cases with ≥2 surviving runs — `None` when nothing is measurable - `inst-semantic-calibrate`
+
 ## 4. States (CDSL)
 
 ### Eval Report Lifecycle
@@ -253,6 +288,7 @@ them (subscripting when the flag is absent raises `KeyError`):
 | Eval Harness | `skills/studio/scripts/studio/utils/eval_harness.py` | Scenario/run loading, scorer seam, runner, report, regression diff |
 | Structural Scorer | `skills/studio/scripts/studio/utils/eval_structural.py` | Deterministic structural checks over a run's manifest + phase frontmatter |
 | Advisory Judge | `skills/studio/scripts/studio/utils/eval_judge.py` | Advisory rule-compliance judge (pluggable model seam) + gold-set calibration |
+| Semantic Coverage | `skills/studio/scripts/studio/utils/eval_semantic.py` | Token-overlap pre-filter + advisory judge seam over marked-block vs requirement, with honesty + evidence guards |
 
 ## 7. Acceptance Criteria
 
@@ -267,3 +303,7 @@ them (subscripting when the flag is absent raises `KeyError`):
 - [x] `p1` - Judge calibration reports accuracy against a human gold set and run-to-run consistency, kept separate from structural compliance; judge coverage is derived from which scenarios carry a gold set
 - [x] `p1` - The run evidence is hard-capped: the total (headers, truncation markers, separators and the omission line included) never exceeds the evidence budget. A trimmed phase is still judged; when whole phases are omitted to fit, the request is marked incomplete and the judge returns `UNKNOWN` without a model call — a verdict is never certified from evidence with entire phases unseen
 - [x] `p1` - In default (non-JSON) mode the human summary prints the scorer coverage line, explains that advisory-only UNKNOWNs come from an unwired judge (never counted against the gate), and prints the calibration metrics under `--calibrate`; the JSON payload is unchanged
+- [x] `p1` - Semantic coverage ranks marked blocks by deterministic token-overlap against their requirement and judges only the surfaced weak links — a strong-overlap block triggers no model call, except a block in a `whole_file_claims` file, which is always judged regardless of overlap (its structural coverage rests on a whole-file scope marker, so a high lexical score there must not buy a free pass)
+- [x] `p1` - A block with no retrievable requirement, or with too little text to compare, is reported `unjudgeable`, never a silent `covered`; with no `SemanticJudgeFn` wired every weak link is `unjudgeable` and nothing gates
+- [x] `p1` - A model `evidence_quote` absent from the cited code sets `evidence_ok=false`; a raising or malformed judge reply degrades that one finding to `unjudgeable` without sinking the assessment
+- [x] `p1` - Files a human declared in the coverage report's `excluded[]` are skipped; a report lacking the `excluded[]` / `whole_file_claims[]` fields yields an empty scope (skip nothing, prioritise nothing), never an error

--- a/skills/studio/scripts/studio/utils/eval_semantic.py
+++ b/skills/studio/scripts/studio/utils/eval_semantic.py
@@ -1,0 +1,773 @@
+"""Semantic coverage — *does a marked block implement the requirement it cites?*
+
+Structural ``spec-coverage`` scores marker **density**: a file can read 100% covered while the
+code inside its markers does the wrong thing. This engine adds the layer density cannot reach —
+**code-vs-requirement correctness** — and it does so honestly:
+
+* **Rank first, judge last.** A deterministic, stdlib-only token-overlap pre-filter scores every
+  marked block against its requirement text and surfaces the **weak links** (low overlap). Only
+  those go to a model, so a large repo triggers **zero model calls per block**. The pre-filter is a
+  *budget heuristic*, not a correctness oracle: strong overlap → ``presumed_covered`` buys a block
+  out of a model call, it never proves the block correct. Lexical overlap is gameable, so
+  ``presumed_covered`` is not evidence of correctness — only a judged verdict is.
+* **Seam, not transport.** Like the rules-judge, the model call is a pluggable ``SemanticJudgeFn``
+  supplied out-of-tree; with none wired the weak links are ``UNJUDGEABLE`` (never a false verdict)
+  and nothing gates. This module contains no model client.
+* **Advisory, never gates.** A verdict here never touches an exit code (enforced at integration).
+* **Honest coverage.** Blocks with no retrievable requirement, or too little text to compare, are
+  reported ``UNJUDGEABLE`` — never a silent "covered". The report states what it could not judge.
+* **Scoped by the frozen coverage contract.** Files a human declared ``excluded`` are skipped;
+  files flagged ``whole_file_claims`` (scope-only) are prioritised — that is where a green
+  structural number most plausibly hides wrong code.
+
+@cpt-algo:cpt-studio-algo-eval-semantic:p1
+"""
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-imports
+from __future__ import annotations
+
+import io
+import logging
+import re
+import tokenize as _tokenize   # aliased: this module defines its own public ``tokenize`` word-splitter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Protocol, Sequence, Set, Tuple, runtime_checkable
+
+from .document import get_content_scoped
+from .manifest import load_toml_file
+
+logger = logging.getLogger(__name__)
+
+#: The three model verdicts, plus the honest "could not compare" outcome the engine owns.
+SEM_COVERED = "covered"
+SEM_PARTIAL = "partial"
+SEM_WRONG = "wrong"
+SEM_UNJUDGEABLE = "unjudgeable"
+_MODEL_VERDICTS = frozenset({SEM_COVERED, SEM_PARTIAL, SEM_WRONG})
+
+#: Schema version stamped on ``SemanticReport`` / ``SemanticCalibration`` so a coverage-report
+#: consumer can detect a shape change. Bump on any breaking field change.
+SEMANTIC_SCHEMA_VERSION = 1
+
+#: Provisional calibration constants — a comparison needs at least this many domain tokens on each
+#: side, and a block scoring below the threshold is a weak link. Named here (not buried in logic)
+#: so calibration on our own corpus can retune them. They are **not yet corpus-calibrated** — their
+#: empirical basis is future work (see the design note); these are conservative defaults.
+_MIN_TOKENS = 4
+_WEAK_LINK_THRESHOLD = 0.30
+#: Per-field cap on the requirement/code interpolated into the judge prompt, so a huge block or
+#: requirement can never produce an unbounded prompt. The structured request fields stay full (for
+#: the evidence guard and a host that builds its own prompt); only the prompt string is bounded.
+_PROMPT_FIELD_CAP = 2000
+
+#: Syntax words that are not evidence a requirement was implemented — dropped before overlap so a
+#: score reflects domain vocabulary, not boilerplate shared by every block.
+_STOPWORDS = frozenset({
+    "the", "a", "an", "and", "or", "not", "is", "are", "be", "to", "of", "in", "on", "for",
+    "with", "as", "if", "else", "elif", "return", "def", "class", "self", "import", "from",
+    "none", "true", "false", "pass", "raise", "try", "except", "this", "that", "it",
+})
+#: Split on Unicode non-word runs *and* underscore, so accented / non-Latin terms (Gebühr, Cyrillic)
+#: stay whole instead of fragmenting to empty — an ASCII-only class silently deflated the pre-filter
+#: on multilingual corpora and could report a real block UNJUDGEABLE. Transliteration mismatches
+#: (gebuehr vs Gebühr) remain inherent to lexical overlap.
+_TOKEN_SPLIT = re.compile(r"[\W_]+")
+_CAMEL_SPLIT = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-imports
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-datamodel
+@dataclass(frozen=True)
+class Pairing:
+    """One marked code block paired with the requirement text it cites. The engine's unit of work.
+
+    ``requirement`` is ``None`` when no scoped requirement could be retrieved for the block's id —
+    an honest "unjudgeable", never treated as an empty requirement the code trivially satisfies.
+    """
+
+    block_id: str
+    inst: str
+    path: str
+    start_line: int
+    code: str
+    requirement: Optional[str]
+
+
+@dataclass(frozen=True)
+class Ranked:
+    """A pairing scored by the deterministic pre-filter."""
+
+    pairing: Pairing
+    score: Optional[float]        # overlap in [0, 1]; None when unjudgeable (below the floor)
+    weak_link: bool               # scored and below the weak-link threshold → send to the judge
+    reason: str                   # why unjudgeable / why a weak link (human-readable)
+    forced: bool = False          # judged because it is a whole_file_claim, regardless of overlap
+
+
+@dataclass(frozen=True)
+class SemanticRequest:
+    """The deterministic input handed to a ``SemanticJudgeFn`` — pure, no model call."""
+
+    block_id: str
+    requirement: str
+    code: str
+    prompt: str
+
+
+@dataclass(frozen=True)
+class SemanticReply:
+    """A model's structured answer, parsed back by the engine."""
+
+    verdict: str                  # covered | partial | wrong
+    rationale: str = ""
+    evidence_quote: str = ""      # a substring of the code the verdict rests on (grep-verified)
+
+
+@runtime_checkable
+class SemanticJudgeFn(Protocol):  # pylint: disable=too-few-public-methods
+    """The seam the host/agent supplies: turn a ``SemanticRequest`` into a ``SemanticReply``.
+
+    Never implemented here with a real model — that lives out-of-tree. Tests and calibration use
+    a deterministic stub.
+
+    **Latency is the implementer's contract.** The engine calls this *synchronously* and does not
+    bound its runtime: a judge that blocks (e.g. an un-timed network call) blocks ``assess`` /
+    ``calibrate`` for exactly as long as it runs. An implementation that can hang MUST enforce its
+    own timeout and raise on expiry — a raise degrades that one finding to UNJUDGEABLE (never sinks
+    the run), whereas a hang has no in-engine recourse.
+    """
+
+    def __call__(self, request: SemanticRequest) -> SemanticReply:
+        """Return the model's verdict on ``request``."""  # pragma: no cover
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-datamodel
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-blank
+def _blank(code: str, spans: Sequence[Tuple[int, int]]) -> str:
+    """Replace each ``[start, end)`` character span with spaces, preserving newlines and every other
+    character's position — so a verbatim quote of the untouched text still matches as a substring."""
+    if not spans:
+        return code
+    chars = list(code)
+    for start, end in spans:
+        for i in range(start, min(end, len(chars))):
+            if chars[i] != "\n":
+                chars[i] = " "
+    return "".join(chars)
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-blank
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-strip
+#: Fallback-only: strip ``#`` comment tails when a block will not tokenize (a mid-file fragment).
+#: The grammar-aware ``tokenize`` pass below is the real lexer; Python's comments and string literals
+#: are mutually recursive (``#`` lives in strings, ``'''`` lives in comments), so no sequence of
+#: independent regexes can strip them correctly — only a single left-to-right scan can.
+_LINE_COMMENT = re.compile(r"#[^\n]*")
+#: Token types a string can follow to be a *statement-leading* (docstring-like) string rather than an
+#: inline value — a suite start (INDENT), a statement break (NEWLINE), or a block close (DEDENT, which
+#: ends an inner suite so the next token opens a fresh statement). Such prose is blanked from the
+#: evidence view; an inline string (after ``=``, ``(``, …) never follows one of these.
+_STATEMENT_START = frozenset({_tokenize.NEWLINE, _tokenize.INDENT, _tokenize.DEDENT})
+#: PEP 701 (Python 3.12+) tokenizes an f-string as FSTRING_START/MIDDLE/END around its interior
+#: expressions, not a single STRING token. FSTRING_MIDDLE carries the literal *text* (prose); the
+#: interior expressions are ordinary tokens (kept). ``None`` on < 3.12, where f-strings are STRING.
+_FSTRING_MIDDLE = getattr(_tokenize, "FSTRING_MIDDLE", None)
+
+
+def _code_views(code: str) -> Tuple[str, str, bool]:
+    """One ``tokenize`` pass → ``(overlap_view, evidence_view, lexed)``; comment/string spans blanked in place.
+
+    * ``overlap_view`` blanks comments **and every string literal**, so prose (a comment, docstring, or
+      string echoing the requirement) can never inflate the overlap score and mask wrong code.
+    * ``evidence_view`` blanks comments **and docstrings** but keeps inline string literals, so a quote
+      of a real string the code executes (an error message, SQL, a regex) is valid evidence while a
+      quote lifted only from a comment or docstring is not. A docstring is a statement-leading string.
+    * ``lexed`` is ``False`` when the block did not tokenize (an indentation-broken or unterminated
+      fragment). The fallback can only comment-strip, so a string literal would survive into the
+      overlap view — ``overlap_score`` therefore treats ``lexed=False`` as **unjudgeable** (returns
+      ``None``) rather than risk a prose-inflated ``presumed_covered``. Never raises.
+
+    Grammar-aware, so ``#`` inside a string and ``'''`` inside a comment are handled correctly, and an
+    f-string's literal text is blanked from overlap on Python 3.12+ (PEP 701) where it is no longer a
+    single STRING token.
+    """
+    # Split on ``\n`` only, matching ``io.StringIO(...).readline`` below — NOT ``str.splitlines()``,
+    # which also breaks on form-feed / NEL / LS / PS and would insert phantom lines the tokenizer's
+    # row numbering lacks, desyncing every later span. The trailing surplus entry is never indexed.
+    line_start = [0]
+    for segment in code.split("\n"):
+        line_start.append(line_start[-1] + len(segment) + 1)
+    all_strings_and_comments: List[Tuple[int, int]] = []   # overlap view blanks these
+    comments_and_docstrings: List[Tuple[int, int]] = []    # evidence view blanks these
+    prev = _tokenize.NEWLINE                                # file start behaves like a statement break
+    try:
+        for tok in _tokenize.generate_tokens(io.StringIO(code).readline):
+            span = (line_start[tok.start[0] - 1] + tok.start[1],
+                    line_start[tok.end[0] - 1] + tok.end[1])
+            if tok.type == _tokenize.COMMENT:
+                all_strings_and_comments.append(span)
+                comments_and_docstrings.append(span)
+            elif tok.type == _tokenize.STRING:
+                all_strings_and_comments.append(span)
+                if prev in _STATEMENT_START:               # a statement-leading string = docstring
+                    comments_and_docstrings.append(span)
+            elif tok.type == _FSTRING_MIDDLE:              # PEP 701 f-string literal text (Py 3.12+)
+                all_strings_and_comments.append(span)      # blank the prose from overlap; the interior
+                                                           # expressions are separate tokens, kept. An
+                                                           # f-string is an inline value → kept for evidence.
+            if tok.type not in (_tokenize.NL, _tokenize.COMMENT):
+                prev = tok.type
+    except (_tokenize.TokenError, SyntaxError, ValueError):   # IndentationError ⊂ SyntaxError
+        stripped = _LINE_COMMENT.sub(" ", code)               # best-effort: comments only (strings survive)
+        return stripped, stripped, False                      # lexed=False → caller treats as unjudgeable
+    return _blank(code, all_strings_and_comments), _blank(code, comments_and_docstrings), True
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-strip
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-tokenize
+def tokenize(text: str) -> Set[str]:
+    """Domain tokens of ``text``: split on Unicode word boundaries *and* camelCase, casefold, drop
+    stopwords and 1-char fragments. Deterministic — the basis of every overlap score."""
+    out: Set[str] = set()
+    for raw in _TOKEN_SPLIT.split(text):
+        for piece in _CAMEL_SPLIT.split(raw):
+            token = piece.casefold()
+            if len(token) > 1 and token not in _STOPWORDS:
+                out.add(token)
+    return out
+
+
+def overlap_score(code: str, requirement: str) -> Optional[float]:
+    """Fraction of the requirement's domain tokens present in the code, in [0, 1].
+
+    An **advisory budget heuristic**, never a correctness proof: a strong score buys a block out of
+    a model call, it does not show the block is correct. Comments/docstrings/strings are stripped from
+    the code first so *prose* echoing the requirement cannot inflate the score. A residual gap remains
+    and is inherent to any lexical measure: executable identifiers named after the requirement can push
+    the score **above** the threshold, so the block is ``presumed_covered`` and never judged — the
+    judge (which only sees weak links) does not close this case; only a semantic model would.
+    Scored against the (smaller) requirement set — "does the code cover what the requirement asks",
+    not the reverse. Returns ``None`` when either side has fewer than ``_MIN_TOKENS`` domain tokens
+    (too little to compare honestly) **or** the block did not tokenize (the fallback can't strip
+    strings, so scoring it could mask wrong code) — unjudgeable, not zero.
+    """
+    overlap_view, _evidence, lexed = _code_views(code)
+    if not lexed:                          # could not lex → cannot honestly score; never presumed_covered
+        return None
+    code_tokens = tokenize(overlap_view)
+    req_tokens = tokenize(requirement)
+    if len(code_tokens) < _MIN_TOKENS or len(req_tokens) < _MIN_TOKENS:
+        return None
+    return len(code_tokens & req_tokens) / len(req_tokens)
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-tokenize
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-prefilter
+def _rank_one(pairing: Pairing, priority: Set[str]) -> Ranked:
+    """Score a single pairing → ``Ranked``. Unjudgeable when no requirement or below the floor.
+
+    A pairing in a ``priority`` (``whole_file_claims``) file is **always** a weak link regardless of
+    overlap: its structural coverage rests on a whole-file scope marker, so its lexical overlap is
+    untrustworthy (comments/leftover text inflate it) and it is exactly where wrong code hides — a
+    high score there must not buy a free pass. This is what "prioritise" means: always judge it.
+    """
+    if not pairing.requirement:
+        return Ranked(pairing, None, False, "no retrievable requirement for this id")
+    score = overlap_score(pairing.code, pairing.requirement)
+    if score is None:
+        return Ranked(pairing, None, False,
+                      "too little text to compare (below token floor) or the block did not tokenize")
+    if _norm_path(pairing.path) in priority:
+        return Ranked(pairing, score, True,
+                      f"whole-file claim — always judged (overlap {score:.2f})", forced=True)
+    if score < _WEAK_LINK_THRESHOLD:
+        return Ranked(pairing, score, True, f"low overlap {score:.2f} < {_WEAK_LINK_THRESHOLD}")
+    return Ranked(pairing, score, False, f"overlap {score:.2f}")
+
+
+def rank_pairings(pairings: Sequence[Pairing], priority_paths: Sequence[str] = ()) -> List[Ranked]:
+    """Rank every pairing weakest-first so the judge budget is spent where it matters.
+
+    A ``whole_file_claims`` file is always judged (see ``_rank_one``). Sort key: weak links before
+    strong, then blocks in a ``priority_paths`` file ahead of the rest, then by ascending overlap.
+    Unjudgeable blocks sort last — they carry no signal and are reported separately as coverage gaps.
+    """
+    priority = {_norm_path(p) for p in priority_paths}
+    ranked = [_rank_one(p, priority) for p in pairings]
+
+    def key(item: Ranked) -> Tuple[int, int, float]:
+        if item.weak_link:
+            group = 0                       # weak links first — where the judge budget goes
+        elif item.score is None:
+            group = 2                       # unjudgeable last — no signal
+        else:
+            group = 1                       # strong overlap in between
+        return (group,
+                0 if _norm_path(item.pairing.path) in priority else 1,
+                item.score if item.score is not None else 1.0)
+
+    return sorted(ranked, key=key)
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-prefilter
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-scope
+@dataclass(frozen=True)
+class CoverageScope:
+    """Scoping read from the frozen coverage-report contract (excluded / whole-file-claim files)."""
+
+    excluded: Set[str] = field(default_factory=set)      # human-declared, skip entirely
+    prioritised: List[str] = field(default_factory=list)  # whole_file_claims, in the producer's order
+
+
+def _norm_path(path: str) -> str:
+    """Normalise a path for scope comparison: back- to forward-slashes and a stripped leading
+    ``./``, so a report path and a pairing path that differ only by separator style still match.
+    Matching stays **case-sensitive** — case-folding would wrongly merge distinct files on a
+    case-sensitive filesystem (the common one for this codebase)."""
+    norm = path.replace("\\", "/")
+    return norm[2:] if norm.startswith("./") else norm
+
+
+def _paths_from(report: Dict[str, object], key: str) -> List[str]:
+    """Extract normalised ``path`` strings from ``report[key]`` (a list of dicts), tolerating a bad shape."""
+    rows = report.get(key)
+    if not isinstance(rows, list):
+        return []
+    return [_norm_path(row["path"]) for row in rows
+            if isinstance(row, dict) and isinstance(row.get("path"), str)]
+
+
+def coverage_scope(report: Optional[Dict[str, object]]) -> CoverageScope:
+    """Read ``excluded[]`` / ``whole_file_claims[]`` from a coverage report, degrading to empty.
+
+    The producer (the coverage-report reporting change) may not have emitted these yet; a report
+    without them simply yields an empty scope — skip nothing, prioritise nothing — never an error.
+    """
+    if not isinstance(report, dict):
+        return CoverageScope()
+    return CoverageScope(excluded=set(_paths_from(report, "excluded")),
+                         prioritised=_paths_from(report, "whole_file_claims"))
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-scope
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-prompt
+def _capped(text: str) -> str:
+    """Trim ``text`` to ``_PROMPT_FIELD_CAP``, marking a cut so the judge sees it was truncated."""
+    return text if len(text) <= _PROMPT_FIELD_CAP else text[:_PROMPT_FIELD_CAP].rstrip() + "\n[…truncated]"
+
+
+def build_semantic_request(ranked: Ranked) -> SemanticRequest:
+    """Assemble the deterministic judge prompt for one weak link — pure, no model call. The
+    requirement and code are capped in the prompt so it stays bounded; the returned request keeps
+    the full fields for the evidence guard and any host that builds its own prompt."""
+    pairing = ranked.pairing
+    requirement = pairing.requirement or ""
+    prompt = (
+        "You are judging whether a block of code implements the requirement it cites. This is an "
+        "advisory judgement; it never gates a build.\n\n"
+        f"REQUIREMENT (id {pairing.block_id}):\n{_capped(requirement)}\n\n"
+        f"CODE ({pairing.path}:{pairing.start_line}):\n{_capped(pairing.code)}\n\n"
+        "Answer with a verdict of 'covered', 'partial', or 'wrong', a one-line rationale, and an "
+        "evidence_quote copied verbatim from the CODE above that your verdict rests on.")
+    return SemanticRequest(pairing.block_id, requirement, pairing.code, prompt)
+
+
+def _reply_to_verdict(reply: object) -> str:
+    """Map a reply to a verdict; anything unrecognised — ``None``, a bad object, a **non-string**
+    ``verdict`` (e.g. an int), or an unknown string — is UNJUDGEABLE. A first line of defence: it
+    never raises on a *missing* or non-string attribute; ``_judge_one`` additionally wraps this call
+    so a reply whose attribute *access* raises degrades to UNJUDGEABLE instead of sinking the run."""
+    verdict = getattr(reply, "verdict", "")
+    if not isinstance(verdict, str):
+        return SEM_UNJUDGEABLE
+    verdict = verdict.strip().lower()
+    return verdict if verdict in _MODEL_VERDICTS else SEM_UNJUDGEABLE
+
+
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-prompt
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-evidence
+def evidence_present(code: str, quote: str) -> bool:
+    """Hallucination guard: the model's ``evidence_quote`` must actually occur in the *executable*
+    code.
+
+    The haystack is the ``_code_views`` evidence view — comments and docstrings removed, **inline
+    string literals kept** — so a quote lifted only from a comment or docstring (e.g. a stale comment
+    describing intended-but-unimplemented behaviour) is **not** accepted, while a quote of a real
+    string the code executes (an error message, SQL, a regex — often the exact evidence) still is.
+    Whitespace-normalised so trivial reformatting does not fail a genuine quote; an empty quote is
+    not evidence. A deterministic check sitting *under* the non-deterministic judge.
+    """
+    needle = " ".join(quote.split())
+    haystack = " ".join(_code_views(code)[1].split())
+    return bool(needle) and needle in haystack
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-evidence
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-finding
+@dataclass(frozen=True)
+class SemanticFinding:
+    """One judged weak link — the advisory unit the report carries."""
+
+    block_id: str
+    path: str
+    start_line: int
+    verdict: str                  # covered | partial | wrong | unjudgeable
+    rationale: str
+    evidence_ok: bool             # did evidence_present() confirm the quote?
+    forced: bool = False          # judged because its file is a whole_file_claim, not by low overlap
+
+
+def judge_weak_links(ranked: Sequence[Ranked],
+                     judge_fn: Optional[SemanticJudgeFn]) -> List[SemanticFinding]:
+    """Judge only the weak links. With no ``judge_fn`` every weak link is UNJUDGEABLE (advisory).
+
+    A judge that raises or returns a malformed reply degrades that one finding to UNJUDGEABLE —
+    it never sinks the assessment. Each verdict carries an evidence check (the hallucination
+    guard); a quote absent from the code sets ``evidence_ok=False`` rather than being trusted.
+    """
+    findings: List[SemanticFinding] = []
+    for item in ranked:
+        if not item.weak_link:
+            continue
+        findings.append(_judge_one(item, judge_fn))
+    return findings
+
+
+def _judge_one(item: Ranked, judge_fn: Optional[SemanticJudgeFn]) -> SemanticFinding:
+    """Judge a single weak link defensively → a ``SemanticFinding``."""
+    pairing = item.pairing
+    if judge_fn is None:
+        return SemanticFinding(pairing.block_id, pairing.path, pairing.start_line,
+                               SEM_UNJUDGEABLE, "no judge model wired (advisory)", False, item.forced)
+    request = build_semantic_request(item)
+    try:
+        reply = judge_fn(request)
+        # Marshal *inside* the try: the call is not the only thing that can raise. ``reply`` is
+        # duck-typed ``object``, so a lazily-parsed proxy whose ``.verdict``/``.evidence_quote`` is
+        # a property can raise any exception on access (getattr's default only swallows
+        # AttributeError). Reading here degrades that one finding to UNJUDGEABLE rather than
+        # aborting judge_weak_links/assess — and calibrate, which routes through here too.
+        verdict = _reply_to_verdict(reply)
+        quote = getattr(reply, "evidence_quote", "")
+        rationale = getattr(reply, "rationale", "")
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("semantic: judge_fn raised on %s: %s", pairing.block_id, exc)
+        return SemanticFinding(pairing.block_id, pairing.path, pairing.start_line,
+                               SEM_UNJUDGEABLE, f"judge_fn raised: {exc}", False, item.forced)
+    # A non-string evidence_quote/rationale (a host may return an int or a list) is coerced, not
+    # trusted. An unrecognised verdict names its own cause rather than echoing the model's text.
+    quote = quote if isinstance(quote, str) else ""
+    rationale = rationale if isinstance(rationale, str) else ""
+    if verdict == SEM_UNJUDGEABLE:
+        rationale = "judge returned an unrecognized verdict"
+    return SemanticFinding(pairing.block_id, pairing.path, pairing.start_line, verdict,
+                           rationale, evidence_present(pairing.code, quote), item.forced)
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-finding
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-stub
+def reference_stub_judge(request: SemanticRequest) -> SemanticReply:
+    """A deterministic overlap ``SemanticJudgeFn`` — **not a real model.**
+
+    Ships so tests and calibration exercise the machinery with no model wired. It re-scores the
+    request's own overlap and buckets it (high→covered, mid→partial, low→wrong), quoting the code
+    line with the most requirement tokens so the evidence guard has something real to verify.
+    A real judge_fn is supplied out-of-tree and replaces it.
+
+    **Not an independent oracle.** It buckets the *same* ``overlap_score`` against the *same*
+    ``_WEAK_LINK_THRESHOLD`` the pre-filter already used to flag the pairing, so it is structurally
+    correlated with the pre-filter, not an independent check of it. Calibrating against this stub
+    measures the wiring, not judge quality — meaningful accuracy/consistency need a real judge.
+    """
+    score = overlap_score(request.code, request.requirement) or 0.0
+    if score >= _WEAK_LINK_THRESHOLD:
+        verdict = SEM_COVERED
+    elif score >= _WEAK_LINK_THRESHOLD / 2:
+        verdict = SEM_PARTIAL
+    else:
+        verdict = SEM_WRONG
+    return SemanticReply(verdict, f"reference stub: overlap {score:.2f}",
+                         _best_evidence_line(request))
+
+
+def _best_evidence_line(request: SemanticRequest) -> str:
+    """The *executable* code line sharing the most tokens with the requirement — a real, verifiable
+    quote. Selected over the ``_code_views`` evidence view (comments/docstrings blanked, strings kept)
+    — the same view ``evidence_present`` matches against — so the quote it returns is one the guard
+    will accept, even on a block whose comment echoes the requirement."""
+    req_tokens = tokenize(request.requirement)
+    # Split on ``\n`` only, consistent with how ``_code_views`` defines "one line" — ``str.splitlines()``
+    # would fragment a line at a form-feed/NEL/etc. and could pick a truncated fragment as evidence.
+    lines = [line for line in _code_views(request.code)[1].split("\n") if line.strip()]
+    if not lines:
+        return ""
+    return max(lines, key=lambda line: len(tokenize(line) & req_tokens)).strip()
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-stub
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-gap
+@dataclass(frozen=True)
+class SemanticGap:
+    """One block the engine could not judge — a coverage gap, located like a ``SemanticFinding``.
+
+    Carries ``start_line`` (unlike a bare dict) so a coverage-report consumer can point at every gap
+    precisely, with a shape consistent with ``findings``.
+    """
+
+    block_id: str
+    path: str
+    start_line: int
+    reason: str                   # no requirement / below the token floor / judge could not verdict
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-gap
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-report
+@dataclass
+class SemanticReport:
+    """The advisory result of assessing a set of pairings. Never carries a gate signal.
+
+    Every pairing is accounted for: ``skipped_excluded`` (files a human excluded, dropped before
+    ranking) + ``assessed`` (weak links that got a real covered/partial/wrong verdict) +
+    ``presumed_covered`` (strong overlap, not judged) + ``len(unjudgeable)`` (coverage gaps — no
+    requirement, below the token floor, or the judge could not produce a verdict). So a small
+    ``assessed`` can never be mistaken for "only this many blocks existed".
+
+    "Nothing to assess" and "could not assess" are distinguishable: an **empty** pairing set yields
+    an all-zero report with an **empty** ``unjudgeable``, whereas a resolution failure (no
+    requirement / below floor) yields ``unjudgeable`` **entries** — never a silent all-zero.
+    """
+
+    assessed: int                          # weak links that got a real covered/partial/wrong verdict
+    presumed_covered: int                  # strong overlap → not judged; a budget heuristic, NOT a
+                                           # correctness claim (lexical overlap is gameable)
+    unjudgeable: List[SemanticGap]         # coverage gaps: no requirement / below floor / judge unjudgeable
+    findings: List[SemanticFinding] = field(default_factory=list)   # only the real-verdict findings
+    skipped_excluded: int = 0              # blocks in human-excluded files, dropped before ranking
+    schema_version: int = SEMANTIC_SCHEMA_VERSION   # report-shape version for the coverage consumer
+
+
+def assess(pairings: Sequence[Pairing], judge_fn: Optional[SemanticJudgeFn] = None,
+           report: Optional[Dict[str, object]] = None) -> SemanticReport:
+    """Assess ``pairings`` end-to-end: scope → rank → judge weak links → honest report.
+
+    Advisory throughout. Files in the coverage report's ``excluded`` set are dropped before
+    ranking (human-declared, skip safely); every block with no requirement or too little text is
+    listed in ``unjudgeable`` rather than silently counted covered. ``excluded`` takes precedence
+    over ``whole_file_claims``: a path in both is dropped here, before ranking ever sees it — the
+    human exclusion is the override.
+    """
+    scope = coverage_scope(report)
+    in_scope = [p for p in pairings if _norm_path(p.path) not in scope.excluded]
+    ranked = rank_pairings(in_scope, scope.prioritised)
+    presumed = sum(1 for r in ranked if not r.weak_link and r.score is not None)
+    all_findings = judge_weak_links(ranked, judge_fn)
+    # A weak link the judge could not verdict (no judge wired / crash / malformed) is a coverage
+    # gap, not a "judged" result — it joins the unjudgeable list, not the findings.
+    findings = [f for f in all_findings if f.verdict in _MODEL_VERDICTS]
+    unjudgeable = [SemanticGap(r.pairing.block_id, r.pairing.path, r.pairing.start_line, r.reason)
+                   for r in ranked if r.score is None]
+    unjudgeable += [SemanticGap(f.block_id, f.path, f.start_line, f.rationale or "judge unjudgeable")
+                    for f in all_findings if f.verdict == SEM_UNJUDGEABLE]
+    return SemanticReport(assessed=len(findings), presumed_covered=presumed,
+                          unjudgeable=unjudgeable, findings=findings,
+                          skipped_excluded=len(pairings) - len(in_scope))
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-report
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-resolve
+def resolve_requirement(doc_path: Path, block_id: str) -> Optional[str]:
+    """Fetch the requirement text scoped to ``block_id`` from a feature doc, or ``None``.
+
+    A thin adapter over ``get_content_scoped``; a ``None`` (id absent / doc unreadable) is the
+    honest "unjudgeable" signal the pre-filter propagates, never a crash. The id→doc mapping that
+    drives this at scale is the reporting-integration follow-up; the engine only needs the lookup.
+
+    **Security — caller contract.** ``doc_path`` is opened as given; ``block_id`` never selects a
+    file, so there is no traversal via the id. The caller owns the path's trust boundary: pass a
+    path already resolved and confirmed to be within the intended project root. The engine has no
+    project root of its own to check against, so it cannot enforce containment here.
+    """
+    scoped = get_content_scoped(doc_path, id_value=block_id)
+    return scoped[0] if scoped else None
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-resolve
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-gold
+@dataclass
+class SemanticGold:
+    """A human label for one pairing — the ground truth calibration compares against."""
+
+    verdict: str                  # covered | partial | wrong
+    rationale: str = ""
+
+
+def load_gold(gold_path: Optional[Path]) -> Optional[SemanticGold]:
+    """Read a ``[gold]`` verdict label, or ``None`` when absent/malformed. Never raises.
+
+    A missing or unreadable gold file means the pairing is not gold-backed, so its verdict is
+    unvalidated advisory rather than a crash.
+
+    **Security — caller contract.** ``gold_path`` is opened as given. The caller owns the path's
+    trust boundary: pass a path already resolved and confirmed within the intended project root. The
+    engine has no project root of its own to check containment against, so it cannot enforce it here.
+    """
+    if gold_path is None:
+        return None
+    data = load_toml_file(gold_path)   # shared tolerant reader: logs + returns None on OSError/parse
+    if data is None:
+        # Case B — the reader returned None for *any* reason. Surface both sub-cases (the reader is
+        # silent on a missing file, and logs only the low-level detail on a read/parse failure): a
+        # present-but-unreadable gold file is an unexpected misconfiguration, not "no gold provided".
+        if gold_path.is_file():
+            logger.warning("semantic: gold file present but unreadable/unparseable: %s", gold_path)
+        else:
+            logger.warning("semantic: gold file not found: %s", gold_path)
+        return None
+    section = data.get("gold")
+    verdict = section.get("verdict") if isinstance(section, dict) else None
+    # isinstance-guard before the frozenset test: a TOML array/table verdict is unhashable and would
+    # raise ``TypeError: unhashable type`` from ``in`` — breaking the "never raises" contract.
+    if not isinstance(verdict, str) or verdict not in _MODEL_VERDICTS:
+        logger.warning("semantic: gold needs [gold].verdict in covered|partial|wrong: %s", gold_path)
+        return None
+    return SemanticGold(verdict=verdict, rationale=str(section.get("rationale", "")))
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-gold
+
+
+# @cpt-begin:cpt-studio-algo-eval-semantic:p1:inst-semantic-calibrate
+@dataclass
+class SemanticCalibration:
+    """The judge's measured quality over gold-backed pairings."""
+
+    accuracy: Optional[float]     # fraction whose majority matches the label, over cases with a majority
+    consistency: Optional[float]  # majority verdict's mean share of surviving runs, over cases with ≥2
+    covered: List[str]            # block ids that carry a gold label
+    runs_per_scenario: int
+    per_case: List[Dict[str, object]] = field(default_factory=list)
+    excluded: List[str] = field(default_factory=list)   # unscoreable pairing / judge crash — not a mismatch
+    judge: str = ""               # best-effort identity of the judge_fn these numbers describe
+    schema_version: int = SEMANTIC_SCHEMA_VERSION   # calibration-shape version for the consumer
+
+
+def _majority(verdicts: Sequence[str]) -> Tuple[str, int]:
+    """The most common verdict and its count. Ties resolve by sorted verdict name (canonical), so
+    the *display* value is independent of run order — not the first-seen order the runs produced.
+    The canonical pick (alphabetically-first: covered < partial < wrong) must never decide accuracy —
+    that would skew scoring by the gold label's rank — so ``_calibrate_case`` detects a strict tie
+    (no single verdict holds the top count) and excludes it from accuracy rather than trusting this."""
+    counts: Dict[str, int] = {}
+    for verdict in verdicts:
+        counts[verdict] = counts.get(verdict, 0) + 1
+    if not counts:
+        return SEM_UNJUDGEABLE, 0
+    best = max(sorted(counts), key=lambda v: counts[v])
+    return best, counts[best]
+
+
+def _pairing_unscoreable(pairing: Pairing) -> bool:
+    """A pairing the pre-filter would mark unjudgeable — no requirement, or too little text to
+    compare. The judge would never see it in normal operation, so it is excluded from calibration
+    rather than judged on empty input and scored as a mismatch."""
+    if not pairing.requirement:
+        return True
+    return overlap_score(pairing.code, pairing.requirement) is None
+
+
+def _calibrate_case(pairing: Pairing, gold: SemanticGold, judge_fn: SemanticJudgeFn,
+                    runs: int) -> "Tuple[bool, Optional[bool], Optional[float], Dict[str, object]]":
+    """Judge one gold-backed pairing ``runs`` times → ``(unscoreable, matched, consistency, row)``.
+    ``consistency`` is ``None`` when fewer than two runs survived (run-to-run agreement is unmeasurable
+    with one verdict, never a false 1.0). ``matched`` is ``None`` on a strict tie (no majority) and on a
+    *crash-degraded* case (``runs>=2`` reduced to one survivor — which run crashed must not flip
+    accuracy); an *intentional* ``runs=1`` single verdict still scores accuracy (a trivial majority).
+
+    ``unscoreable`` is true when **no** run produced a real verdict (every run was UNJUDGEABLE — a
+    crash, a malformed reply, or none wired): a harness/operational outcome, not a disagreement, so
+    the caller excludes it. UNJUDGEABLE runs are dropped **before** majority/consistency. ``accuracy``
+    is fully guarded — below two survivors ``matched`` is ``None`` (a crash that drops survivors to one
+    must not turn an excluded tie into a hit or miss). ``consistency`` is a share **over the survivors**,
+    so when a crash coincides with a *dissenting* run it is an estimate: e.g. real ``[covered, covered,
+    wrong]`` is 0.667, but a crash on the ``wrong`` run reads 1.0 and a crash on a ``covered`` run reads
+    0.5. It is honest for what it measures (agreement among the runs that returned) and ``runs_effective``
+    records the survivor count; it does not pretend a crashed run agreed. Keying off the verdicts (not a
+    rationale substring) means a real verdict is never falsely excluded for mentioning an error.
+    """
+    forced = Ranked(pairing, 0.0, True, "calibration")
+    verdicts = [_judge_one(forced, judge_fn).verdict for _ in range(runs)]
+    real = [verdict for verdict in verdicts if verdict != SEM_UNJUDGEABLE]
+    if not real:
+        return True, False, None, {"block_id": pairing.block_id, "expected": gold.verdict,
+                                   "majority": SEM_UNJUDGEABLE, "matched": False,
+                                   "runs_effective": 0, "consistency": None}
+    majority, count = _majority(real)
+    # Normalise the gold side the same way ``_reply_to_verdict`` normalises the judge side, so a
+    # directly-built ``SemanticGold("Covered")`` / ``" covered"`` (``load_gold`` enforces lowercase,
+    # direct construction does not) is a formatting difference, never a false accuracy=0 mismatch.
+    gold_verdict = gold.verdict.strip().lower()
+    matched: Optional[bool]
+    consistency: Optional[float]
+    if len(real) >= 2:
+        # A strict tie (more than one verdict shares the top count) has no majority: scoring it against
+        # gold would credit the canonical (alphabetically-first) pick, deflating accuracy whenever gold
+        # is a later label (e.g. the safety-critical ``wrong``). ``matched=None`` leaves accuracy alone.
+        tied = sum(1 for verdict in set(real) if real.count(verdict) == count) > 1
+        matched = None if tied else majority == gold_verdict
+        # Consistency = the majority verdict's share of the surviving runs (``count / len(real)``): 1.0
+        # when every real run agreed, 0.5 when a 3-run case split 2:1. ``runs_effective`` records how
+        # many runs produced a verdict, so a case decided on fewer than ``runs`` stays visible.
+        consistency = round(count / len(real), 4)
+    elif runs == 1:
+        # Intentional single run: a lone clean verdict has a trivial majority, so it *does* score
+        # accuracy (matching the doc); consistency needs ≥2 runs to mean anything, so it stays None.
+        matched = majority == gold_verdict
+        consistency = None
+    else:
+        # Crash-degraded: ``runs`` asked for repetition but crashes left one survivor. Scoring that
+        # lone verdict would let *which* run crashed flip a would-be tie into a hit or miss, so a
+        # degraded case feeds neither denominator — gold-independent.
+        matched = None
+        consistency = None
+    return False, matched, consistency, {"block_id": pairing.block_id, "expected": gold.verdict,
+                                         "majority": majority, "matched": matched,
+                                         "runs_effective": len(real), "consistency": consistency}
+
+
+def calibrate(cases: Sequence[Tuple[Pairing, SemanticGold]], judge_fn: SemanticJudgeFn,
+              runs: int = 3) -> SemanticCalibration:
+    """Run the judge ``runs`` times over each gold-backed pairing; report accuracy + consistency.
+
+    Both are ``None`` when there is nothing to measure — never a false 0. A pairing the pre-filter
+    would mark unjudgeable (no requirement / below the token floor), or one whose judged majority is
+    UNJUDGEABLE (a crash, a malformed reply, or no judge wired), is **excluded** — a harness/
+    operational outcome, not a judge mismatch — so it never deflates accuracy. ``covered`` still
+    lists every gold-backed pairing.
+
+    Calibrating against ``reference_stub_judge`` is warned at runtime: the stub re-uses the
+    pre-filter's own overlap, so its numbers measure the machinery, not judge quality.
+    """
+    runs = max(1, runs)
+    if judge_fn is reference_stub_judge:
+        logger.warning("semantic: calibrating against reference_stub_judge — it re-uses the pre-filter's "
+                       "own overlap score, so accuracy/consistency measure the machinery, not judge "
+                       "quality; wire a real judge for meaningful calibration.")
+    scoreable = [(pairing, gold) for pairing, gold in cases if not _pairing_unscoreable(pairing)]
+    excluded = [pairing.block_id for pairing, _ in cases if _pairing_unscoreable(pairing)]
+    outcomes = [(pairing, _calibrate_case(pairing, gold, judge_fn, runs))
+                for pairing, gold in scoreable]
+    excluded = excluded + [pairing.block_id for pairing, out in outcomes if out[0]]  # out[0]: unscoreable?
+    scored = [out for _, out in outcomes if not out[0]]
+    # Accuracy is over cases with a real majority (matched is not None — a strict tie is unmeasurable,
+    # not a miss); consistency only over cases with a real run-to-run measurement (≥2 survivors), so a
+    # one-survivor case cannot contribute a spurious 1.0. Independent denominators, each honest.
+    matched = [m for _, m, _, _ in scored if m is not None]
+    measured = [c for _, _, c, _ in scored if c is not None]
+    judge = getattr(judge_fn, "__qualname__", "") or type(judge_fn).__name__
+    return SemanticCalibration(
+        accuracy=round(sum(1 for m in matched if m) / len(matched), 4) if matched else None,
+        consistency=round(sum(measured) / len(measured), 4) if measured else None,
+        covered=[pairing.block_id for pairing, _ in cases],
+        runs_per_scenario=runs, per_case=[row for _, _, _, row in scored], excluded=excluded,
+        judge=judge)
+# @cpt-end:cpt-studio-algo-eval-semantic:p1:inst-semantic-calibrate

--- a/tests/test_eval_semantic.py
+++ b/tests/test_eval_semantic.py
@@ -1,0 +1,990 @@
+"""Tests for the semantic-coverage engine (utils.eval_semantic).
+
+The headline is the adversarial pair: a marked block implementing the *wrong* behaviour must be
+surfaced as a weak link and judged non-covered, while a faithful implementation must not be
+touched by the judge at all. The rest pin the honesty guards: unjudgeable-not-zero, the
+evidence (hallucination) guard, defensive degradation, and the advisory-never-gates discipline.
+"""
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Callable, List, Optional
+
+import pytest
+
+from studio.utils import eval_semantic as sem
+from studio.utils.eval_semantic import (Pairing, SemanticReply, SemanticReport, assess,
+                                        calibrate, coverage_scope, evidence_present, load_gold,
+                                        overlap_score, rank_pairings, reference_stub_judge,
+                                        resolve_requirement, tokenize)
+
+# A requirement with a clear domain vocabulary, and two code blocks: one faithful, one wrong.
+_REQUIREMENT = ("Validate the user email address format and reject a malformed address before "
+                "saving the record.")
+_CORRECT_CODE = ("def validate_email(address):\n"
+                 "    if not email_format(address):\n"
+                 "        reject_malformed(address)\n"
+                 "    return save_record(address)")
+_WRONG_CODE = ("def compute_tax(amount):\n"
+               "    rate = lookup_rate(amount)\n"
+               "    return amount * rate")
+
+
+def _pairing(block_id: str, code: str, requirement: Optional[str],
+             path: str = "mod.py", start_line: int = 10) -> Pairing:
+    return Pairing(block_id=block_id, inst=f"inst-{block_id}", path=path,
+                   start_line=start_line, code=code, requirement=requirement)
+
+
+class _SpyJudge:
+    """A judge_fn that records the ids it was asked to judge and returns a fixed verdict."""
+
+    def __init__(self, verdict: str = sem.SEM_WRONG, quote: str = "") -> None:
+        self.calls: List[str] = []
+        self._verdict = verdict
+        self._quote = quote
+
+    def __call__(self, request: sem.SemanticRequest) -> SemanticReply:
+        self.calls.append(request.block_id)
+        return SemanticReply(self._verdict, "spy", self._quote)
+
+
+# --- tokenisation + overlap ------------------------------------------------
+
+def test_tokenize_splits_camel_and_snake_and_drops_stopwords() -> None:
+    tokens = tokenize("validateEmail user_email and the RECORD")
+    assert {"validate", "email", "user", "record"} <= tokens
+    assert "and" not in tokens  # stopwords dropped
+    assert "the" not in tokens
+
+
+def test_overlap_below_token_floor_is_none_not_zero() -> None:
+    # Too few domain tokens on the requirement side → unjudgeable, never a false 0.
+    assert overlap_score(_CORRECT_CODE, "do it") is None
+
+
+def test_overlap_is_fraction_of_requirement_tokens_present() -> None:
+    # Pinned to the exact value — the denominator is the REQUIREMENT token count (not code, not
+    # Jaccard). Asserting only >= threshold would not catch a denominator regression.
+    assert overlap_score(_CORRECT_CODE, _REQUIREMENT) == 0.7
+    # A case where the requirement-denominator and code-denominator answers differ, pinned to the
+    # requirement-denominator value (2/4); a code denominator would give 2/7 ~= 0.29.
+    assert overlap_score("alpha beta zeta eta theta iota kappa", "alpha beta gamma delta") == 0.5
+
+
+# --- the adversarial pair (headline) ---------------------------------------
+
+def test_adversarial_wrong_is_flagged_and_correct_is_not_even_judged() -> None:
+    spy = _SpyJudge(verdict=sem.SEM_WRONG)
+    report = assess([_pairing("correct", _CORRECT_CODE, _REQUIREMENT),
+                     _pairing("wrong", _WRONG_CODE, _REQUIREMENT)], judge_fn=spy)
+    judged = {f.block_id: f for f in report.findings}
+    # The wrong block is surfaced as a weak link and judged; the faithful one is not.
+    assert "wrong" in judged
+    assert judged["wrong"].verdict == sem.SEM_WRONG
+    assert "correct" not in judged
+    assert spy.calls == ["wrong"]  # pre-filter-first: no model call on the strong block
+
+
+def test_prefilter_first_no_model_call_when_all_blocks_are_strong() -> None:
+    spy = _SpyJudge()
+    report = assess([_pairing("a", _CORRECT_CODE, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == []
+    assert report.findings == []
+    assert report.assessed == 0
+    # accounted for as presumed-covered, not silently dropped
+    assert report.presumed_covered == 1
+
+
+def test_report_accounts_for_every_in_scope_block() -> None:
+    report = assess([_pairing("strong", _CORRECT_CODE, _REQUIREMENT),
+                     _pairing("weak", _WRONG_CODE, _REQUIREMENT),
+                     _pairing("gap", _WRONG_CODE, None)], judge_fn=_SpyJudge())
+    assert report.assessed == 1
+    assert report.presumed_covered == 1
+    assert len(report.unjudgeable) == 1
+
+
+# --- honesty: unjudgeable-not-zero -----------------------------------------
+
+def test_missing_requirement_is_unjudgeable_not_judged() -> None:
+    report = assess([_pairing("noreq", _WRONG_CODE, None)], judge_fn=_SpyJudge())
+    assert report.findings == []
+    assert [u.block_id for u in report.unjudgeable] == ["noreq"]
+    assert "no retrievable requirement" in report.unjudgeable[0].reason
+
+
+def test_below_floor_requirement_is_unjudgeable() -> None:
+    report = assess([_pairing("tiny", _WRONG_CODE, "do it")], judge_fn=_SpyJudge())
+    assert [u.block_id for u in report.unjudgeable] == ["tiny"]
+
+
+def test_no_judge_wired_makes_every_weak_link_unjudgeable() -> None:
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT)], judge_fn=None)
+    assert report.findings == []                                     # nothing got a real verdict
+    assert any(u.block_id == "wrong" for u in report.unjudgeable)  # surfaced as a coverage gap
+
+
+# --- the evidence (hallucination) guard ------------------------------------
+
+def test_evidence_present_normalises_whitespace() -> None:
+    assert evidence_present("a   b\n c", "a b c")
+    assert not evidence_present("real code here", "fabricated quote")
+    assert not evidence_present("code", "")  # an empty quote is not evidence
+
+
+def test_fabricated_quote_sets_evidence_not_ok() -> None:
+    spy = _SpyJudge(verdict=sem.SEM_WRONG, quote="this text is not in the code")
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT)], judge_fn=spy)
+    assert report.findings[0].evidence_ok is False
+
+
+def test_real_quote_sets_evidence_ok() -> None:
+    spy = _SpyJudge(verdict=sem.SEM_WRONG, quote="rate = lookup_rate(amount)")
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT)], judge_fn=spy)
+    assert report.findings[0].evidence_ok is True
+
+
+# --- defensive degradation --------------------------------------------------
+
+def test_judge_that_raises_degrades_to_unjudgeable() -> None:
+    def boom(_request: sem.SemanticRequest) -> SemanticReply:
+        raise RuntimeError("model down")
+
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT)], judge_fn=boom)
+    assert report.findings == []
+    assert any(u.block_id == "wrong" for u in report.unjudgeable)
+
+
+@pytest.mark.parametrize("reply", [None, object(), SemanticReply("bogus")])
+def test_malformed_reply_is_unjudgeable(reply: object) -> None:
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT)],
+                    judge_fn=lambda _r: reply)
+    assert report.findings == []
+    assert any(u.block_id == "wrong" for u in report.unjudgeable)
+
+
+# --- advisory never gates ---------------------------------------------------
+
+def test_report_carries_no_gate_signal() -> None:
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT)],
+                    judge_fn=_SpyJudge(sem.SEM_WRONG))
+    # A wrong verdict produces a finding but nothing resembling a pass/fail/exit gate.
+    assert isinstance(report, SemanticReport)
+    assert not any(hasattr(report, attr) for attr in ("gate", "exit_code", "passed"))
+
+
+# --- the frozen coverage-report scope --------------------------------------
+
+def test_excluded_files_are_skipped_before_ranking() -> None:
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT, path="skip.py")],
+                    judge_fn=_SpyJudge(),
+                    report={"excluded": [{"path": "skip.py", "reason": "x", "declared_by": "config"}]})
+    assert report.findings == []
+    assert report.unjudgeable == []
+
+
+def test_whole_file_claims_are_prioritised_in_ranking() -> None:
+    weak_plain = _pairing("plain", _WRONG_CODE, _REQUIREMENT, path="plain.py")
+    weak_claim = _pairing("claim", _WRONG_CODE, _REQUIREMENT, path="claim.py")
+    ranked = rank_pairings([weak_plain, weak_claim], priority_paths=["claim.py"])
+    assert ranked[0].pairing.path == "claim.py"  # prioritised file bubbles to the top
+
+
+def test_report_missing_the_fields_yields_empty_scope() -> None:
+    scope = coverage_scope({"some_other_key": 1})
+    assert scope.excluded == set()
+    assert scope.prioritised == []
+    assert coverage_scope(None).excluded == set()  # a None report never errors
+
+
+# --- the reference stub -----------------------------------------------------
+
+def test_reference_stub_buckets_by_overlap() -> None:
+    covered = reference_stub_judge(sem.build_semantic_request(
+        sem.Ranked(_pairing("c", _CORRECT_CODE, _REQUIREMENT), 0.0, True, "x")))
+    wrong = reference_stub_judge(sem.build_semantic_request(
+        sem.Ranked(_pairing("w", _WRONG_CODE, _REQUIREMENT), 0.0, True, "x")))
+    assert covered.verdict == sem.SEM_COVERED
+    assert wrong.verdict == sem.SEM_WRONG
+    assert covered.evidence_quote  # a real line, so the evidence guard can verify it
+
+
+def test_reference_stub_on_empty_code_is_wrong_with_no_quote() -> None:
+    reply = reference_stub_judge(sem.SemanticRequest("e", _REQUIREMENT, "", "prompt"))
+    assert reply.verdict == sem.SEM_WRONG
+    assert reply.evidence_quote == ""
+
+
+# --- the requirement resolver ----------------------------------------------
+
+def test_resolve_requirement_reads_scoped_doc(tmp_path: Path) -> None:
+    doc = tmp_path / "feature.md"
+    doc.write_text("### cpt-studio-algo-demo\nThe demo requirement text.\n", encoding="utf-8")
+    assert resolve_requirement(doc, "cpt-studio-algo-demo") == "The demo requirement text."
+    assert resolve_requirement(doc, "cpt-studio-algo-absent") is None
+
+
+# --- gold + calibration -----------------------------------------------------
+
+def test_load_gold_valid_and_malformed(tmp_path: Path) -> None:
+    good = tmp_path / "gold.toml"
+    good.write_text('[gold]\nverdict = "wrong"\nrationale = "off"\n', encoding="utf-8")
+    loaded = load_gold(good)
+    assert loaded is not None
+    assert loaded.verdict == "wrong"
+
+    bad = tmp_path / "bad.toml"
+    bad.write_text('[gold]\nverdict = "nonsense"\n', encoding="utf-8")
+    assert load_gold(bad) is None
+    assert load_gold(tmp_path / "missing.toml") is None
+    assert load_gold(None) is None
+
+
+def test_calibrate_reports_accuracy_and_consistency() -> None:
+    cases = [(_pairing("w", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong")),
+             (_pairing("c", _CORRECT_CODE, _REQUIREMENT), sem.SemanticGold("covered"))]
+    result = calibrate(cases, reference_stub_judge, runs=3)
+    assert result.accuracy == 1.0            # stub agrees with both human labels
+    assert result.consistency == 1.0         # deterministic stub → no run-to-run variance
+    assert set(result.covered) == {"w", "c"}
+
+
+def test_calibrate_empty_is_none_not_zero() -> None:
+    result = calibrate([], reference_stub_judge)
+    assert result.accuracy is None
+    assert result.consistency is None
+
+
+def test_non_string_verdict_is_unjudgeable_not_raise() -> None:
+    # A reply whose verdict is a truthy non-string (e.g. 123) must degrade to unjudgeable, not raise
+    # an AttributeError — this runs outside any try/except and calibration calls it directly.
+    class _IntVerdict:
+        verdict = 123
+
+    assert sem._reply_to_verdict(_IntVerdict()) == sem.SEM_UNJUDGEABLE
+
+
+def test_calibration_excludes_a_crashing_judge() -> None:
+    # A judge_fn that raises is an operational failure, not a disagreement — the case is excluded,
+    # not scored as a mismatch, so a transient crash never deflates accuracy.
+    def boom(_request: sem.SemanticRequest) -> SemanticReply:
+        raise RuntimeError("model down")
+
+    cal = calibrate([(_pairing("c", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    boom, runs=2)
+    assert "c" in cal.excluded
+    assert cal.accuracy is None            # the only case crashed → nothing scored
+    assert cal.per_case == []
+
+
+def test_calibration_excludes_an_unscoreable_pairing() -> None:
+    # A pairing with no requirement (unjudgeable at the pre-filter) is excluded from calibration,
+    # not judged on empty input and scored as a mismatch.
+    cal = calibrate([(_pairing("noreq", _WRONG_CODE, None), sem.SemanticGold("wrong"))],
+                    reference_stub_judge, runs=2)
+    assert "noreq" in cal.excluded
+    assert cal.accuracy is None
+
+
+def test_prompt_fields_are_bounded() -> None:
+    # A huge code block must not produce an unbounded prompt; the interpolated fields are capped,
+    # while the structured request field stays full for the evidence guard.
+    huge = "x = 1\n" * 5000
+    req = sem.build_semantic_request(sem.Ranked(_pairing("big", huge, _REQUIREMENT), 0.0, True, "x"))
+    assert len(req.prompt) < sem._PROMPT_FIELD_CAP * 3   # bounded, not ~30k
+    assert "[…truncated]" in req.prompt
+    assert req.code == huge                              # the structured field is not truncated
+
+
+# --- deep-review hardening (verified findings M1, M2, M3, M5, m2, excluded-count) ---
+
+def test_non_string_evidence_quote_and_rationale_do_not_sink_assessment() -> None:
+    # a host returning a non-string evidence_quote/rationale must not crash out of _judge_one
+    # (its try only wraps the model call) and sink assess()/calibrate() — degrade the fields.
+    class _BadReply:
+        verdict = "wrong"
+        evidence_quote = 42                 # non-string
+        rationale = ["not", "a", "string"]  # non-string
+
+    report = assess([_pairing("wrong", _WRONG_CODE, _REQUIREMENT)], judge_fn=lambda _r: _BadReply())
+    assert report.findings[0].verdict == sem.SEM_WRONG       # verdict still parsed, no crash
+    assert report.findings[0].evidence_ok is False           # non-string quote is not evidence
+    cal = calibrate([(_pairing("w", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    lambda _r: _BadReply(), runs=2)
+    assert cal.accuracy == 1.0                               # scored without raising
+
+
+def test_calibration_excludes_an_unknown_verdict_reply() -> None:
+    # a reply mapping to UNJUDGEABLE for a non-crash reason (unknown verdict) is excluded, not
+    # scored as a mismatch that deflates accuracy.
+    cal = calibrate([(_pairing("u", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    lambda _r: SemanticReply("maybe"), runs=2)
+    assert "u" in cal.excluded
+    assert cal.accuracy is None
+
+
+def test_calibration_does_not_exclude_a_real_verdict_mentioning_an_error() -> None:
+    # a genuine verdict must not be excluded just because its free-text rationale mentions an
+    # error phrase — exclusion keys off the verdict, not a rationale substring.
+    reply = SemanticReply("wrong", "the branch where judge_fn raised is not covered")
+    cal = calibrate([(_pairing("r", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    lambda _r: reply, runs=2)
+    assert cal.excluded == []
+    assert cal.accuracy == 1.0
+
+
+def test_calibration_accuracy_below_one_on_disagreement() -> None:
+    # accuracy must be able to fall below 1 — a stub verdict that disagrees with gold is a miss.
+    cases = [(_pairing("hit", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong")),      # stub wrong == gold
+             (_pairing("miss", _CORRECT_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))]   # stub covered != gold
+    cal = calibrate(cases, reference_stub_judge, runs=2)
+    assert cal.accuracy == 0.5
+    assert 0.0 < cal.accuracy < 1.0
+
+
+def test_calibration_consistency_below_one_for_a_flaky_judge() -> None:
+    # consistency must be able to fall below 1 — a judge that varies run-to-run.
+    calls = {"n": 0}
+
+    def flaky(_request: sem.SemanticRequest) -> SemanticReply:
+        calls["n"] += 1
+        return SemanticReply("covered" if calls["n"] % 2 else "wrong")
+
+    cal = calibrate([(_pairing("f", _CORRECT_CODE, _REQUIREMENT), sem.SemanticGold("covered"))],
+                    flaky, runs=3)
+    assert cal.consistency is not None
+    assert cal.consistency < 1.0                 # covered, wrong, covered → majority 2/3
+
+
+def test_reference_stub_partial_bucket() -> None:
+    # a mid-overlap block (~0.2, in [threshold/2, threshold)) buckets to PARTIAL.
+    partial_code = "def validate_thing(item):\n    email_field = item\n    return compute_other(item)"
+    req = sem.build_semantic_request(sem.Ranked(_pairing("p", partial_code, _REQUIREMENT), 0.2, True, "x"))
+    assert reference_stub_judge(req).verdict == sem.SEM_PARTIAL
+
+
+def test_report_counts_excluded_file_blocks() -> None:
+    # excluded-count: blocks in a human-excluded file are counted (skipped_excluded), not dropped.
+    report = assess([_pairing("keep", _WRONG_CODE, _REQUIREMENT, path="keep.py"),
+                     _pairing("s1", _WRONG_CODE, _REQUIREMENT, path="skip.py"),
+                     _pairing("s2", _WRONG_CODE, _REQUIREMENT, path="skip.py")],
+                    judge_fn=_SpyJudge(sem.SEM_WRONG),
+                    report={"excluded": [{"path": "skip.py"}]})
+    assert report.skipped_excluded == 2
+    assert report.assessed == 1                  # only the kept block was judged
+
+
+# --- deep-review round 2 (M1 design fix, M2 crash, M3 minority-unjudgeable, M5 accounting) ---
+
+def test_whole_file_claim_block_is_always_judged_despite_high_overlap() -> None:
+    # a whole_file_claims (prioritised) file's overlap is untrustworthy — a high-overlap block
+    # there must be JUDGED, not waved through as presumed_covered (the engine's headline purpose).
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("claim", _CORRECT_CODE, _REQUIREMENT, path="claim.py")],
+                    judge_fn=spy, report={"whole_file_claims": [{"path": "claim.py"}]})
+    assert spy.calls == ["claim"]                       # judged despite overlap 0.7 (would be strong)
+    assert report.presumed_covered == 0
+    assert [f.verdict for f in report.findings] == [sem.SEM_WRONG]
+
+
+def test_load_gold_non_string_verdict_returns_none_not_raise(tmp_path: Path) -> None:
+    # a TOML array/table verdict is unhashable; load_gold must return None, never raise.
+    for bad in ('verdict = ["wrong"]', 'verdict = { x = 1 }'):
+        p = tmp_path / "g.toml"
+        p.write_text(f"[gold]\n{bad}\n", encoding="utf-8")
+        assert load_gold(p) is None
+
+
+def test_calibration_minority_unjudgeable_does_not_deflate_consistency() -> None:
+    # one transient crash among good runs must not deflate consistency or flip the exclude
+    # decision — UNJUDGEABLE runs are dropped before majority/consistency.
+    calls = {"n": 0}
+
+    def flaky(_request: sem.SemanticRequest) -> SemanticReply:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("transient")             # only the first run fails
+        return SemanticReply("wrong")
+
+    cal = calibrate([(_pairing("m", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    flaky, runs=3)
+    assert cal.excluded == []                           # a real verdict was produced → scored
+    assert cal.accuracy == 1.0
+    assert cal.consistency == 1.0                       # over the 2 real runs, both agreed
+
+
+def test_assess_covered_verdict_lands_in_findings() -> None:
+    # a weak link the judge rules COVERED must land in findings with a real verdict, not vanish
+    # from every accounting bucket (it is not UNJUDGEABLE and was not presumed_covered).
+    report = assess([_pairing("w", _WRONG_CODE, _REQUIREMENT)], judge_fn=_SpyJudge(sem.SEM_COVERED))
+    assert [f.verdict for f in report.findings] == [sem.SEM_COVERED]
+    assert report.assessed == 1
+
+
+def test_assess_accounting_identity_holds() -> None:
+    # every pairing is accounted for exactly once across the four buckets.
+    pairings = [_pairing("strong", _CORRECT_CODE, _REQUIREMENT),
+                _pairing("weak", _WRONG_CODE, _REQUIREMENT),
+                _pairing("gap", _WRONG_CODE, None),
+                _pairing("skip", _WRONG_CODE, _REQUIREMENT, path="x.py")]
+    report = assess(pairings, judge_fn=_SpyJudge(sem.SEM_PARTIAL),
+                    report={"excluded": [{"path": "x.py"}]})
+    assert (report.assessed + report.presumed_covered
+            + len(report.unjudgeable) + report.skipped_excluded) == len(pairings)
+
+
+def test_majority_of_empty_is_unjudgeable() -> None:
+    # Defensive: _majority over no verdicts is UNJUDGEABLE with count 0, never an error.
+    assert sem._majority([]) == (sem.SEM_UNJUDGEABLE, 0)
+
+
+# --- deep-review round 3 (M2 comment inflation, m2 effective-n, m3 unicode, m5/i2 gaps) ---
+
+def test_comment_echoing_requirement_does_not_mask_wrong_code() -> None:
+    # a comment/docstring that restates the requirement must NOT inflate overlap and wave the
+    # block through as presumed_covered — comments/strings are stripped before scoring, so wrong
+    # code beneath a requirement-echoing comment is still surfaced as a weak link and judged.
+    echoed = ('def compute_tax(amount):\n'
+              '    # Validate the user email address format and reject a malformed address'
+              ' before saving the record.\n'
+              '    """Validate the user email address format and reject a malformed address."""\n'
+              '    return amount * lookup_rate(amount)')
+    score = overlap_score(echoed, _REQUIREMENT)
+    assert score is not None                          # enough executable tokens to compare
+    assert score < sem._WEAK_LINK_THRESHOLD           # not inflated by the echoing prose
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("masked", echoed, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == ["masked"]                    # judged, not presumed_covered
+    assert report.presumed_covered == 0
+
+
+def test_tokenize_keeps_non_ascii_terms_whole() -> None:
+    # non-ASCII terms must stay whole, not fragment to empty — an ASCII-only split deflated the
+    # pre-filter and could report a real multilingual block UNJUDGEABLE.
+    assert "gebühr" in tokenize("Berechne die Gebühr")   # not {'geb', 'hr'}
+    cyrillic = tokenize("проверить адрес электронной почты")
+    assert cyrillic                                      # non-empty, not fragmented below the floor
+    assert "адрес" in cyrillic
+
+
+def test_single_surviving_run_is_unmeasurable_for_both_accuracy_and_consistency() -> None:
+    # when only one run survives (others crashed), BOTH accuracy and consistency are
+    # unmeasurable → None. Scoring the lone survivor for accuracy would let a transient crash flip an
+    # excluded tie into a hit/miss, so the case feeds neither denominator (symmetric gate).
+    calls = {"n": 0}
+
+    def mostly_down(_request: sem.SemanticRequest) -> SemanticReply:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return SemanticReply("wrong")               # exactly one real verdict
+        raise RuntimeError("down")
+
+    cal = calibrate([(_pairing("s", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    mostly_down, runs=3)
+    assert cal.excluded == []                           # a real verdict was produced → in per_case
+    assert cal.accuracy is None                         # one survivor → accuracy unmeasurable
+    assert cal.consistency is None                      # one survivor → consistency unmeasurable
+    assert cal.per_case[0]["runs_effective"] == 1
+    assert cal.per_case[0]["matched"] is None
+    assert cal.per_case[0]["consistency"] is None
+
+
+def test_majority_tie_break_is_canonical_not_first_seen() -> None:
+    # ties resolve by sorted verdict name (covered < partial < wrong), independent of run
+    # order — a regression to the sibling judge's first-seen tie-break would pass every other test.
+    assert sem._majority(["wrong", "covered"]) == ("covered", 1)
+    assert sem._majority(["covered", "wrong"]) == ("covered", 1)
+    assert sem._majority(["wrong", "partial"]) == ("partial", 1)
+
+
+def test_overlap_below_code_token_floor_is_none() -> None:
+    # the CODE side of the token floor is exercised directly — below-floor code is unjudgeable
+    # (None), not a judged weak link. Deleting the code-side guard would otherwise pass every test.
+    assert overlap_score("a b", _REQUIREMENT) is None   # 0 domain tokens on the code side
+    assert overlap_score("", _REQUIREMENT) is None
+
+
+# --- deep-review round 4 (F1 escape-aware strip, F2 gold-independent tie) ---
+
+def test_escaped_quote_string_literal_does_not_leak_requirement_text() -> None:
+    # A string literal that OPENS with an escaped quote and restates the requirement must be fully
+    # stripped from the overlap view, not leak its words into code_tokens. _code_views blanks each
+    # STRING token wholesale via the grammar-aware tokenizer, so an escaped internal quote is a
+    # non-issue (it is one token) — where the old escape-aware regex could have ended the literal early.
+    leaky = ('def compute_tax(amount):\n'
+             '    ERR = "\\"validate the user email address format and reject a malformed address\\""\n'
+             '    return amount * lookup_rate(amount)')
+    score = overlap_score(leaky, _REQUIREMENT)
+    assert score is not None
+    assert score < sem._WEAK_LINK_THRESHOLD            # requirement words stripped, not leaked
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("leaky", leaky, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == ["leaky"]                      # judged, not presumed_covered
+    assert report.presumed_covered == 0
+
+
+def test_strict_tie_is_gold_independent_and_excluded_from_accuracy() -> None:
+    # a strict tie (no majority) must not be scored by the gold label's alphabetical rank. It is
+    # excluded from accuracy (matched=None) — the SAME result whether gold is 'wrong' or 'covered' —
+    # while its low consistency is still reported. Previously a 1-1 tie was a forced miss on 'wrong'.
+    calls = {"n": 0}
+
+    def split(_request: sem.SemanticRequest) -> SemanticReply:
+        calls["n"] += 1
+        return SemanticReply("covered" if calls["n"] % 2 else "wrong")   # covered, wrong → 1-1 tie
+
+    cal_wrong = calibrate([(_pairing("t", _CORRECT_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                          split, runs=2)
+    assert cal_wrong.accuracy is None                  # no majority → unmeasurable, not a miss
+    assert cal_wrong.consistency == 0.5                # 1 of 2 agreed → reported honestly
+    assert cal_wrong.per_case[0]["matched"] is None
+    cal_covered = calibrate([(_pairing("t", _CORRECT_CODE, _REQUIREMENT), sem.SemanticGold("covered"))],
+                            split, runs=2)
+    assert cal_covered.accuracy is None                # identical result — gold label does not decide
+
+
+# --- property-based invariants (seed-deterministic; generated inputs the examples never picked) ---
+
+# Deliberately mixes ASCII, snake/camelCase, non-ASCII (Gebühr, Cyrillic), and the noise that
+# _code_views must survive: comments, plain strings, and escaped-quote string literals.
+_VOCAB = ["validate", "email", "address", "reject", "malformed", "save", "record", "compute",
+          "tax", "amount", "rate", "lookup", "user", "format", "checkUser", "reject_all",
+          "Gebühr", "проверить", "адрес"]
+
+
+def _rand_words(rng: random.Random, n: int) -> str:
+    return " ".join(rng.choice(_VOCAB) for _ in range(n))
+
+
+def _rand_code(rng: random.Random) -> str:
+    """Generate a code-like block: statements, comments, plain + escaped-quote string literals,
+    docstrings, and blanks — the shapes _code_views and tokenize must handle without raising."""
+    lines = ["def f():"]
+    for _ in range(rng.randint(0, 7)):
+        kind = rng.randint(0, 4)
+        if kind == 0:
+            lines.append(f"    {rng.choice(_VOCAB)}_{rng.choice(_VOCAB)} = {rng.randint(0, 9)}")
+        elif kind == 1:
+            lines.append(f"    # {_rand_words(rng, rng.randint(1, 5))}")
+        elif kind == 2:
+            quote = rng.choice(['"', "'"])
+            esc = rng.choice(["", "\\" + quote])         # sometimes open with an escaped quote
+            lines.append(f"    ERR = {quote}{esc}{_rand_words(rng, rng.randint(1, 4))}{esc}{quote}")
+        elif kind == 3:
+            lines.append(f'    """{_rand_words(rng, rng.randint(1, 4))}"""')
+        else:
+            lines.append("")
+    return "\n".join(lines)
+
+
+def _raises(_request: sem.SemanticRequest) -> SemanticReply:
+    raise ValueError("model down")
+
+
+class _HostileReply:
+    """A reply whose attribute access itself raises — the fail-safe boundary must absorb it."""
+
+    @property
+    def verdict(self) -> str:
+        raise RuntimeError("lazy parse failed")
+
+
+def _judges(rng: random.Random) -> List[Optional[Callable[[sem.SemanticRequest], object]]]:
+    """The full spread of judge behaviours a host might supply — none may make assess/calibrate raise."""
+    verdicts = [sem.SEM_COVERED, sem.SEM_PARTIAL, sem.SEM_WRONG, "maybe", ""]
+    return [None, reference_stub_judge, _SpyJudge(), _raises,
+            lambda _r: _HostileReply(),
+            lambda _r: SemanticReply(rng.choice(verdicts))]
+
+
+def test_property_overlap_score_is_bounded_or_none() -> None:
+    rng = random.Random(1234)
+    for _ in range(400):
+        score = overlap_score(_rand_code(rng), _rand_words(rng, rng.randint(0, 8)))
+        assert score is None or (isinstance(score, float) and 0.0 <= score <= 1.0)
+
+
+def test_property_tokenize_drops_short_and_stopwords_and_is_deterministic() -> None:
+    rng = random.Random(5678)
+    for _ in range(400):
+        text = _rand_code(rng) if rng.random() < 0.5 else _rand_words(rng, rng.randint(0, 10))
+        tokens = tokenize(text)
+        assert tokens == tokenize(text)                          # deterministic
+        assert all(len(t) > 1 and t not in sem._STOPWORDS for t in tokens)
+
+
+def test_property_assess_never_raises_and_accounting_identity_holds() -> None:
+    rng = random.Random(9012)
+    for _ in range(300):
+        n = rng.randint(0, 6)
+        pairings = [
+            Pairing(block_id=f"b{i}", inst=f"inst-{i}", path=f"p{rng.randint(0, 3)}.py",
+                    start_line=rng.randint(1, 99), code=_rand_code(rng),
+                    requirement=(None if rng.random() < 0.2 else _rand_words(rng, rng.randint(0, 8))))
+            for i in range(n)]
+        paths = [p.path for p in pairings]
+        report = {"excluded": [{"path": p} for p in paths if rng.random() < 0.25],
+                  "whole_file_claims": [{"path": p} for p in paths if rng.random() < 0.25]}
+        judge = rng.choice(_judges(rng))
+        result = assess(pairings, judge_fn=judge, report=report)   # must not raise
+        assert (result.assessed + result.presumed_covered
+                + len(result.unjudgeable) + result.skipped_excluded) == n
+        assert all(f.verdict in sem._MODEL_VERDICTS for f in result.findings)
+
+
+def test_property_calibrate_never_raises_and_metrics_are_bounded() -> None:
+    rng = random.Random(3456)
+    for _ in range(300):
+        cases = [
+            (Pairing(block_id=f"c{i}", inst=f"inst-{i}", path="m.py", start_line=i + 1,
+                     code=_rand_code(rng),
+                     requirement=(None if rng.random() < 0.2 else _rand_words(rng, rng.randint(0, 8)))),
+             sem.SemanticGold(rng.choice([sem.SEM_COVERED, sem.SEM_PARTIAL, sem.SEM_WRONG])))
+            for i in range(rng.randint(0, 4))]
+        judge = rng.choice([j for j in _judges(rng) if j is not None])
+        cal = calibrate(cases, judge, runs=rng.randint(1, 4))       # must not raise
+        for metric in (cal.accuracy, cal.consistency):
+            assert metric is None or 0.0 <= metric <= 1.0
+        assert len(cal.covered) == len(cases)
+
+
+# --- deep-review round 5 (ainetx: evidence-strip, forced, precedence, gap start_line, path norm) ---
+
+def test_evidence_quote_matching_only_a_comment_is_not_evidence() -> None:
+    # the hallucination guard strips comments/strings like overlap_score, so a quote
+    # that occurs only in a comment (not executable code) sets evidence_ok=False.
+    code = ('def compute_tax(amount):\n'
+            '    # validate the user email address and reject malformed input\n'
+            '    result = lookup_rate(amount)\n'
+            '    return result * amount')
+    spy = _SpyJudge(verdict=sem.SEM_WRONG, quote="validate the user email address")
+    report = assess([_pairing("masked", code, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == ["masked"]                       # judged (low overlap on executable tokens)
+    assert report.findings[0].evidence_ok is False       # quote lived only in the comment
+
+
+def test_whole_file_claim_finding_is_marked_forced() -> None:
+    # a judgment forced by a whole_file_claim carries forced=True; an ordinary
+    # weak-link judgment carries forced=False, so a report consumer can tell them apart.
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("claim", _CORRECT_CODE, _REQUIREMENT, path="claim.py"),
+                     _pairing("weak", _WRONG_CODE, _REQUIREMENT, path="plain.py")],
+                    judge_fn=spy, report={"whole_file_claims": [{"path": "claim.py"}]})
+    by_id = {f.block_id: f for f in report.findings}
+    assert by_id["claim"].forced is True
+    assert by_id["weak"].forced is False
+
+
+def test_excluded_takes_precedence_over_whole_file_claims() -> None:
+    # a path in BOTH excluded and whole_file_claims is dropped (exclusion is the
+    # human override, applied before ranking).
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("both", _WRONG_CODE, _REQUIREMENT, path="both.py")],
+                    judge_fn=spy,
+                    report={"excluded": [{"path": "both.py"}],
+                            "whole_file_claims": [{"path": "both.py"}]})
+    assert spy.calls == []                    # never judged — excluded wins
+    assert report.skipped_excluded == 1
+
+
+def test_unjudgeable_gap_is_typed_and_carries_start_line() -> None:
+    # a coverage gap is a typed SemanticGap with start_line, located like a finding.
+    report = assess([_pairing("noreq", _WRONG_CODE, None, start_line=42)], judge_fn=_SpyJudge())
+    gap = report.unjudgeable[0]
+    assert isinstance(gap, sem.SemanticGap)
+    assert (gap.block_id, gap.start_line) == ("noreq", 42)
+
+
+def test_scope_paths_match_across_separator_style() -> None:
+    # a report path in Windows separators matches a pairing path in POSIX separators;
+    # scope comparison is separator-normalised.
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("x", _WRONG_CODE, _REQUIREMENT, path="pkg/mod.py")],
+                    judge_fn=spy, report={"excluded": [{"path": "pkg\\mod.py"}]})
+    assert report.skipped_excluded == 1       # matched despite backslash vs forward-slash
+
+
+# --- deep-review round 5b (ainetx: gold-log, schema version, judge id, boundaries, formula/oracle) ---
+
+def test_missing_gold_file_is_logged(tmp_path: Path, caplog) -> None:
+    # a missing gold file (the common misconfiguration) is logged, not silently None.
+    import logging
+    with caplog.at_level(logging.WARNING):
+        assert load_gold(tmp_path / "nope.toml") is None
+    assert any("gold file not found" in r.message for r in caplog.records)
+
+
+def test_report_and_calibration_carry_schema_version() -> None:
+    # the consumed report shapes carry a schema-version discriminator.
+    report = assess([_pairing("w", _WRONG_CODE, _REQUIREMENT)], judge_fn=_SpyJudge())
+    assert report.schema_version == sem.SEMANTIC_SCHEMA_VERSION
+    cal = calibrate([(_pairing("w", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    reference_stub_judge, runs=3)
+    assert cal.schema_version == sem.SEMANTIC_SCHEMA_VERSION
+
+
+def test_calibration_records_runs_and_judge_identity() -> None:
+    # runs_per_scenario is asserted, and the calibration records
+    # which judge produced it.
+    cal = calibrate([(_pairing("w", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    reference_stub_judge, runs=3)
+    assert cal.runs_per_scenario == 3
+    assert cal.judge == "reference_stub_judge"
+
+
+def test_weak_link_threshold_boundary_is_strong_not_weak() -> None:
+    # a block scoring EXACTLY the threshold (0.30) is strong (score < threshold is
+    # strict), so it is presumed-covered, not judged.
+    req = "alpha beta gamma delta epsilon zeta eta theta iota kappa"    # 10 domain tokens
+    code = "alpha beta gamma lorem ipsum dolor"                          # shares exactly 3 → 0.30
+    assert overlap_score(code, req) == 0.30
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("edge", code, req)], judge_fn=spy)
+    assert spy.calls == []                     # not a weak link at the exact boundary
+    assert report.presumed_covered == 1
+
+
+def test_min_tokens_floor_boundary_and_distinct_reasons() -> None:
+    # exactly _MIN_TOKENS (4) is sufficient; 3 is below the floor (None). And the
+    # "below floor" gap reason stays distinct from the "no requirement" gap reason.
+    assert overlap_score("alpha beta gamma delta", "alpha beta gamma delta") is not None  # 4 tokens
+    assert overlap_score("alpha beta gamma", "alpha beta gamma") is None                  # 3 tokens
+    reason_noreq = assess([_pairing("nr", _WRONG_CODE, None)]).unjudgeable[0].reason
+    reason_floor = assess([_pairing("tf", "a b", "c d")]).unjudgeable[0].reason
+    assert reason_noreq != reason_floor
+    assert "requirement" in reason_noreq
+    assert "floor" in reason_floor
+
+
+# --- deep-review round 5c (review pass: strip-policy split + calibration symmetry) ---
+
+def test_evidence_quote_of_a_real_string_literal_is_accepted() -> None:
+    # a quote of an inline string literal the code executes (an error message) IS evidence
+    # — evidence_present strips comments/docstrings but keeps string-literal contents.
+    code = ('def compute_tax(amount):\n'
+            '    if amount < 0:\n'
+            '        raise ValueError("amount must be positive")\n'
+            '    return amount * lookup_rate(amount)')
+    spy = _SpyJudge(verdict=sem.SEM_WRONG, quote='raise ValueError("amount must be positive")')
+    report = assess([_pairing("s", code, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == ["s"]                              # low overlap → judged
+    assert report.findings[0].evidence_ok is True         # real string quote survives the strip
+
+
+def test_reference_stub_grounds_its_quote_on_executable_code() -> None:
+    # on a block whose COMMENT echoes the requirement, the stub picks an executable line
+    # (not the comment), so its own evidence_ok is True — it keeps its "verifiable quote" promise.
+    code = ('def compute_tax(amount):\n'
+            '    # validate the user email address and reject malformed input before saving\n'
+            '    return compute(amount)')
+    req = sem.build_semantic_request(sem.Ranked(_pairing("c", code, _REQUIREMENT), 0.1, True, "x"))
+    reply = reference_stub_judge(req)
+    assert evidence_present(code, reply.evidence_quote) is True   # quote is real code, guard accepts
+    assert "validate" not in reply.evidence_quote                 # not the requirement-echoing comment
+
+
+def test_transient_crash_does_not_flip_accuracy_via_lone_survivor() -> None:
+    # a 1-1 tie is excluded from accuracy (None); if a transient crash drops it to a single
+    # survivor, accuracy must STILL be None — not flip to a hit/miss by which run happened to crash.
+    tie_calls = {"n": 0}
+
+    def split(_r: sem.SemanticRequest) -> SemanticReply:
+        tie_calls["n"] += 1
+        return SemanticReply("wrong" if tie_calls["n"] % 2 else "partial")
+
+    tie = calibrate([(_pairing("t", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    split, runs=2)
+    assert tie.accuracy is None                     # 1-1 tie → excluded from accuracy
+
+    crash_calls = {"n": 0}
+
+    def split_crash(_r: sem.SemanticRequest) -> SemanticReply:
+        crash_calls["n"] += 1
+        if crash_calls["n"] == 1:
+            return SemanticReply("partial")
+        raise RuntimeError("down")
+
+    lone = calibrate([(_pairing("t", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                     split_crash, runs=2)
+    assert lone.accuracy is None                    # lone survivor → still unmeasurable, no flip
+
+
+# --- deep-review round 6 (grammar-aware lexing: docstring-leak, #-in-string, runs=1 accuracy) ---
+
+def test_triple_quote_inside_comment_does_not_leak_docstring_into_overlap() -> None:
+    # a stray triple-quote inside a comment must NOT mis-pair with a real docstring and
+    # leak its requirement-echoing body into overlap. The wrong block stays a weak link (judged), not
+    # a false presumed_covered; a docstring-only quote is not evidence. (The old regex strip leaked.)
+    code = ('def compute_tax(amount):\n'
+            '    # prefer """ here\n'
+            '    """Validate the user email address format and reject a malformed address before saving."""\n'
+            '    return amount * lookup_rate(amount)')
+    assert overlap_score(code, _REQUIREMENT) < sem._WEAK_LINK_THRESHOLD   # docstring did NOT leak
+    spy = _SpyJudge(sem.SEM_WRONG, quote="Validate the user email address format")
+    report = assess([_pairing("leak", code, _REQUIREMENT)], judge_fn=spy)
+    assert report.presumed_covered == 0                # judged, not waved through as covered
+    assert report.findings[0].evidence_ok is False     # docstring-only quote is not evidence
+
+
+def test_hash_inside_a_string_literal_does_not_truncate_evidence() -> None:
+    # a '#' inside a kept string literal must not be read as a comment and truncate the
+    # evidence haystack — a verbatim quote of that string is still valid evidence.
+    code = ('def pick_color(kind):\n'
+            '    if kind < 0:\n'
+            '        raise ValueError("bad #tag for color #FF0000")\n'
+            '    return compute(kind)')
+    spy = _SpyJudge(sem.SEM_WRONG, quote='raise ValueError("bad #tag for color #FF0000")')
+    report = assess([_pairing("c", code, _REQUIREMENT)], judge_fn=spy)
+    assert report.findings[0].evidence_ok is True      # the #-bearing string survived the strip
+
+
+def test_calibrate_runs_one_scores_accuracy() -> None:
+    # runs=1 is a supported input; a single clean verdict has a trivial majority and DOES
+    # score accuracy (consistency stays None — repeatability is unmeasurable with one run).
+    cal = calibrate([(_pairing("w", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                    reference_stub_judge, runs=1)
+    assert cal.accuracy == 1.0        # the one clean verdict matched gold
+    assert cal.consistency is None    # one run → repeatability unmeasurable
+
+
+def test_untokenizable_fragment_falls_back_without_raising() -> None:
+    # a mid-file fragment that won't tokenize (an unterminated string) must not
+    # raise — overlap falls back to a comment strip, evidence to raw code. Advisory and safe.
+    fragment = 'x = "unterminated\n    y = compute(the_user_email_address)  # note'
+    score = overlap_score(fragment, _REQUIREMENT)         # must not raise
+    assert score is None or (isinstance(score, float) and 0.0 <= score <= 1.0)
+    assert evidence_present(fragment, "y = compute(the_user_email_address)") is True  # raw fallback
+
+
+# --- deep-review round 7 (line-offset table must match the tokenizer's \n-only line splitting) ---
+
+def test_line_boundary_char_does_not_desync_evidence_view() -> None:
+    # the offset table feeds the evidence view; a docstring after a form-feed page
+    # break must still be blanked (str.splitlines() breaks on \x0c but the tokenizer does not, so a
+    # mismatched table would leave the docstring un-blanked and accept a docstring-only quote).
+    code = ('def compute_tax(amount):\n'
+            '\x0c\n'                                    # a form-feed page break (PEP 8 convention)
+            '    """validate the user email address and reject malformed input"""\n'
+            '    return amount * lookup_rate(amount)')
+    spy = _SpyJudge(sem.SEM_WRONG, quote="validate the user email address")
+    report = assess([_pairing("d", code, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == ["d"]                           # judged (docstring blanked → low overlap)
+    assert report.findings[0].evidence_ok is False      # docstring-only quote is not evidence
+
+
+def test_many_line_boundary_chars_do_not_leak_comment_into_overlap() -> None:
+    # enough boundary chars before a requirement-echoing comment would, under the old
+    # str.splitlines() table, desync spans and leak the comment into the overlap view → false
+    # presumed_covered. With the \n-matched table the comment stays blanked and the block is judged.
+    breaks = "\x0c\n" * 40
+    code = ('def compute_tax(amount):\n'
+            + breaks +
+            '    # validate the user email address format reject malformed address saving record\n'
+            '    return amount * lookup_rate(amount)')
+    assert overlap_score(code, _REQUIREMENT) < sem._WEAK_LINK_THRESHOLD   # comment did not leak
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("ff", code, _REQUIREMENT)], judge_fn=spy)
+    assert report.presumed_covered == 0                 # judged, not waved through
+
+
+def test_dedented_statement_leading_string_is_not_evidence() -> None:
+    # a statement-leading string after a DEDENT is a bare string statement (prose),
+    # not executable logic — _STATEMENT_START includes DEDENT so it is blanked from the evidence view,
+    # and a quote lifted only from it is not accepted as evidence.
+    code = ('def compute_tax(amount):\n'
+            '    total = amount * 2\n'
+            '"""validate the user email address and reject malformed input"""\n'
+            'result = total')
+    spy = _SpyJudge(sem.SEM_WRONG, quote="validate the user email address")
+    report = assess([_pairing("d", code, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == ["d"]                       # judged (all strings blanked from overlap)
+    assert report.findings[0].evidence_ok is False  # dedented bare string is not evidence
+
+
+def test_fstring_prose_does_not_inflate_overlap() -> None:
+    # PEP 701: on Python 3.12+ an f-string tokenizes to FSTRING_START/MIDDLE/END, not one STRING
+    # token. The literal text must still be blanked from overlap, so a requirement-echoing f-string
+    # cannot mask wrong code as presumed_covered.
+    code = ('def compute_tax(amount):\n'
+            '    log(f"validate the user email address and reject malformed address before saving")\n'
+            '    return amount * 2')
+    assert overlap_score(code, _REQUIREMENT) < sem._WEAK_LINK_THRESHOLD   # f-string prose blanked
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("f", code, _REQUIREMENT)], judge_fn=spy)
+    assert report.presumed_covered == 0            # judged, not waved through as covered
+
+
+def test_present_but_unreadable_gold_file_is_logged(tmp_path: Path, caplog) -> None:
+    # A gold file that exists but fails to parse (case B) is logged as unexpected, not silently None.
+    import logging
+    bad = tmp_path / "g.toml"
+    bad.write_text("not = valid = toml [[[", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="studio.utils.eval_semantic"):
+        assert load_gold(bad) is None
+    assert any("present but unreadable" in r.message for r in caplog.records)
+
+
+def test_calibrating_against_reference_stub_warns(caplog) -> None:
+    # The stub re-uses the pre-filter's own overlap; calibrating against it is warned at runtime so a
+    # caller who skipped the docstring still sees the numbers are not judge quality.
+    import logging
+    with caplog.at_level(logging.WARNING, logger="studio.utils.eval_semantic"):
+        calibrate([(_pairing("w", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("wrong"))],
+                  reference_stub_judge, runs=2)
+    assert any("reference_stub_judge" in r.message for r in caplog.records)
+
+
+def test_untokenizable_block_with_requirement_echoing_string_is_not_presumed_covered() -> None:
+    # A block that fails to tokenize (unterminated string) must not let a requirement-echoing STRING
+    # inflate overlap into a false presumed_covered — the fallback can't strip strings, so an
+    # unlexable block is unjudgeable (None), never presumed_covered.
+    frag = ('def compute_tax(amount):\n'
+            '    msg = "validate the user email address and reject a malformed address before saving\n'
+            '    return amount * 2')
+    assert overlap_score(frag, _REQUIREMENT) is None       # unlexable → unjudgeable, not inflated
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("frag", frag, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == []
+    assert report.presumed_covered == 0                    # never presumed covered
+    assert any(u.block_id == "frag" for u in report.unjudgeable)   # surfaced as a coverage gap
+
+
+def test_untokenizable_block_comment_quote_is_not_evidence() -> None:
+    # On the fallback path the evidence view is comment-stripped too, so a quote from a comment in an
+    # unlexable block is not accepted as evidence.
+    frag = 'x = "unterminated\n# validate the user email address\ny = 1'
+    assert evidence_present(frag, "validate the user email address") is False
+
+
+def test_gold_verdict_is_normalized_for_accuracy() -> None:
+    # A directly-built SemanticGold with mixed case/whitespace must not deflate accuracy — the gold
+    # side is normalized like the judge side.
+    cal = calibrate([(_pairing("w", _WRONG_CODE, _REQUIREMENT), sem.SemanticGold("  Wrong "))],
+                    reference_stub_judge, runs=2)
+    assert cal.accuracy == 1.0     # "  Wrong " matches the judge's normalized "wrong"
+
+
+def test_prompt_requirement_side_is_bounded() -> None:
+    # The requirement-side cap in build_semantic_request is exercised (the code-side test alone let a
+    # dropped requirement cap survive). A huge requirement must be truncated in the prompt.
+    huge_req = "email " * 5000
+    req = sem.build_semantic_request(sem.Ranked(_pairing("r", _WRONG_CODE, huge_req), 0.0, True, "x"))
+    assert len(req.prompt) < sem._PROMPT_FIELD_CAP * 3
+    assert "[…truncated]" in req.prompt
+    assert req.requirement == huge_req            # the structured field stays full
+
+
+def test_identifier_gaming_blind_spot_is_presumed_covered_not_judged() -> None:
+    # Pin the acknowledged blind spot as a visible contract: a block whose executable identifiers echo
+    # the requirement pushes overlap ABOVE threshold, so it is presumed_covered and never judged — a
+    # semantic model, not this lexical filter, would be needed to catch it.
+    gamed = ('def f(x):\n'
+             '    validate = user = email = address = format = reject = malformed = record = x\n'
+             '    return x')
+    assert overlap_score(gamed, _REQUIREMENT) >= sem._WEAK_LINK_THRESHOLD   # identifiers inflate it
+    spy = _SpyJudge(sem.SEM_WRONG)
+    report = assess([_pairing("gamed", gamed, _REQUIREMENT)], judge_fn=spy)
+    assert spy.calls == []                        # never judged — the blind spot
+    assert report.presumed_covered == 1

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -72,3 +72,41 @@ record_review  # noqa: B018
 record_escalation  # noqa: B018
 record_invocation  # noqa: B018
 summarize  # noqa: B018
+
+# eval_semantic public API — the semantic-coverage engine. Library + tests only for now;
+# the `cfs` surface and coverage-report integration are the follow-up, so these are not yet
+# reached from a production path. Exercised by tests.
+# See skills/studio/scripts/studio/utils/eval_semantic.py.
+from studio.utils.eval_semantic import (  # noqa: E402
+    reference_stub_judge,
+    assess,
+    resolve_requirement,
+    load_gold,
+    calibrate,
+    SemanticFinding,
+    SemanticGap,
+    SemanticReport,
+    SemanticCalibration,
+)
+
+reference_stub_judge  # noqa: B018
+assess  # noqa: B018
+resolve_requirement  # noqa: B018
+load_gold  # noqa: B018
+calibrate  # noqa: B018
+SemanticFinding.evidence_ok  # noqa: B018
+SemanticFinding.forced  # noqa: B018
+SemanticGap.block_id  # noqa: B018
+SemanticGap.path  # noqa: B018
+SemanticGap.start_line  # noqa: B018
+SemanticGap.reason  # noqa: B018
+SemanticReport.presumed_covered  # noqa: B018
+SemanticReport.skipped_excluded  # noqa: B018
+SemanticReport.schema_version  # noqa: B018
+SemanticCalibration.accuracy  # noqa: B018
+SemanticCalibration.consistency  # noqa: B018
+SemanticCalibration.runs_per_scenario  # noqa: B018
+SemanticCalibration.per_case  # noqa: B018
+SemanticCalibration.excluded  # noqa: B018
+SemanticCalibration.judge  # noqa: B018
+SemanticCalibration.schema_version  # noqa: B018


### PR DESCRIPTION
## What

Adds an **advisory semantic-coverage engine** (`utils/eval_semantic.py`). Structural `spec-coverage` scores marker *density* — a file can read 100% covered while the code inside its markers does the wrong thing. This engine adds the layer density can't reach: **does a marked block implement the requirement it cites?**

## How

- **Rank first, judge last.** A deterministic, stdlib-only token-overlap pre-filter scores every marked block against its requirement text and surfaces the *weak links* (low overlap). Only those go to a model, so a large repo triggers zero model calls per block. The pre-filter is a *budget heuristic*, not a correctness oracle — a strong-overlap `presumed_covered` block buys itself out of a model call, it is never evidence the block is correct (lexical overlap is gameable; comments/string literals are stripped before scoring so prose echoing the requirement can't inflate it).
- **Seam, not transport.** The model call is a pluggable `SemanticJudgeFn` supplied out-of-tree; with none wired, every weak link is `unjudgeable` (never a false verdict) and nothing gates. This module contains no model client.
- **Advisory, never gates.** A verdict here never touches an exit code.
- **Honest coverage.** Blocks with no retrievable requirement, or too little text to compare, are reported `unjudgeable` — never a silent "covered". Every block is accounted for exactly once: `assessed + presumed_covered + unjudgeable + skipped_excluded`. Each verdict carries an evidence check (a quote absent from the code sets `evidence_ok=false`).
- **Scoped by the coverage-report contract.** Files a human declared `excluded` are skipped; `whole_file_claims` files are always judged regardless of overlap — that's where a green structural number most plausibly hides wrong code.
- **Optional calibration** over gold-labelled pairings reports the judge's accuracy + run-to-run consistency, honestly excluding unscoreable / crashed / no-majority (tie) cases and reporting effective sample size rather than deflating or inflating the metric.

## Tests & gates

- New tests span unit, adversarial (wrong code surfaced; comment- and escaped-quote-literal masking; non-ASCII/Cyrillic), fail-safe (a judge that raises, and a reply object whose attribute access itself raises), honest-accounting, calibration integrity, and **property-based invariants** — seed-deterministic generated inputs asserting overlap stays in `[0,1]∪{None}`, the accounting identity always holds, `tokenize` never emits short/stopword tokens, and `assess`/`calibrate` never raise.
- `cfs validate` PASS (CPT markers 1:1) · `spec-coverage` thresholds met · `pylint` · `vulture-ci` · **100% line coverage** on the new module; full suite green.

## Scope

Library + tests. The coverage-report field integration and the `cfs` command surface are the follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added semantic coverage assessment for marked code blocks against cited requirements.
  - Weak matches can receive advisory coverage verdicts and rationales.
  - Added evidence-quote verification and honest `unjudgeable` reporting.
  - Added support for excluded items and whole-file claims.
  - Added calibration tools to measure assessment accuracy and consistency.

- **Documentation**
  - Documented the semantic coverage workflow and acceptance criteria.

- **Tests**
  - Added comprehensive coverage for scoring, judging, evidence validation, error handling, scoping, and calibration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->