### PR TITLE
codebase: three commands walk a registry entry three ways — resolve them all through one exclusion policy

### DIFF
--- a/architecture/features/traceability-validation.md
+++ b/architecture/features/traceability-validation.md
@@ -188,6 +188,8 @@ Catches structural and traceability issues that AI agents miss or hallucinate â€
 
 **Supporting**:
 - [x] - `p1` - Imports and module setup for query commands (list-ids, where-defined, where-used) - `inst-query-imports`
+- [x] - `p1` - Resolve the code files one registered codebase entry covers, applying the shared exclusion policy and returning how many candidates were excluded - `inst-query-resolve-entry-files`
+- [x] - `p1` - Refuse a candidate that is a symlink or resolves outside the project root, so a link cannot re-open an excluded tree - `inst-query-escapes-project`
 - [x] - `p1` - Argument parsing, context resolution, and artifact collection for query commands - `inst-query-resolve`
 - [x] - `p1` - Deduplicate scan hits per ID, preferring a definition record and surfacing conflicting duplicate definitions - `inst-scan-dedupe`
 - [x] - `p1` - Human-friendly formatters for list-ids, where-defined, and where-used output - `inst-query-format`

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -11,9 +11,10 @@ import argparse
 import json
 import logging
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 from ..utils import decision_log
+from ..utils.codebase import resolve_entry_code_files
 from ..utils.coverage import (
     FileCoverage,
     calculate_metrics,
@@ -104,7 +105,16 @@ def _collect_codebase_files(
     system_node: object,
     project_root: Path,
     code_files_to_scan: List[Path],
-) -> None:
+) -> int:
+    """Collect this node's code files, returning how many candidates were excluded.
+
+    The count is returned rather than dropped because switching to the shared
+    policy changes the population the coverage percentage is computed over: a
+    registered root holding a vendored subtree contributes fewer files than it
+    used to. A metric whose denominator moves has to say so, or a percentage
+    change looks like the code changed.
+    """
+    excluded = 0
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-collect-codebase-files
     for cb_entry in getattr(system_node, "codebase", []):
         path_str = (
@@ -118,17 +128,20 @@ def _collect_codebase_files(
             else cb_entry.get("extensions", None)
         ) or [".py"]
         code_path = _resolve_code_path(project_root, path_str)
-        if not code_path.exists():
-            continue
-        if code_path.is_file():
-            code_files_to_scan.append(code_path)
-            continue
-        for ext in extensions:
-            code_files_to_scan.extend(code_path.rglob(f"*{ext}"))
+        # Resolved through the shared policy rather than a bare rglob, so this
+        # command and `validate` cannot disagree about which files one entry
+        # covers -- and so a registered parent root does not re-admit the
+        # vendored trees that registration itself refuses.
+        entry_files, entry_excluded = resolve_entry_code_files(
+            code_path, extensions, project_root=project_root
+        )
+        excluded += entry_excluded
+        code_files_to_scan.extend(entry_files)
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-collect-codebase-files
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-collect-codebase-files
     for child in getattr(system_node, "children", []):
-        _collect_codebase_files(child, project_root, code_files_to_scan)
+        excluded += _collect_codebase_files(child, project_root, code_files_to_scan)
+    return excluded
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-collect-codebase-files
 
 
@@ -148,24 +161,29 @@ def _validate_selected_systems(args, meta) -> tuple[set[str] | None, dict | None
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-validate-systems
 
 
-def _collect_selected_system_files(meta, project_root: Path, system_slugs: set[str] | None) -> List[Path]:
+def _collect_selected_system_files(
+    meta, project_root: Path, system_slugs: set[str] | None
+) -> Tuple[List[Path], int]:
+    """Files the selected systems register, and how many candidates were excluded."""
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-resolve-code-files
     code_files_to_scan: List[Path] = []
+    excluded = 0
 
     def visit(node: object) -> None:
+        nonlocal excluded
         if system_slugs is None:
-            _collect_codebase_files(node, project_root, code_files_to_scan)
+            excluded += _collect_codebase_files(node, project_root, code_files_to_scan)
             return
         slug = getattr(node, "slug", "")
         if slug in system_slugs:
-            _collect_codebase_files(node, project_root, code_files_to_scan)
+            excluded += _collect_codebase_files(node, project_root, code_files_to_scan)
             return
         for child in getattr(node, "children", []):
             visit(child)
 
     for system_node in meta.systems:
         visit(system_node)
-    return code_files_to_scan
+    return code_files_to_scan, excluded
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-resolve-code-files
 
 
@@ -392,11 +410,10 @@ def _generate_spec_coverage_report(args, meta, project_root: Path) -> tuple[dict
     if system_slugs == set():
         return {}, 2
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-validate-systems
-    filtered_files = _filter_ignored_files(
-        _collect_selected_system_files(meta, project_root, system_slugs),
-        project_root,
-        meta,
+    collected_files, files_excluded = _collect_selected_system_files(
+        meta, project_root, system_slugs
     )
+    filtered_files = _filter_ignored_files(collected_files, project_root, meta)
     # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
     if not filtered_files:
         requested = _requested_thresholds(args)
@@ -408,6 +425,9 @@ def _generate_spec_coverage_report(args, meta, project_root: Path) -> tuple[dict
     file_coverages = _scan_file_coverages(filtered_files)
     report = calculate_metrics(file_coverages)
     json_report = generate_report(report, verbose=args.verbose, project_root=project_root)
+    # The population this percentage is computed over, so a shift in it is
+    # attributable rather than looking like a change in the code.
+    json_report["summary"]["files_excluded"] = files_excluded
     status = _apply_thresholds(report, args, project_root, json_report)
     # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-covered
     if status == "PASS" and report.covered_lines > 0:
@@ -562,7 +582,9 @@ def _human_spec_coverage(data: dict) -> None:
         ui.blank()
 
     summary = data.get("summary", {})
-    ui.detail("Files", f"{summary.get('covered_files', 0)}/{summary.get('total_files', 0)} covered")
+    files_line = f"{summary.get('covered_files', 0)}/{summary.get('total_files', 0)} covered"
+    excluded = summary.get("files_excluded") or 0
+    ui.detail("Files", f"{files_line} ({excluded} excluded)" if excluded else files_line)
     ui.detail("Coverage", f"{summary.get('coverage_pct', 0):.1f}%")
     ui.detail("Granularity", f"{summary.get('granularity_score', 0):.4f}")
 

--- a/skills/studio/scripts/studio/commands/validate.py
+++ b/skills/studio/scripts/studio/commands/validate.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 from ..utils import decision_log
 from ..utils import error_codes as EC
-from ..utils.codebase import CodeFile, cross_validate_code, error as code_issue
+from ..utils.codebase import CodeFile, cross_validate_code, error as code_issue, resolve_entry_code_files
 from ..utils.constraints import (
     ArtifactRecord,
     cross_validate_artifacts,
@@ -42,6 +42,9 @@ class _ValidateSession:
     known_kinds: Set[str]
     ctx_errors: List[Dict[str, object]]
     artifacts_to_validate: List[Tuple[Path, Path, str, str, str]] = field(default_factory=list)
+    # Reported alongside the scanned count: a file total without the number
+    # excluded does not say whether the scope was what the reader assumed.
+    code_files_excluded: int = 0
 
 
 @dataclass
@@ -826,14 +829,21 @@ def _resolve_code_scan_targets(session: _ValidateSession, entry: object) -> List
         code_path = (session.project_root / _codebase_entry_path(entry)).resolve()
     if code_path is None or not code_path.exists():
         return []
-    if code_path.is_file():
-        return [code_path]
+    # No early return for a single file: that bypassed the shared resolver
+    # entirely, so a file entry was judged by this command and by the policy
+    # differently -- which is the disagreement this resolver exists to end.
     extensions = (
         getattr(entry, "extensions", None)
         if not isinstance(entry, dict)
         else entry.get("extensions", None)
     ) or [".py"]
-    return [candidate for ext in extensions for candidate in code_path.rglob(f"*{ext}")]
+    # Resolved through the shared policy rather than a bare rglob: a registered
+    # parent root otherwise re-admits the vendored and generated trees that
+    # registration itself refuses, and this command's file count then disagrees
+    # with every other consumer of the same entry.
+    files, excluded = resolve_entry_code_files(code_path, extensions, project_root=session.project_root)
+    session.code_files_excluded += excluded
+    return files
     # @cpt-end:cpt-studio-flow-traceability-validation-validate:p1:inst-validate-code-scan
 
 
@@ -1168,6 +1178,9 @@ def _emit_final_validate_report(session: _ValidateSession, results: _ValidateRes
     }
     if not session.args.skip_code and not session.args.artifact:
         report["code_files_scanned"] = len(results.code_files_scanned)
+        # A scanned total without the number excluded does not say whether
+        # the scope was the one the reader assumed.
+        report["code_files_excluded"] = session.code_files_excluded
         report["to_code_ids_total"] = len(results.to_code_ids)
         report["code_ids_found"] = len(results.code_ids_found)
         if results.to_code_ids:
@@ -1505,7 +1518,9 @@ def _human_validate(data: dict) -> None:
     ui.detail("Warnings", str(n_warn))
 
     if data.get("code_files_scanned") is not None:
-        ui.detail("Code files", str(data["code_files_scanned"]))
+        excluded = data.get("code_files_excluded") or 0
+        scanned = str(data["code_files_scanned"])
+        ui.detail("Code files", f"{scanned} ({excluded} excluded)" if excluded else scanned)
     if data.get("coverage"):
         ui.detail("Code coverage", str(data["coverage"]))
 

--- a/skills/studio/scripts/studio/utils/codebase.py
+++ b/skills/studio/scripts/studio/utils/codebase.py
@@ -660,22 +660,100 @@ def _is_in_default_ignored_dir(file_path: Path, root: Path) -> bool:
     return any(part in _DEFAULT_IGNORED_DIR_NAMES for part in rel_parts[:-1])
 
 
-def _code_paths_for_entry(code_path: Path, extensions: List[str]) -> List[Path]:
-    """Return code files covered by one registry codebase entry, sorted for determinism."""
+# @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-query-load-context
+
+
+# @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-query-resolve-entry-files
+def resolve_entry_code_files(
+    code_path: Path,
+    extensions: List[str],
+    *,
+    project_root: Path,
+) -> Tuple[List[Path], int]:
+    """Code files one registry codebase entry covers, and how many were excluded.
+
+    Every consumer of a codebase entry resolves it through here, so that a
+    directory the policy excludes cannot be skipped by one command and scanned
+    by another. Three rules apply:
+
+    * conventional non-source directory names, at any depth -- a registered
+      parent root otherwise re-admits the `vendor/` and `dist/` trees that
+      registration itself refuses;
+    * symlinked candidates, so one link cannot re-open an excluded tree or reach
+      outside the project under a name that looks local;
+    * resolved containment, because a symlinked *directory* escapes the project
+      by a different route than a symlinked file.
+
+    The excluded count is returned rather than logged so the caller can report
+    its own denominator: "scanned N, excluded M" is checkable where a bare file
+    count is not.
+    """
+    root = project_root.resolve()
     if not code_path.exists():
-        return []
+        return [], 0
+    # The entry itself is judged before anything is read, so a `../..` entry is
+    # refused rather than walked and then discarded file by file. Checking only
+    # the candidates meant an external tree was traversed first, and every file
+    # in it counted separately toward a total describing this project.
+    #
+    # This also covers the single-file case, which previously returned the path
+    # unconditionally: an entry resolving to a file outside the project was
+    # refused by `list-ids` and read by `validate` and `spec-coverage`.
+    if _escapes_project(code_path, root):
+        return [], 1
     if code_path.is_file():
-        return [code_path]
+        return [code_path], 0
 
-    files: List[Path] = []
+    # Candidates are collected before they are judged, so each one is decided
+    # once. Judging inside the extension loop counted a single excluded file
+    # once per matching extension, which made the excluded total disagree with
+    # the file list it is meant to be the denominator of.
+    candidates: Set[Path] = set()
     for ext in extensions:
-        for candidate in code_path.rglob(f"*{ext}"):
-            if _is_in_default_ignored_dir(candidate, code_path):
-                continue
-            files.append(candidate)
-    return sorted(files, key=str)
+        candidates.update(code_path.rglob(f"*{ext}"))
+
+    files: Set[Path] = set()
+    excluded = 0
+    for candidate in candidates:
+        if _is_in_default_ignored_dir(candidate, code_path):
+            excluded += 1
+            continue
+        if _escapes_project(candidate, root):
+            excluded += 1
+            continue
+        files.add(candidate)
+    return sorted(files, key=str), excluded
 
 
+# @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-query-resolve-entry-files
+
+
+# @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-query-escapes-project
+def _escapes_project(candidate: Path, root: Path) -> bool:
+    """Whether *candidate* is a symlink or resolves outside *root*.
+
+    Checked on the resolved path: refusing symlinked files alone still lets a
+    symlinked directory inside a registered root carry the scan outside the
+    project.
+    """
+    try:
+        if candidate.is_symlink():
+            return True
+        resolved = candidate.resolve()
+    except OSError as exc:
+        _warn_codebase(f"failed to resolve {candidate}: {exc}")
+        return True
+    if resolved == root:
+        return False
+    return root not in resolved.parents
+
+
+
+
+# @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-query-escapes-project
+
+
+# @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-query-load-context
 def _is_ignored_code_file(file_path: Path, ctx) -> bool:
     """Return whether *file_path* is registry-ignored and should be skipped.
 
@@ -752,7 +830,13 @@ def _scan_codebase_entries(scan_ctx) -> Tuple[List[Dict[str, object]], int, int]
         except ValueError:
             _warn_codebase(f"codebase entry {cb_entry.path!r} resolves outside {root}; skipping")
             continue
-        for file_path in _code_paths_for_entry(code_path, cb_entry.extensions or [".py"]):
+        entry_files, entry_excluded = resolve_entry_code_files(
+            code_path, cb_entry.extensions or [".py"], project_root=root
+        )
+        # Counted as skipped: that total already means "ignored, oversized, or
+        # unparsable", and a policy exclusion is the first of those.
+        skipped += entry_excluded
+        for file_path in entry_files:
             file_hits = _scan_code_file_references(file_path, scan_ctx)
             if file_hits is None:
                 skipped += 1

--- a/tests/test_cli_py_coverage.py
+++ b/tests/test_cli_py_coverage.py
@@ -1388,10 +1388,14 @@ class TestCLIPyCoverageValidateBranches(unittest.TestCase):
                 return set()
 
         with TemporaryDirectory() as td1:
-            with TemporaryDirectory() as td2:
+            with TemporaryDirectory() as _td2:
                 root = Path(td1)
-                outside = Path(td2)
-                code_file = outside / "x.py"
+                # Inside the project: a codebase entry resolving outside the
+                # project root is now refused by the shared scan policy, so an
+                # external path would exercise the refusal rather than the
+                # code-scan failure branch this test is about.
+                (root / "src").mkdir(parents=True, exist_ok=True)
+                code_file = root / "src" / "x.py"
                 code_file.write_text("print('x')\n", encoding="utf-8")
 
                 (root / "kits" / "x" / "artifacts" / "REQ").mkdir(parents=True, exist_ok=True)

--- a/tests/test_codebase.py
+++ b/tests/test_codebase.py
@@ -78,7 +78,11 @@ class TestScanRegisteredCodebaseReferences:
         hits, code_files_scanned, code_files_skipped = scan_registered_codebase_references(ctx)
 
         assert code_files_scanned == 0
-        assert code_files_skipped == 0
+        # Counted, not silent. `skipped` means "ignored, oversized, or
+        # unparsable", and an excluded vendored file is the first of those --
+        # reporting 0 scanned and 0 skipped would say there was nothing here
+        # when in fact there was a file the policy declined to scan.
+        assert code_files_skipped == 1
         assert hits == []
 
     def test_oversized_file_is_skipped_not_read(self, tmp_path: Path, monkeypatch):
@@ -117,17 +121,18 @@ class TestScanRegisteredCodebaseReferences:
         assert code_files_scanned == 0
         assert hits == []
 
-    def test_code_paths_for_entry_is_sorted_for_determinism(self, tmp_path: Path):
-        from studio.utils.codebase import _code_paths_for_entry
+    def test_entry_code_files_are_sorted_for_determinism(self, tmp_path: Path):
+        from studio.utils.codebase import resolve_entry_code_files
 
         code_dir = tmp_path / "src"
         code_dir.mkdir()
         for name in ("zeta.py", "alpha.py", "mid.py"):
             (code_dir / name).write_text("pass\n")
 
-        paths = _code_paths_for_entry(code_dir, [".py"])
+        paths, excluded = resolve_entry_code_files(code_dir, [".py"], project_root=tmp_path)
 
         assert [p.name for p in paths] == ["alpha.py", "mid.py", "zeta.py"]
+        assert excluded == 0
 
     def test_ignored_code_file_fails_closed_when_containment_cannot_be_established(self, tmp_path: Path):
         from studio.utils.codebase import _is_ignored_code_file

--- a/tests/test_shared_scan_policy.py
+++ b/tests/test_shared_scan_policy.py
@@ -1,0 +1,323 @@
+"""One policy decides which files a codebase entry covers.
+
+`init` writes `codebase` entries and no `ignore` patterns, so in a fresh project
+the only thing standing between a registered root and its vendored or generated
+subdirectories is the default exclusion policy. That policy lived in
+`utils/codebase.py` and was applied by one of the three consumers of a registry
+entry: `list-ids`/`where-used` honoured it, while `validate` and `spec-coverage`
+globbed the entry directly. The same entry therefore covered different files
+depending on which command read it.
+
+These tests pin the shared resolver so the three cannot drift apart again.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scripts"))
+
+from studio.utils.codebase import resolve_entry_code_files
+
+
+def _tree(root: Path, files: list[str]) -> None:
+    for rel in files:
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("x = 1\n", encoding="utf-8")
+
+
+def _names(files: list[Path], root: Path) -> list[str]:
+    return sorted(f.relative_to(root).as_posix() for f in files)
+
+
+class TestExcludedDirectoriesStayExcluded:
+    def test_a_registered_parent_does_not_re_admit_vendored_code(self):
+        """The case a bare rglob gets wrong.
+
+        Registration refuses `vendor/` and `node_modules/`, but it registers the
+        shallowest parent -- so scanning that parent recursively pulled the
+        refused trees back in, and traceability then demanded markers in
+        third-party code.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _tree(root, [
+                "src/main.py",
+                "src/vendor/dependency.py",
+                "src/node_modules/pkg/index.py",
+                "src/dist/bundle.py",
+                "src/__pycache__/main.py",
+            ])
+
+            files, excluded = resolve_entry_code_files(
+                root / "src", [".py"], project_root=root
+            )
+
+        assert _names(files, root) == ["src/main.py"]
+        assert excluded == 4, "the count is the denominator; a bare total hides the scope"
+
+    def test_nothing_excluded_is_reported_as_nothing_excluded(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _tree(root, ["src/a.py", "src/pkg/b.py"])
+
+            files, excluded = resolve_entry_code_files(
+                root / "src", [".py"], project_root=root
+            )
+
+        assert _names(files, root) == ["src/a.py", "src/pkg/b.py"]
+        assert excluded == 0
+
+
+class TestNothingOutsideTheProjectIsScanned:
+    def test_a_symlinked_source_file_is_refused(self):
+        with TemporaryDirectory() as outside_dir, TemporaryDirectory() as tmpdir:
+            outside = Path(outside_dir)
+            _tree(outside, ["secret.py"])
+            root = Path(tmpdir)
+            _tree(root, ["src/main.py"])
+            (root / "src" / "linked.py").symlink_to(outside / "secret.py")
+
+            files, excluded = resolve_entry_code_files(
+                root / "src", [".py"], project_root=root
+            )
+
+        assert _names(files, root) == ["src/main.py"]
+        assert excluded == 1
+
+    def test_a_symlinked_directory_does_not_bring_in_an_external_tree(self):
+        """Pins the outcome, which is currently guaranteed twice over.
+
+        `rglob`'s `**` does not descend into symlinked directories (verified on
+        3.11), so the external file is never yielded and the containment check
+        never sees it -- hence `excluded == 0` rather than 1. The check is kept
+        as defence in depth: it covers the routes the traversal does yield, and
+        it does not depend on that traversal behaviour staying the same across
+        the Python versions this project supports.
+        """
+        with TemporaryDirectory() as outside_dir, TemporaryDirectory() as tmpdir:
+            outside = Path(outside_dir)
+            _tree(outside, ["secret.py"])
+            root = Path(tmpdir)
+            _tree(root, ["src/main.py"])
+            (root / "src" / "linked").symlink_to(outside, target_is_directory=True)
+
+            files, excluded = resolve_entry_code_files(
+                root / "src", [".py"], project_root=root
+            )
+
+        assert _names(files, root) == ["src/main.py"]
+        assert excluded == 0
+
+    def test_a_symlink_pointing_back_inside_the_project_is_still_refused(self):
+        """Containment is necessary but not sufficient: a link is still a duplicate.
+
+        Following it would scan the same file twice under two names and count
+        its lines twice in coverage.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _tree(root, ["src/main.py"])
+            (root / "src" / "alias.py").symlink_to(root / "src" / "main.py")
+
+            files, excluded = resolve_entry_code_files(
+                root / "src", [".py"], project_root=root
+            )
+
+        assert _names(files, root) == ["src/main.py"]
+        assert excluded == 1
+
+
+class TestTheResolverIsPredictable:
+    def test_an_entry_naming_a_single_file_resolves_to_it(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _tree(root, ["src/main.py"])
+
+            files, excluded = resolve_entry_code_files(
+                root / "src" / "main.py", [".py"], project_root=root
+            )
+
+        assert _names(files, root) == ["src/main.py"]
+        assert excluded == 0
+
+    def test_a_single_file_entry_outside_the_project_is_refused(self):
+        """The rules apply to the single-file branch too.
+
+        Returning the path unconditionally left this case enforced only by a
+        pre-check on the query path, so an entry resolving outside the project
+        was refused by `list-ids` and read by `validate` and `spec-coverage`.
+        """
+        with TemporaryDirectory() as outside_dir, TemporaryDirectory() as tmpdir:
+            outside = Path(outside_dir)
+            _tree(outside, ["secret.py"])
+            root = Path(tmpdir)
+            root.mkdir(exist_ok=True)
+
+            files, excluded = resolve_entry_code_files(
+                outside / "secret.py", [".py"], project_root=root
+            )
+
+        assert files == []
+        assert excluded == 1
+
+    def test_an_escaping_directory_entry_is_refused_without_being_walked(self):
+        """The entry is judged before anything is read.
+
+        Checking only the candidates meant an external tree was traversed
+        first and every file in it counted separately toward a total that is
+        supposed to describe this project. `rglob` is patched to fail so the
+        test proves traversal never starts, not merely that the result is empty.
+        """
+        from unittest.mock import patch
+
+        with TemporaryDirectory() as outside_dir, TemporaryDirectory() as tmpdir:
+            outside = Path(outside_dir)
+            _tree(outside, ["a.py", "nested/b.py"])
+            root = Path(tmpdir)
+
+            def refuse(self, pattern):
+                raise AssertionError(f"traversal started on {self}")
+
+            with patch.object(Path, "rglob", refuse):
+                files, excluded = resolve_entry_code_files(
+                    outside, [".py"], project_root=root
+                )
+
+        assert files == []
+        assert excluded == 1, "the refused entry counts once, not once per file inside it"
+
+    def test_a_missing_entry_resolves_to_nothing(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            assert resolve_entry_code_files(root / "gone", [".py"], project_root=root) == ([], 0)
+
+    def test_overlapping_extensions_do_not_double_count(self):
+        """Two globs matching one file must yield it once, and count it once.
+
+        The file list was deduplicated and the excluded total was not, so the
+        denominator disagreed with the list it describes.
+        """
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _tree(root, ["src/main.py", "src/vendor/dep.py"])
+
+            once = resolve_entry_code_files(root / "src", [".py"], project_root=root)
+            twice = resolve_entry_code_files(root / "src", [".py", ".py"], project_root=root)
+
+        assert _names(once[0], root) == ["src/main.py"]
+        assert once == twice, "repeating an extension must change neither list nor count"
+        assert twice[1] == 1, "one excluded file counted once"
+
+    def test_repeated_runs_agree_exactly(self):
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _tree(root, ["src/a.py", "src/b.py", "src/pkg/c.py", "src/vendor/d.py"])
+
+            results = {
+                repr(resolve_entry_code_files(root / "src", [".py"], project_root=root))
+                for _ in range(5)
+            }
+
+        assert len(results) == 1
+
+
+class TestTheCommandsAgreeOnOneEntry:
+    """The property this convergence exists to guarantee, asserted directly.
+
+    The resolver's own tests pin its behaviour, but they cannot catch the two
+    call sites drifting -- one passing different extensions or a different
+    project root, or post-processing the result differently. This drives both
+    call sites over one fixture and compares the file sets.
+    """
+
+    def test_validate_and_spec_coverage_select_the_same_files(self):
+        from unittest.mock import MagicMock
+
+        from studio.commands.spec_coverage import _collect_codebase_files
+        from studio.commands.validate import _resolve_code_scan_targets
+
+        with TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            _tree(root, [
+                "src/main.py",
+                "src/pkg/mod.py",
+                "src/vendor/dependency.py",
+                "src/node_modules/pkg/index.py",
+                "src/dist/bundle.py",
+            ])
+            (root / "src" / "linked.py").symlink_to(root / "src" / "main.py")
+
+            entry = MagicMock()
+            entry.path = "src"
+            entry.extensions = [".py"]
+            entry.source = None
+
+            session = MagicMock()
+            session.project_root = root
+            session.ws_ctx = None
+            session.code_files_excluded = 0
+            validate_files = {p.resolve() for p in _resolve_code_scan_targets(session, entry)}
+
+            node = MagicMock()
+            node.codebase = [entry]
+            node.children = []
+            collected: list = []
+            _collect_codebase_files(node, root, collected)
+            coverage_files = {p.resolve() for p in collected}
+
+        assert validate_files == coverage_files, (
+            "the two commands must select the same files for one registry entry"
+        )
+        assert {p.name for p in validate_files} == {"main.py", "mod.py"}, (
+            "and the shared policy must actually be in force in both"
+        )
+
+    def test_validate_and_spec_coverage_agree_on_a_single_file_entry(self):
+        """A file entry has to go through the resolver in both commands.
+
+        `validate` used to return the path before ever calling the resolver, so
+        a file entry was the one shape where the two commands could still
+        disagree -- and an external file was read by one and refused by the
+        other.
+        """
+        from unittest.mock import MagicMock
+
+        from studio.commands.spec_coverage import _collect_codebase_files
+        from studio.commands.validate import _resolve_code_scan_targets
+
+        with TemporaryDirectory() as outside_dir, TemporaryDirectory() as tmpdir:
+            outside = Path(outside_dir)
+            _tree(outside, ["secret.py"])
+            root = Path(tmpdir)
+            _tree(root, ["src/main.py"])
+
+            for label, rel in (("inside", "src/main.py"), ("outside", os.path.relpath(outside / "secret.py", root))):
+                entry = MagicMock()
+                entry.path = rel
+                entry.extensions = [".py"]
+                entry.source = None
+
+                session = MagicMock()
+                session.project_root = root
+                session.ws_ctx = None
+                session.code_files_excluded = 0
+                validate_files = {p.resolve() for p in _resolve_code_scan_targets(session, entry)}
+
+                node = MagicMock()
+                node.codebase = [entry]
+                node.children = []
+                collected: list = []
+                _collect_codebase_files(node, root, collected)
+                coverage_files = {p.resolve() for p in collected}
+
+                assert validate_files == coverage_files, f"{label} file entry: commands disagree"
+                if label == "outside":
+                    assert validate_files == set(), "an external file entry must be refused"
+                else:
+                    assert {p.name for p in validate_files} == {"main.py"}


### PR DESCRIPTION
Closes #100.

**What.** One resolver for "which files does this codebase entry cover", used by `validate`, `spec-coverage` and `list-ids`/`where-used`. Reports how many candidates it excluded. No threshold changes, no metric changes.

**Why.** Three consumers read the same registry entry and each walked it differently. Only `list-ids`/`where-used` applied `_DEFAULT_IGNORED_DIR_NAMES`; `validate` and `spec-coverage` globbed the entry directly:

```python
return [candidate for ext in extensions for candidate in code_path.rglob(f"*{ext}")]
```

So `vendor/`, `dist/`, `node_modules/` and `__pycache__` beneath a registered root were third-party code to one command and project source to the other two. Registration refuses those directory names and then registers their shallowest parent — scanning that parent recursively puts them straight back.

**Where it bites: a fresh project, not this one.** `cfs init` writes **no `ignore` patterns at all**. So a newly initialised repository has codebase entries and zero exclusions, and vendored code under a registered root was scanned by `validate` and `spec-coverage`, which then demanded `@cpt` markers in third-party files. This repository is unaffected only because its registry hand-lists `skills/studio/scripts/studio/vendor/**` — the two files that pattern covers are now excluded by policy *and counted*, where before they were dropped silently.

**How.** `resolve_entry_code_files()` applies three rules:

| Rule | Why it is separate |
|---|---|
| Conventional non-source directory names, at any depth | The registered parent otherwise re-admits the trees registration refuses |
| Symlinked candidates refused | A link re-opens an excluded tree, and scanning the same file under two names double-counts its lines |
| Resolved containment | A symlinked *directory* leaves the project by a different route than a symlinked file |

It returns `(files, excluded_count)`, and callers report the count: `validate` now prints `Code files: 93 (2 excluded)` and emits `code_files_excluded` in JSON. A scanned total on its own does not say whether the scope was the one the reader assumed.

**Behaviour change worth calling out.** Policy exclusions are counted as *skipped* in `scan_registered_codebase_references` instead of being filtered invisibly. That total is already documented as "ignored, oversized, or unparsable", and an excluded file is the first of those. This also settles an inconsistency the existing tests had encoded — the fail-closed containment path counted its file while the ignored-directory path did not, so `scanned=0, skipped=0` could mean either "nothing here" or "one file we declined to scan". Consequence: `where-used` and `list-ids` will report a non-zero skipped count on projects with vendored code under a registered root.

`_code_paths_for_entry` is removed — it became a wrapper with no callers, and its determinism test now exercises the resolver directly.

**Tests.** New `tests/test_shared_scan_policy.py`: a registered parent not re-admitting `vendor/`/`node_modules/`/`dist/`/`__pycache__` with the excluded count asserted, symlinked files refused, a symlink pointing back *inside* the project still refused because following it double-counts, a single-file entry, a missing entry, overlapping extensions not double-counting, and determinism across repeated runs. Both rules are mutation-checked: removing the ignored-directory rule fails the vendored-code test, removing the symlink/containment rule fails the two symlink tests.

One case is pinned rather than claimed: `rglob`'s `**` does not descend into symlinked directories on the supported versions, so an external tree reached that way is already absent and the containment check never sees it — asserted as `excluded == 0` with the reason stated. The check stays as defence in depth so the guarantee does not rest on that traversal behaviour.

**Gates.** `make test` 4719 passed / 4 skipped / 15 xfailed / 58 subtests · `pylint` clean · `vulture-ci` clean · `cfs validate` **0 errors 0 warnings, 221/221** · `validate-toc` correct · per-file line coverage ≥90%.

**This repository's verdict does not move.** `spec-coverage --system studio --min-coverage 90 --min-file-coverage 60 --min-granularity 0.46` reports 90.4% coverage and granularity 0.4606, all thresholds met, unchanged from `main` apart from the new excluded count. A policy change that altered the existing result would be a behaviour change in disguise, so it is asserted rather than assumed.

No new dependencies; stdlib only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Code scanning and spec coverage now consistently exclude vendored, generated, cached, and symlinked files.
  * Symlinks resolving outside the project or into excluded directories are no longer scanned.
  * Validation and coverage reports now accurately count and display excluded files, including single-file entries.

* **Tests**
  * Added coverage for exclusions, symlinks, single-file entries, overlapping extensions, repeatability, and consistent scanning results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->