### PR TITLE
feat(spec-coverage): add an advisory `--semantic` coverage pass

### DIFF
--- a/architecture/features/spec-coverage.md
+++ b/architecture/features/spec-coverage.md
@@ -14,6 +14,7 @@
   - [Calculate Coverage Metrics](#calculate-coverage-metrics)
   - [Calculate Granularity Score](#calculate-granularity-score)
   - [Generate Coverage Report](#generate-coverage-report)
+  - [Assess Semantic Coverage (advisory)](#assess-semantic-coverage-advisory)
 - [4. States (CDSL)](#4-states-cdsl)
   - [Coverage Report Lifecycle](#coverage-report-lifecycle)
 - [5. Definitions of Done](#5-definitions-of-done)
@@ -72,7 +73,7 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 - No code files found → report with `applicable: false` naming how many registered entries resolved to no files, and 0% coverage
 
 **Steps**:
-1. [x] - `p1` - User invokes `cfs spec-coverage [--min-coverage N] [--min-file-coverage N] [--min-granularity N] [--min-file-granularity N] [--verbose]` - `inst-user-spec-coverage`
+1. [x] - `p1` - User invokes `cfs spec-coverage [--min-coverage N] [--min-file-coverage N] [--min-granularity N] [--min-file-granularity N] [--verbose] [--semantic]` - `inst-user-spec-coverage`
 2. [x] - `p1` - Load project context: studio config, registry, systems, codebase entries - `inst-load-context`
 3. [x] - `p1` - Resolve all code files from registered codebase entries - `inst-resolve-code-files`
 4. [x] - `p1` - **FOR EACH** code file, scan for `@cpt-*` markers using `cpt-studio-algo-spec-coverage-scan` - `inst-foreach-file`
@@ -97,6 +98,7 @@ Without spec coverage, teams have no visibility into which parts of the codebase
 - [x] - `p1` - Route JSON report to file or terminal UI - `inst-output-report`
 - [x] - `p1` - Format uncovered ranges and render human-friendly per-file/status sections - `inst-human-report-helpers`
 - [x] - `p1` - Name the files whose coverage rests on a whole-file scope marker, largest first, with their count and total claimed lines - `inst-human-report-claims`
+- [x] - `p1` - When `--semantic` is set, run the advisory semantic pass (`cpt-studio-algo-semantic-coverage-pass`) and attach its section to the report **after** status/exit are computed, so it can never gate - `inst-attach-semantic`
 
 ## 3. Processes / Business Logic (CDSL)
 
@@ -167,6 +169,23 @@ A file with good granularity has approximately 1 CDSL instruction (`@cpt-begin`/
 
 **Supporting**:
 - [x] - `p1` - Report function signature and relative path helper - `inst-report-datamodel`
+
+### Assess Semantic Coverage (advisory)
+
+- [x] `p1` - **ID**: `cpt-studio-algo-semantic-coverage-pass`
+
+**Input**: registered artifacts (for id→doc resolution), the scanned code files, the coverage report (for scope)
+
+**Output**: an advisory `semantic` report section — never affects status/exit. Success shape: `assessed` / `presumed_covered` / `unjudgeable[]` / `findings[]` / `skipped_excluded` / `schema_version` / `advisory`. If the pass raises, it degrades to `{advisory: true, error: <message>}` instead.
+
+**Steps**:
+1. [x] - `p1` - Build the id→declaring-artifact map from cpt definition hits across the registered artifacts - `inst-scov-defmap`
+2. [x] - `p1` - Build one pairing per marked block: code = the block's lines, requirement = the algo declaration resolved from the block's id (unjudgeable when unresolved) - `inst-scov-pairings`
+3. [x] - `p1` - Run the advisory engine (`assess`) over the pairings, passing the coverage report for scope, and serialise the result as the `semantic` section (`advisory: true`) - `inst-scov-run`
+4. [x] - `p1` - Render a one-line advisory human summary (counts + weak/wrong tally) - `inst-scov-summary`
+
+**Supporting**:
+- [x] - `p1` - Module imports and setup for the semantic-coverage pass - `inst-scov-imports`
 
 ## 4. States (CDSL)
 
@@ -240,6 +259,7 @@ The system **MUST** output a JSON report with: summary (total files, covered fil
 | Report Generator | `skills/.../utils/coverage.py` | JSON report assembly |
 | Codebase Utils | `skills/.../utils/codebase.py` | Existing code scanning infrastructure (reused) |
 | Language Config | `skills/.../utils/language_config.py` | Language-specific comment patterns (reused) |
+| Semantic Coverage Pass | `skills/.../utils/semantic_coverage.py` | Advisory: build pairings, run the semantic engine, serialise the `semantic` section (never gates) |
 
 ## 7. Acceptance Criteria
 

--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -75,6 +75,10 @@ def _build_spec_coverage_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--verbose", action="store_true", help="Include per-file marker details and covered ranges")
     parser.add_argument("--output", default=None, help="Write report to file instead of stdout")
+    parser.add_argument("--semantic", action="store_true",
+                        help="Attach the advisory semantic-coverage pass — assesses covered/partial/"
+                             "wrong/unjudgeable per marked block; never gates status/exit "
+                             "(see architecture/features/spec-coverage.md)")
     return parser
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-build-parser
 
@@ -402,6 +406,27 @@ def _load_spec_coverage_context():
     # @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-load-context
 
 
+# @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-attach-semantic
+def _attach_semantic_section(args, filtered_files, json_report) -> None:
+    """Attach the advisory semantic pass AFTER status/exit are set, so a verdict can never gate."""
+    if not getattr(args, "semantic", False):
+        return
+    try:
+        # Everything advisory lives inside the guard — imports, context resolution, and the pass
+        # itself — so NOTHING (an import failure included) can change the structural status/exit
+        # already computed above. A failure is recorded as an advisory error rather than crashing.
+        from ..utils.context import get_context
+        from ..utils.semantic_coverage import run_semantic_pass
+        ctx = get_context()
+        if ctx is None:
+            return
+        json_report["semantic"] = run_semantic_pass(ctx, filtered_files, json_report)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.warning("semantic pass failed (advisory, ignored): %s", exc)
+        json_report["semantic"] = {"advisory": True, "error": str(exc)}
+# @cpt-end:cpt-studio-flow-spec-coverage-report:p1:inst-attach-semantic
+
+
 def _generate_spec_coverage_report(args, meta, project_root: Path) -> tuple[dict, int]:
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-validate-systems
     system_slugs, validation_error = _validate_selected_systems(args, meta)
@@ -417,18 +442,20 @@ def _generate_spec_coverage_report(args, meta, project_root: Path) -> tuple[dict
     # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
     if not filtered_files:
         requested = _requested_thresholds(args)
-        empty = _empty_coverage_result(
-            _count_selected_codebase_entries(meta, system_slugs), requested
-        )
-        return empty, 2 if requested else 0
+        json_report = _empty_coverage_result(
+            _count_selected_codebase_entries(meta, system_slugs), requested)
+        # --semantic still attaches its (empty) advisory section here, so the flag's presence
+        # is consistent whether or not the codebase resolved to any files.
+        _attach_semantic_section(args, filtered_files, json_report)
+        return json_report, 2 if requested else 0
     # @cpt-end:cpt-studio-state-spec-coverage-report:p1:inst-state-uncovered
-    file_coverages = _scan_file_coverages(filtered_files)
-    report = calculate_metrics(file_coverages)
+    report = calculate_metrics(_scan_file_coverages(filtered_files))
     json_report = generate_report(report, verbose=args.verbose, project_root=project_root)
     # The population this percentage is computed over, so a shift in it is
     # attributable rather than looking like a change in the code.
     json_report["summary"]["files_excluded"] = files_excluded
     status = _apply_thresholds(report, args, project_root, json_report)
+    _attach_semantic_section(args, filtered_files, json_report)
     # @cpt-begin:cpt-studio-state-spec-coverage-report:p1:inst-state-covered
     if status == "PASS" and report.covered_lines > 0:
         return json_report, 0
@@ -587,6 +614,17 @@ def _human_spec_coverage(data: dict) -> None:
     ui.detail("Files", f"{files_line} ({excluded} excluded)" if excluded else files_line)
     ui.detail("Coverage", f"{summary.get('coverage_pct', 0):.1f}%")
     ui.detail("Granularity", f"{summary.get('granularity_score', 0):.4f}")
+
+    # Advisory semantic line — never part of the gate; only shown when --semantic ran.
+    semantic = data.get("semantic")
+    if semantic and semantic.get("error"):
+        # The advisory pass recorded a failure (possibly an import failure of semantic_coverage
+        # itself) — render it WITHOUT importing summary_line, which could re-raise here, after the
+        # structural status/exit are already set.
+        ui.info(f"semantic (advisory, never gates): pass errored, skipped — {semantic['error']}")
+    elif semantic:
+        from ..utils.semantic_coverage import summary_line
+        ui.info(summary_line(semantic))
 
     # Per-file details — files is a dict {path: entry_dict}
     files = data.get("files", {})

--- a/skills/studio/scripts/studio/utils/eval_semantic.py
+++ b/skills/studio/scripts/studio/utils/eval_semantic.py
@@ -18,7 +18,9 @@ code inside its markers does the wrong thing. This engine adds the layer density
   reported ``UNJUDGEABLE`` — never a silent "covered". The report states what it could not judge.
 * **Scoped by the frozen coverage contract.** Files a human declared ``excluded`` are skipped;
   files flagged ``whole_file_claims`` (scope-only) are prioritised — that is where a green
-  structural number most plausibly hides wrong code.
+  structural number most plausibly hides wrong code. This scoping activates once the coverage
+  producer emits those keys (tracked in #107); until then the scope is empty and every weak link is
+  judged — the safe default.
 
 @cpt-algo:cpt-studio-algo-eval-semantic:p1
 """
@@ -367,7 +369,10 @@ def build_semantic_request(ranked: Ranked) -> SemanticRequest:
         "advisory judgement; it never gates a build.\n\n"
         f"REQUIREMENT (id {pairing.block_id}):\n{_capped(requirement)}\n\n"
         f"CODE ({pairing.path}:{pairing.start_line}):\n{_capped(pairing.code)}\n\n"
-        "Answer with a verdict of 'covered', 'partial', or 'wrong', a one-line rationale, and an "
+        "Verdicts: 'covered' = the code fully implements the requirement; 'partial' = it implements "
+        "some of the requirement but omits or only partly satisfies part of it; 'wrong' = it "
+        "contradicts the requirement or implements something materially different.\n"
+        "Answer with one verdict ('covered', 'partial', or 'wrong'), a one-line rationale, and an "
         "evidence_quote copied verbatim from the CODE above that your verdict rests on.")
     return SemanticRequest(pairing.block_id, requirement, pairing.code, prompt)
 

--- a/skills/studio/scripts/studio/utils/semantic_coverage.py
+++ b/skills/studio/scripts/studio/utils/semantic_coverage.py
@@ -1,0 +1,149 @@
+"""Advisory semantic-coverage pass — wire the semantic engine into ``spec-coverage``.
+
+Structural ``spec-coverage`` scores marker *density*; the semantic engine
+(:mod:`studio.utils.eval_semantic`) asks the layer density cannot reach — *does a marked block
+implement the requirement it cites?* This module is the thin glue between them: it builds the
+engine's ``Pairing`` list from the real marked blocks and their resolved requirements, runs the
+advisory ``assess``, and serialises the result for the coverage report plus a one-line human summary.
+
+**Advisory, never gates.** Nothing here touches the coverage status or exit code — the caller
+attaches the returned section to the report *after* the structural gate is computed.
+
+Requirement granularity is **per-algo**, not per-instruction: a block marker's ``id`` is its algo id,
+and the feature-doc requirement text is scoped to that id (the instruction slug is not independently
+scoped in the doc format). Every block of an algo therefore pairs with the algo's declaration text;
+blocks whose code diverges from that vocabulary surface as weak links.
+
+@cpt-algo:cpt-studio-algo-semantic-coverage-pass:p1
+"""
+# @cpt-begin:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-imports
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+from .codebase import CodeFile
+from .context import collect_artifacts_to_scan
+from .document import scan_cpt_ids
+from . import eval_semantic
+
+logger = logging.getLogger(__name__)
+# @cpt-end:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-imports
+
+
+# @cpt-begin:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-defmap
+def _definition_map(ctx: object) -> Dict[str, Path]:
+    """Map every cpt **definition** id to its declaring artifact path.
+
+    This is the id→doc lookup the requirement side needs: a block cites an algo id, and the
+    requirement text lives in whichever artifact *defines* that id. Built from the registered
+    artifacts (``collect_artifacts_to_scan``); the first definition wins on the rare duplicate.
+    """
+    out: Dict[str, Path] = {}
+    artifacts, _sources = collect_artifacts_to_scan(ctx)
+    for artifact_path, _kind in artifacts:
+        for hit in scan_cpt_ids(artifact_path):
+            if hit.get("type") == "definition" and isinstance(hit.get("id"), str):
+                existing = out.get(hit["id"])
+                if existing is not None and existing != artifact_path:
+                    logger.warning("semantic: cpt id %s defined in both %s and %s; keeping the first",
+                                   hit["id"], existing, artifact_path)
+                out.setdefault(hit["id"], artifact_path)
+    return out
+# @cpt-end:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-defmap
+
+
+# @cpt-begin:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-pairings
+def _relative_posix(path: Path, project_root: Optional[Path]) -> str:
+    """A **project-relative POSIX** path, never absolute — so no local path leaks into the report or
+    the out-of-tree judge prompt. Degrades to a ``..``-relative path for a file outside the root,
+    then to the bare filename if even that is impossible (Windows cross-drive)."""
+    if project_root is None:
+        return path.as_posix()
+    root, resolved = Path(project_root).resolve(), path.resolve()
+    try:
+        return resolved.relative_to(root).as_posix()
+    except ValueError:
+        logger.debug("semantic: %s is outside project_root; using a relative path", path)
+    try:
+        return Path(os.path.relpath(resolved, root)).as_posix()
+    except ValueError:
+        return Path(path.name).as_posix()
+
+
+def _pairings_for_files(files: Sequence[Path], definitions: Dict[str, Path],
+                        project_root: Optional[Path] = None) -> List[eval_semantic.Pairing]:
+    """One ``Pairing`` per marked block: code = the block's own lines, requirement = the algo
+    declaration resolved from the block's id, or ``None`` (unjudgeable) when the id declares no
+    retrievable text. ``block_id`` is ``<algo>:<inst>`` so each block is individually identifiable
+    even though the requirement (and ``bm.id``) is shared across an algo's blocks.
+
+    ``path`` is emitted **project-relative POSIX** (see ``_relative_posix``) so it matches the
+    coverage report's own scope arrays — the code files arrive absolute, so without this the scope
+    reader would compare an absolute pairing path against a relative report path and never match."""
+    pairings: List[eval_semantic.Pairing] = []
+    for code_path in dict.fromkeys(files):        # dedup duplicate registrations, keep order
+        code_file, errs = CodeFile.from_path(code_path)
+        if code_file is None:
+            logger.warning("semantic: skipping unparseable file %s: %s", code_path, errs)
+            continue
+        path_posix = _relative_posix(code_file.path, project_root)
+        for block in code_file.block_markers:
+            doc = definitions.get(block.id)
+            requirement = eval_semantic.resolve_requirement(doc, block.id) if doc is not None else None
+            pairings.append(eval_semantic.Pairing(
+                block_id=f"{block.id}:{block.inst}",
+                inst=block.inst,
+                path=path_posix,
+                start_line=block.start_line,
+                code="\n".join(block.content),
+                requirement=requirement))
+    return pairings
+# @cpt-end:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-pairings
+
+
+# @cpt-begin:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-run
+def run_semantic_pass(ctx: object, files: Sequence[Path], coverage_report: Dict[str, object],
+                      judge_fn: Optional[eval_semantic.SemanticJudgeFn] = None) -> Dict[str, object]:
+    """Build pairings from the marked blocks, run the advisory engine, return the ``semantic`` section.
+
+    ``coverage_report`` is passed straight to ``assess`` for scoping (``excluded`` / ``whole_file_claims``,
+    tolerated absent → empty scope). With no ``judge_fn`` wired, weak links are ``unjudgeable`` and no
+    model is called. The returned dict is advisory on its face (``"advisory": True``) and is never read
+    by the coverage gate — the caller attaches it after the status/exit are set.
+    """
+    definitions = _definition_map(ctx)
+    pairings = _pairings_for_files(files, definitions, getattr(ctx, "project_root", None))
+    result = eval_semantic.assess(pairings, judge_fn=judge_fn, report=coverage_report)
+    return {
+        "assessed": result.assessed,
+        "presumed_covered": result.presumed_covered,
+        "unjudgeable": [{"block_id": gap.block_id, "path": gap.path,
+                         "start_line": gap.start_line, "reason": gap.reason}
+                        for gap in result.unjudgeable],
+        "findings": [{"block_id": finding.block_id, "path": finding.path,
+                      "start_line": finding.start_line, "verdict": finding.verdict,
+                      "rationale": finding.rationale, "evidence_ok": finding.evidence_ok,
+                      "forced": finding.forced}
+                     for finding in result.findings],
+        "skipped_excluded": result.skipped_excluded,
+        "schema_version": result.schema_version,
+        "advisory": True,
+    }
+# @cpt-end:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-run
+
+
+# @cpt-begin:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-summary
+def summary_line(semantic: Dict[str, object]) -> str:
+    """A one-line advisory human summary: counts + the weak/wrong finding tally, labelled advisory."""
+    if semantic.get("error"):
+        return f"semantic (advisory, never gates): pass errored, skipped — {semantic['error']}"
+    findings = semantic.get("findings") or []
+    weak = sum(1 for finding in findings
+               if finding.get("verdict") in (eval_semantic.SEM_WRONG, eval_semantic.SEM_PARTIAL))
+    return (f"semantic (advisory, never gates): {semantic.get('assessed', 0)} judged, "
+            f"{semantic.get('presumed_covered', 0)} presumed-covered, "
+            f"{len(semantic.get('unjudgeable') or [])} unjudgeable, {weak} weak/wrong")
+# @cpt-end:cpt-studio-algo-semantic-coverage-pass:p1:inst-scov-summary

--- a/tests/test_semantic_coverage.py
+++ b/tests/test_semantic_coverage.py
@@ -1,0 +1,337 @@
+"""Tests for the advisory semantic-coverage pass (utils.semantic_coverage) and its wiring into
+``spec-coverage``.
+
+The headline invariant: attaching a semantic section — even one carrying a ``wrong`` verdict — never
+changes the coverage status or exit code. The rest pin pairing construction, the no-judge default,
+honest serialisation, and scope consumption.
+"""
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scripts"))
+
+from studio.utils import semantic_coverage as sc
+from studio.utils import eval_semantic as sem
+from studio.commands.spec_coverage import cmd_spec_coverage
+from studio.utils.artifacts_meta import ArtifactsMeta, CodebaseEntry, Kit, SystemNode
+
+_ALGO = "cpt-studio-algo-fixture"
+_REQ = "validate the user email address format and reject a malformed address before saving the record"
+
+
+def _marked(tmp_path: Path, name: str = "mod.py") -> Path:
+    """A file with two blocks of one algo: a strong block whose identifiers echo the requirement, and
+    a weak block (compute_tax) with no overlap."""
+    p = tmp_path / name
+    p.write_text(
+        f"# @cpt-begin:{_ALGO}:p1:inst-strong\n"
+        "def validate_email_address_and_reject_malformed(record):\n"
+        "    return save_record(record)\n"
+        f"# @cpt-end:{_ALGO}:p1:inst-strong\n"
+        f"# @cpt-begin:{_ALGO}:p1:inst-weak\n"
+        "def compute_tax(amount):\n"
+        "    return amount * lookup_rate(amount)\n"
+        f"# @cpt-end:{_ALGO}:p1:inst-weak\n",
+        encoding="utf-8")
+    return p
+
+
+# --- pairing construction --------------------------------------------------
+
+def test_pairings_one_per_block_with_fields(tmp_path: Path) -> None:
+    pairings = sc._pairings_for_files([_marked(tmp_path)], {})
+    assert {p.block_id for p in pairings} == {f"{_ALGO}:strong", f"{_ALGO}:weak"}
+    weak = next(p for p in pairings if p.block_id.endswith(":weak"))
+    assert weak.inst == "weak"
+    assert weak.path.endswith("mod.py")
+    assert weak.start_line > 0
+    assert "compute_tax" in weak.code
+    assert weak.requirement is None            # empty definitions map → unresolved → unjudgeable
+
+
+def test_pairings_resolve_requirement_from_definitions(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(sem, "resolve_requirement", lambda doc, bid: _REQ if bid == _ALGO else None)
+    pairings = sc._pairings_for_files([_marked(tmp_path)], {_ALGO: tmp_path / "doc.md"})
+    assert all(p.requirement == _REQ for p in pairings)
+
+
+# --- run_semantic_pass -----------------------------------------------------
+
+def test_no_judge_default_reports_unjudgeable_not_zero(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(sc, "_definition_map", lambda ctx: {})   # no requirements resolve
+    section = sc.run_semantic_pass(None, [_marked(tmp_path)], {}, judge_fn=None)
+    assert section["advisory"] is True
+    assert section["assessed"] == 0
+    assert section["findings"] == []
+    assert len(section["unjudgeable"]) == 2                      # both blocks: no requirement
+
+
+def test_serialises_a_wrong_finding_with_the_full_shape(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(sc, "_definition_map", lambda ctx: {_ALGO: tmp_path / "doc.md"})
+    monkeypatch.setattr(sem, "resolve_requirement", lambda doc, bid: _REQ)
+    section = sc.run_semantic_pass(None, [_marked(tmp_path)], {},
+                                   judge_fn=lambda req: sem.SemanticReply(sem.SEM_WRONG, "r", ""))
+    assert section["advisory"] is True
+    assert sem.SEM_WRONG in [f["verdict"] for f in section["findings"]]
+    assert section["presumed_covered"] >= 1                     # the identifier-echoing block
+    assert set(section["findings"][0]) == {
+        "block_id", "path", "start_line", "verdict", "rationale", "evidence_ok", "forced"}
+
+
+def test_excluded_scope_is_honoured(tmp_path: Path, monkeypatch) -> None:
+    code = _marked(tmp_path)
+    monkeypatch.setattr(sc, "_definition_map", lambda ctx: {})
+    section = sc.run_semantic_pass(None, [code], {"excluded": [{"path": str(code)}]}, judge_fn=None)
+    assert section["skipped_excluded"] == 2                     # both blocks in the excluded file
+    assert section["unjudgeable"] == []
+
+
+def test_summary_line_renders_counts_and_is_labelled_advisory() -> None:
+    line = sc.summary_line({"assessed": 3, "presumed_covered": 5, "unjudgeable": [{}, {}],
+                            "findings": [{"verdict": "wrong"}, {"verdict": "partial"},
+                                         {"verdict": "covered"}]})
+    assert "advisory" in line
+    assert "3 judged" in line
+    assert "5 presumed-covered" in line
+    assert "2 unjudgeable" in line
+    assert "2 weak/wrong" in line
+
+
+# --- command wiring: the headline advisory-cannot-gate invariant ----------
+
+def _ctx(tmp_path: Path, code_path: Path) -> MagicMock:
+    meta = ArtifactsMeta(
+        version=1, project_root=".", kits={"test": Kit("test", "CFS", "kits/test")},
+        systems=[SystemNode(name="sys1", slug="sys1", kit="test", artifacts=[],
+                            codebase=[CodebaseEntry(path=code_path.name, extensions=[".py"])],
+                            children=[])])
+    ctx = MagicMock()
+    ctx.meta = meta
+    ctx.project_root = tmp_path
+    return ctx
+
+
+def _run(ctx: MagicMock, argv: list) -> tuple:
+    from studio.utils.ui import set_json_mode
+    set_json_mode(True)
+    with patch("studio.utils.context.get_context", return_value=ctx):
+        with patch("sys.stdout", new_callable=StringIO) as out:
+            code = cmd_spec_coverage(argv)
+    return code, json.loads(out.getvalue())
+
+
+def test_semantic_section_attaches_and_a_wrong_verdict_never_gates(tmp_path: Path) -> None:
+    code_path = _marked(tmp_path)
+    ctx = _ctx(tmp_path, code_path)
+    wrong_section = {"advisory": True, "assessed": 1, "presumed_covered": 0, "unjudgeable": [],
+                     "findings": [{"block_id": "x", "path": str(code_path), "start_line": 1,
+                                   "verdict": "wrong", "rationale": "r", "evidence_ok": False,
+                                   "forced": False}],
+                     "skipped_excluded": 0, "schema_version": 1}
+    with patch("studio.utils.semantic_coverage.run_semantic_pass", return_value=wrong_section):
+        code_sem, rep_sem = _run(ctx, ["--semantic"])
+    code_plain, rep_plain = _run(ctx, [])
+    # the section is attached and advisory, carrying the wrong verdict
+    assert rep_sem["semantic"]["advisory"] is True
+    assert rep_sem["semantic"]["findings"][0]["verdict"] == "wrong"
+    # …yet status and exit are byte-for-byte what they were without --semantic
+    assert code_sem == code_plain
+    assert rep_sem.get("status") == rep_plain.get("status")
+    assert "semantic" not in rep_plain
+
+
+def test_definition_map_built_from_artifact_definitions(tmp_path: Path, monkeypatch) -> None:
+    # _definition_map scans the registered artifacts for cpt DEFINITION ids and maps id -> doc path.
+    doc = tmp_path / "feature.md"
+    doc.write_text("### My Algo\n\n- [x] `p1` - **ID**: `cpt-studio-algo-fixture`\n\nRequirement text.\n",
+                   encoding="utf-8")
+    monkeypatch.setattr(sc, "collect_artifacts_to_scan", lambda ctx: ([(doc, "feature")], {}))
+    mapping = sc._definition_map(MagicMock())
+    assert mapping.get(_ALGO) == doc
+
+
+def test_pairings_skip_a_file_that_does_not_parse(tmp_path: Path) -> None:
+    # A file with an unbalanced marker fails CodeFile.from_path (None) and is skipped, not a crash.
+    bad = tmp_path / "bad.py"
+    bad.write_text(f"# @cpt-begin:{_ALGO}:p1:inst-orphan\ndef f():\n    return 1\n", encoding="utf-8")  # no @cpt-end
+    good = _marked(tmp_path)
+    pairings = sc._pairings_for_files([bad, good], {})
+    assert {p.path for p in pairings} == {str(good)}    # only the good file contributed blocks
+
+
+def test_semantic_summary_line_rendered_in_human_mode(tmp_path: Path, capsys) -> None:
+    # In non-JSON mode the advisory summary line is printed; restore json mode for sibling tests.
+    from studio.utils.ui import set_json_mode
+    code_path = _marked(tmp_path)
+    ctx = _ctx(tmp_path, code_path)
+    section = {"advisory": True, "assessed": 0, "presumed_covered": 1,
+               "unjudgeable": [{"block_id": "x"}], "findings": [], "skipped_excluded": 0,
+               "schema_version": 1}
+    set_json_mode(False)
+    try:
+        with patch("studio.utils.context.get_context", return_value=ctx):
+            with patch("studio.utils.semantic_coverage.run_semantic_pass", return_value=section):
+                cmd_spec_coverage(["--semantic"])
+        out = capsys.readouterr().out
+    finally:
+        set_json_mode(True)
+    assert "semantic (advisory, never gates)" in out
+
+
+def test_semantic_pass_that_raises_never_gates(tmp_path: Path) -> None:
+    # Fail-safe: an *exception* in the advisory pass (not just a wrong verdict) must leave the
+    # structural status/exit byte-for-byte unchanged — it is swallowed and recorded as an advisory
+    # error. Without exception isolation the crash would flip a computed PASS/exit-0 into a failure.
+    code_path = _marked(tmp_path)
+    ctx = _ctx(tmp_path, code_path)
+    with patch("studio.utils.semantic_coverage.run_semantic_pass",
+               side_effect=RuntimeError("boom")):
+        code_raise, rep_raise = _run(ctx, ["--semantic"])
+    code_plain, rep_plain = _run(ctx, [])
+    assert code_raise == code_plain
+    assert rep_raise.get("status") == rep_plain.get("status")
+    assert rep_raise["semantic"] == {"advisory": True, "error": "boom"}
+
+
+def test_summary_line_reports_an_advisory_error() -> None:
+    # The advisory-error section (attached when the pass raised) renders as an honest one-liner,
+    # not as "0 judged" which would read as a clean run.
+    line = sc.summary_line({"advisory": True, "error": "boom"})
+    assert "advisory" in line
+    assert "errored" in line
+    assert "boom" in line
+
+
+def test_pairings_paths_are_project_relative(tmp_path: Path) -> None:
+    # With a project_root, pairing paths are emitted project-relative POSIX so they match the
+    # coverage report's relative scope arrays (excluded / whole_file_claims) rather than being an
+    # unmatchable absolute path.
+    code = _marked(tmp_path)
+    pairings = sc._pairings_for_files([code], {}, project_root=tmp_path)
+    assert pairings
+    assert all(p.path == "mod.py" for p in pairings)
+
+
+def test_pairings_path_falls_back_when_outside_project_root(tmp_path: Path) -> None:
+    # A file that is not under project_root cannot be made relative — fall back to its own path
+    # rather than crashing, so the pass degrades instead of failing.
+    code = _marked(tmp_path)
+    other_root = tmp_path / "elsewhere"
+    other_root.mkdir()
+    pairings = sc._pairings_for_files([code], {}, project_root=other_root)
+    assert pairings
+    # relative (never absolute — no local path leaks into the report or judge prompt), ends at the file
+    assert all(not Path(p.path).is_absolute() for p in pairings)
+    assert all(p.path.endswith("mod.py") for p in pairings)
+
+
+def test_pairings_survive_a_relpath_failure(tmp_path: Path, monkeypatch) -> None:
+    # If os.path.relpath itself raises (Windows cross-drive), the file falls back to its bare name
+    # rather than the exception sinking the whole pairing loop for every file.
+    code = _marked(tmp_path)
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+
+    def _boom(*_a, **_k):
+        raise ValueError("cross-drive")
+
+    monkeypatch.setattr("os.path.relpath", _boom)
+    pairings = sc._pairings_for_files([code], {}, project_root=other)
+    assert pairings
+    assert all(p.path == "mod.py" for p in pairings)
+
+
+def test_semantic_never_gates_a_structurally_failing_run(tmp_path: Path) -> None:
+    # The never-gates invariant on the FAIL / exit-2 side: --semantic must leave a run that the
+    # structural gate already fails byte-for-byte unchanged (previously only proven for exit-0).
+    p = tmp_path / "mod.py"
+    p.write_text(
+        f"# @cpt-begin:{_ALGO}:p1:inst-strong\n"
+        "def validate_email_address_and_reject_malformed(record):\n"
+        "    return save_record(record)\n"
+        f"# @cpt-end:{_ALGO}:p1:inst-strong\n"
+        "def uncovered():\n"          # code outside any marker → drags coverage below 100%
+        "    return 1\n",
+        encoding="utf-8")
+    ctx = _ctx(tmp_path, p)
+    code_sem, rep_sem = _run(ctx, ["--min-coverage", "100", "--semantic"])
+    code_plain, rep_plain = _run(ctx, ["--min-coverage", "100"])
+    assert code_sem == code_plain == 2
+    assert rep_sem.get("status") == rep_plain.get("status") == "FAIL"
+    assert rep_sem["semantic"]["advisory"] is True
+    assert "semantic" not in rep_plain
+
+
+def test_pairings_dedup_duplicate_file_registrations(tmp_path: Path) -> None:
+    # A file registered more than once must not double-count its marked blocks.
+    code = _marked(tmp_path)
+    once = sc._pairings_for_files([code], {})
+    twice = sc._pairings_for_files([code, code], {})
+    assert len(twice) == len(once)
+
+
+def test_definition_map_warns_on_duplicate_cpt_definition(tmp_path: Path, monkeypatch, caplog) -> None:
+    # Two artifacts defining the same cpt id: the first wins, and the collision is logged (not silent).
+    doc1 = tmp_path / "a.md"
+    doc2 = tmp_path / "b.md"
+    doc1.write_text("x", encoding="utf-8")
+    doc2.write_text("x", encoding="utf-8")
+    monkeypatch.setattr(sc, "collect_artifacts_to_scan", lambda ctx: ([(doc1, "f"), (doc2, "f")], {}))
+    monkeypatch.setattr(sc, "scan_cpt_ids", lambda p: [{"type": "definition", "id": _ALGO}])
+    with caplog.at_level("WARNING"):
+        mapping = sc._definition_map(MagicMock())
+    assert mapping[_ALGO] == doc1
+    assert any("defined in both" in r.message for r in caplog.records)
+
+
+def test_semantic_pass_runs_end_to_end_unmocked(tmp_path: Path) -> None:
+    # End-to-end with run_semantic_pass NOT mocked: real _definition_map + _pairings_for_files +
+    # assess over a real ctx. With no judge wired, blocks are unjudgeable; the section is real and
+    # the run never degrades to the error shape.
+    code_path = _marked(tmp_path)
+    ctx = _ctx(tmp_path, code_path)
+    _code, rep = _run(ctx, ["--semantic"])
+    sem = rep["semantic"]
+    assert sem["advisory"] is True
+    assert "error" not in sem
+    assert sem["schema_version"] >= 1
+    assert sem["assessed"] + sem["presumed_covered"] + len(sem["unjudgeable"]) >= 1
+
+
+def test_semantic_section_attaches_on_empty_scope(tmp_path: Path) -> None:
+    # --semantic must still attach a section when the codebase resolves to no files, so the flag's
+    # presence is consistent (the early empty-scope return used to skip it).
+    meta = ArtifactsMeta(
+        version=1, project_root=".", kits={"test": Kit("test", "CFS", "kits/test")},
+        systems=[SystemNode(name="sys1", slug="sys1", kit="test", artifacts=[],
+                            codebase=[], children=[])])
+    ctx = MagicMock()
+    ctx.meta = meta
+    ctx.project_root = tmp_path
+    _code, rep = _run(ctx, ["--semantic"])
+    assert "semantic" in rep
+    assert rep["semantic"]["advisory"] is True
+
+
+def test_human_error_section_renders_without_summary_line(tmp_path: Path, capsys) -> None:
+    # When the semantic section is an advisory error (e.g. an import failure), human mode renders it
+    # WITHOUT importing/calling summary_line — which could re-raise after status/exit are set.
+    from studio.utils.ui import set_json_mode
+    code_path = _marked(tmp_path)
+    ctx = _ctx(tmp_path, code_path)
+    err_section = {"advisory": True, "error": "boom-import"}
+    set_json_mode(False)
+    try:
+        with patch("studio.utils.context.get_context", return_value=ctx):
+            with patch("studio.utils.semantic_coverage.run_semantic_pass", return_value=err_section):
+                with patch("studio.utils.semantic_coverage.summary_line",
+                           side_effect=AssertionError("summary_line must not be called for an error section")):
+                    cmd_spec_coverage(["--semantic"])
+        out = capsys.readouterr().out
+    finally:
+        set_json_mode(True)
+    assert "errored" in out
+    assert "boom-import" in out


### PR DESCRIPTION
## What

Adds an opt-in `--semantic` pass to `cfs spec-coverage` that wires the advisory semantic-coverage engine (`utils/eval_semantic.py`, landed in #105) into the command. It builds the engine's pairings from the real marked code blocks and their resolved requirements, runs the advisory `assess`, and attaches a `semantic` section to the JSON report plus a one-line human summary.

Off by default; nothing changes unless `--semantic` is passed.

## Why

Structural `spec-coverage` scores marker *density* — a file can read fully covered while a block implements the wrong behaviour. This pass adds the advisory signal density can't reach: *does a marked block actually implement the requirement it cites?* (covered / partial / wrong / unjudgeable).

## Advisory — never gates

The section is attached **after** the structural status and exit code are computed, so a semantic verdict can never change them. Enforced structurally and tested:

- A forced `wrong` verdict leaves status/exit byte-for-byte unchanged.
- The pass is exception-isolated: any failure inside it (imports, context, the pass itself) is swallowed, logged, and recorded as `{"advisory": true, "error": …}` — it can never crash the run.
- With no judge wired, weak links are `unjudgeable` (never a silent zero); no model is called.
- Pairing paths are project-relative POSIX, matching the report's own scope arrays.

## Design notes

- Requirement granularity is **per-algo** (a block's id is its algo id; the feature-doc requirement is scoped to that id).
- Scope (`excluded` / `whole_file_claims`) is read from the coverage report and tolerated absent (degrades to an empty scope, never an error).
- Library-level logic in `utils/semantic_coverage.py`, CPT-traced; the command wiring is a thin resolver.

## Testing

- 14 unit tests: pairing construction, the no-judge default, honest serialisation, scope consumption, the advisory-never-gates invariant (including a **raising** pass), relative-path emission, and human/JSON rendering.
- Gates green: `cfs validate` 223/223 (0 errors), `spec-coverage` thresholds met (granularity 0.4616 ≥ 0.46 floor), pylint, vulture, full suite (4865 passed), per-file coverage (`semantic_coverage.py` 100%, `spec_coverage.py` ≥90%).

Follows the DCO + conventional-commit conventions in `CONTRIBUTING.md`; single signed-off commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional semantic coverage check for the `spec-coverage` command, enabled with `--semantic`.
  - Reports now include semantic assessments, requirement-to-code findings, identified gaps, and a concise summary.
  - Semantic coverage is available in both JSON and human-readable output, including when no files are found.

- **Bug Fixes**
  - Semantic findings and processing errors remain advisory and do not change structural coverage results or command exit status.

- **Documentation**
  - Updated spec-coverage documentation to describe the optional semantic assessment and its non-gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->