### PR TITLE
fix(spec-coverage): resolve project_root so a symlinked root matches resolved file paths

### DIFF
--- a/skills/studio/scripts/studio/commands/spec_coverage.py
+++ b/skills/studio/scripts/studio/commands/spec_coverage.py
@@ -194,9 +194,10 @@ def _collect_selected_system_files(
 def _filter_ignored_files(code_files_to_scan: List[Path], project_root: Path, meta) -> List[Path]:
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-filter-ignored-files
     filtered_files: List[Path] = []
-    for file_path in code_files_to_scan:
+    root = project_root.resolve()   # resolve both sides so a symlinked/unresolved root
+    for file_path in code_files_to_scan:   # (e.g. macOS /var -> /private/var) still matches
         try:
-            rel = file_path.resolve().relative_to(project_root).as_posix()
+            rel = file_path.resolve().relative_to(root).as_posix()
         except ValueError as exc:
             _warn_spec_coverage(f"code file {file_path} is outside project root {project_root}: {exc}")
             rel = None
@@ -495,7 +496,7 @@ def _rel_path(p: str, project_root: Path) -> str:
     """Return path relative to project_root, or original if not possible."""
     # @cpt-begin:cpt-studio-flow-spec-coverage-report:p1:inst-rel-path
     try:
-        return str(Path(p).relative_to(project_root))
+        return Path(p).resolve().relative_to(project_root.resolve()).as_posix()
     except ValueError as exc:
         _warn_spec_coverage(f"path {p} is outside project root {project_root}: {exc}")
         return p

--- a/tests/test_spec_coverage.py
+++ b/tests/test_spec_coverage.py
@@ -17,7 +17,12 @@ from studio.utils.artifacts_meta import (
     Kit,
     SystemNode,
 )
-from studio.commands.spec_coverage import cmd_spec_coverage, _output
+from studio.commands.spec_coverage import (
+    cmd_spec_coverage,
+    _output,
+    _filter_ignored_files,
+    _rel_path,
+)
 
 
 class TestOutput(unittest.TestCase):
@@ -75,6 +80,26 @@ class TestCmdSpecCoverage(unittest.TestCase):
                 with patch("sys.stdout", new_callable=StringIO) as mock_out:
                     ret = cmd_spec_coverage(args)
             return ret, json.loads(mock_out.getvalue())
+
+    def test_symlinked_project_root_is_reconciled(self):
+        # Regression for the macOS /var -> /private/var case: file paths resolve through the symlink
+        # while project_root may be unresolved/symlinked. Both sides must resolve, or every file is
+        # wrongly judged "outside project root" (and its relative key never forms -> KeyError).
+        # Reproduced on any OS via an explicit symlink.
+        with TemporaryDirectory() as d:
+            real = Path(d) / "real"
+            (real / "src").mkdir(parents=True)
+            f = real / "src" / "mod.py"
+            f.write_text("x = 1\n", encoding="utf-8")
+            link = Path(d) / "link"
+            link.symlink_to(real)                       # project_root as an unresolved symlink
+            meta = MagicMock()
+            meta.is_ignored.return_value = False
+            # _filter_ignored_files: the file survives with a clean relative path (not rel=None)
+            self.assertEqual(_filter_ignored_files([f], link, meta), [f])
+            meta.is_ignored.assert_called_once_with("src/mod.py")
+            # _rel_path: a resolved file maps to its relative key, not the absolute path
+            self.assertEqual(_rel_path(str(f.resolve()), link), "src/mod.py")
 
     def test_no_context(self):
         with patch("studio.utils.context.get_context", return_value=None):


### PR DESCRIPTION
## What

Fixes #124 — the macOS `spec-coverage` test failure from a resolved-vs-unresolved `project_root` path mismatch.

`_filter_ignored_files` and `_rel_path` in `spec_coverage.py` resolved the **file** path but not `project_root`. On macOS, `tempfile`'s default temp dir (`/var/folders/...`) is a symlink to `/private/var/...`, so `file_path.resolve()` (→ `/private/var/...`) could not be made `relative_to` an unresolved root (`/var/...`) — every file was judged "outside project root", and the missing relative key surfaced as `KeyError: 'src/broken.py'`.

## Fix

Resolve **both** sides in both functions (`.relative_to(project_root.resolve())`), so a symlinked or otherwise unresolved root still matches resolved file paths. This mirrors what the semantic-coverage pass's `_relative_posix` already does.

## Test

Adds `test_symlinked_project_root_is_reconciled`, which reproduces the mismatch on **any** OS via an explicit symlinked `project_root` — it fails on the old code with the exact `outside project root` warning, and passes with the fix.

Gates green: `cfs validate` 230/230, `spec-coverage` thresholds met, pylint, vulture, full suite (5130 passed). Single signed-off commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved specification coverage path handling when projects use symlinked or unresolved project roots.
  - Files now consistently resolve to the correct relative paths, preventing valid files from being incorrectly excluded.

- **Tests**
  - Added coverage for symlinked project roots and resolved file path comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->