### PR TITLE
ci: run the enforcement gate corpus as its own check, so the red direction is visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,29 @@ jobs:
       - name: Run tests
         run: make test
 
+  # Surfaces the enforcement corpus as its own check. The `test` job already
+  # runs these assertions, but a green suite of ~4,700 tests is not evidence
+  # that a gate can fail -- and a gate that never fails is worthless. This job
+  # makes the red direction visible in the pipeline: known-bad fixtures must be
+  # rejected, known-good fixtures must stay clean.
+  gates:
+    name: Enforcement Gates (seeded violations must fail)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: make install
+
+      - name: Known-bad must be red, known-good must stay green
+        run: make test-gates
+
   coverage:
     name: Coverage (≥90%)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,17 @@ jobs:
   gates:
     name: Enforcement Gates (seeded violations must fail)
     runs-on: ubuntu-latest
+    permissions:
+      # This job runs pull-request code (`make install`, `make test-gates`), so
+      # it gets the least privilege that still lets it check out and read.
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Keep the job token out of .git/config so the test corpus this job
+          # executes cannot read it back. The initial fetch is unaffected.
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ help:
 	@echo ""
 	@echo "Available targets:"
 	@echo "  make test                          - Run all tests in parallel (-n 6)"
+	@echo "  make test-gates                    - Run the enforcement gate corpus (seeded violations must fail)"
 	@echo "  make test-verbose                  - Run tests with verbose output"
 	@echo "  make test-quick                    - Run fast tests only (skip slow integration tests)"
 	@echo "  make test-coverage                 - Run tests with coverage report"
@@ -148,6 +149,14 @@ check-pylint: check-pipx
 test: check-pytest
 	@echo "Running Constructor Studio tests with pipx..."
 	$(PYTEST_PIPX) tests/ -n 6 -v --tb=short
+
+# Runs the enforcement corpus on its own so the pipeline shows, as a named
+# check, that these gates fail on a seeded violation. The assertions already
+# live in the suite; a green `test` job does not evidence the red direction
+# unless you know the tests exist and go and read them.
+test-gates: check-pytest
+	@echo "Running enforcement gate corpus (known-bad must be red, known-good must be green)..."
+	$(PYTEST_PIPX) tests/test_enforcement_empty_codebase.py tests/test_enforcement_empty_scan.py -v --tb=short
 
 # Run tests with verbose output
 test-verbose: check-pytest


### PR DESCRIPTION
**What.** A `gates` CI job and a `make test-gates` target that run the two enforcement test files on their own. No new tests, no behaviour change, no new dependencies.

**Why.** The pipeline currently exercises these gates only in their passing direction. `ci.yml` has ten jobs — `test`, `coverage`, `sonarqube`, `pylint`, `vulture`, `versions`, `spec-coverage`, `validate`, `validate-kits` — and none of them asserts that a seeded violation is *rejected*. So a green run says the checks ran, not that they can fail.

That is this repository's own argument turned on its CI. #89 existed because a green exit did not mean the spec was implemented; the same reasoning applies to a green pipeline that never demonstrates a gate failing.

**The assertions already exist** — this is about visibility, not coverage. `tests/test_enforcement_empty_codebase.py` and `tests/test_enforcement_empty_scan.py` drive the real CLI and assert exit codes in both directions:

| Fixture | Expected |
|---|---|
| Registered codebase, one **unmarked** source file | exit 2, `code-no-marker` |
| Same claim, **zero** code files | exit 2 — scan size does not change the verdict |
| Correctly **marked** implementation | exit 0 |
| Spec-first project, nothing claimed, no code | exit 0 — nothing claimed, nothing owed |

Those run inside a suite of ~4,850 tests, so today the red direction is provable only by knowing the tests exist and going to read them. After this, the pipeline shows it as *"Enforcement Gates (seeded violations must fail)"*.

**Verified load-bearing rather than decorative.** Restoring the early return that cross-validation used to have — `if not results.parsed_code_files_full:` — makes **5 of the 39** fail. So the check catches the regression it exists to catch. Green on `main` as it stands.

**Scope.** Deliberately limited to the enforcement corpus. The semantic-coverage tests are advisory and currently have an interpreter-dependent failure of their own (#120), so including them would make this check red for a reason unrelated to enforcement — which would defeat the point of a named gate check.

**Non-goals.** Not making any check *required* — that is branch protection and not something a commit can do. Not adding a CLI-level negative fixture repo; the existing tests already drive the real CLI end-to-end, and a second mechanism would duplicate them.

**Gates.** The corpus itself: 39 passed. Repository unaffected, as expected for a Makefile/workflow-only change — `cfs validate` 0 errors 0 warnings, `spec-coverage --system studio` granularity 0.4612 with all thresholds met, `pylint` clean. Workflow YAML parses with the new job registered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a dedicated enforcement gate check for validating known-good and known-bad scenarios.
  * Added a separate CI pipeline check to report enforcement results independently from the main test suite.

* **Documentation**
  * Updated available development commands to include the new enforcement gate check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->