### PR TITLE
feat(artifact-quality): add the shared advisory finding model + JSON schema

### DIFF
--- a/architecture/DECOMPOSITION.md
+++ b/architecture/DECOMPOSITION.md
@@ -24,6 +24,7 @@
   - [2.16 Dependency Mapping 🔶 HIGH](#216-dependency-mapping--high)
   - [2.17 Thin Skill Runtime ⏳ HIGH](#217-thin-skill-runtime--high)
   - [2.18 Workflow Eval-Harness ⏳ HIGH](#218-workflow-eval-harness--high)
+  - [2.19 Artifact Quality ⏳ HIGH](#219-artifact-quality--high)
 - [3. Feature Dependencies](#3-feature-dependencies)
 
 <!-- /toc -->
@@ -948,6 +949,38 @@ Studio DESIGN is decomposed into features organized around architectural layers 
 
 ---
 
+### 2.19 [Artifact Quality](features/artifact-quality.md) ⏳ HIGH
+
+- [ ] `p1` - **ID**: `cpt-studio-feature-artifact-quality`
+
+- **Purpose**: Surface advisory semantic-quality findings on Project Markdown artifacts (duplication, purpose-mismatch, gap, traceability-meaning, contradiction) — evidence plus a suggested action, read-only, no combined score, never gating. The first piece is the shared finding model and JSON schema every detector emits.
+
+- **Depends On**: `cpt-studio-feature-spec-coverage`
+
+- **Scope**:
+  - A shared `ArtifactFinding` model + `Locus`, advisory and read-only, with a detector-namespaced verdict
+  - A versioned wire contract from `finding_json_schema()` — the shape a presentation layer consumes
+  - Structural detectors — duplication, gap, and rule-based purpose (deterministic, in-core) — later tasks
+  - Judge-backed detectors — traceability, contradiction, and ambiguous-purpose (reuse the advisory judge seam) — later tasks
+  - A read-only `cfs artifact-quality` command — later task
+
+- **Out of scope**:
+  - Rewriting artifacts; any combined quality score
+  - Heavy embedding/clustering (stays in the dashboard-service lane)
+
+- **Requirements Covered**:
+
+  - `p1` - `cpt-studio-fr-core-traceability`
+
+- **API**:
+  - `cfs artifact-quality [--detectors ...]` (later task)
+
+- **Data**:
+  - Project Markdown artifacts (read-only)
+
+
+---
+
 ## 3. Feature Dependencies
 
 ```text
@@ -971,6 +1004,8 @@ cpt-studio-feature-core-infra
     │    ├─→ cpt-studio-feature-developer-experience
     │    │
     │    └─→ cpt-studio-feature-spec-coverage
+    │        ↓
+    │        └─→ cpt-studio-feature-artifact-quality
     │
     ├─→ cpt-studio-feature-workspace ←── cpt-studio-feature-traceability-validation
     │
@@ -992,4 +1027,5 @@ cpt-studio-feature-core-infra
 - `cpt-studio-feature-developer-experience` requires `cpt-studio-feature-traceability-validation`: VS Code plugin and doctor delegate to validator and traceability engine
 - `cpt-studio-feature-workspace` requires `cpt-studio-feature-core-infra` and `cpt-studio-feature-traceability-validation`: workspace federation builds on core context loading and extends cross-repo ID resolution in the traceability engine
 - `cpt-studio-feature-ralphex-delegation` requires `cpt-studio-feature-execution-plans` and `cpt-studio-feature-version-config`: delegation compiles exported plans from Studio's authoritative decomposition model and persists ralphex integration settings via the config manager
+- `cpt-studio-feature-artifact-quality` requires `cpt-studio-feature-spec-coverage`: its judged detectors reuse the advisory semantic seam (never-gating, honest-unjudgeable, evidence checks) that spec-coverage introduced
 - SDLC-specific features (F4, F6, F9) have been extracted to `constructorfabric/studio-kit-sdlc` per `cpt-studio-adr-extract-sdlc-kit`

--- a/architecture/features/artifact-quality.md
+++ b/architecture/features/artifact-quality.md
@@ -1,0 +1,112 @@
+# Feature: Artifact Quality
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1. Overview](#1-overview)
+  - [2. Purpose](#2-purpose)
+  - [3. Actors](#3-actors)
+  - [4. References](#4-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Assess Artifact Quality](#assess-artifact-quality)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [Artifact-Quality Finding Model](#artifact-quality-finding-model)
+- [4. States (CDSL)](#4-states-cdsl)
+  - [Finding Lifecycle](#finding-lifecycle)
+- [5. Definitions of Done](#5-definitions-of-done)
+  - [Finding Model Contract](#finding-model-contract)
+- [6. Implementation Modules](#6-implementation-modules)
+- [7. Acceptance Criteria](#7-acceptance-criteria)
+
+<!-- /toc -->
+
+- [ ] `p1` - **ID**: `cpt-studio-featstatus-artifact-quality`
+
+## 1. Feature Context
+
+- [ ] `p1` - `cpt-studio-feature-artifact-quality`
+
+### 1. Overview
+
+Surfaces advisory **semantic-quality findings** on Project Markdown artifacts (Vision, PRD, Epics, feature specs) — duplication, purpose-mismatch, gap, traceability-meaning, and contradiction — as evidence and, where a detector provides one, a suggested action. Read-only and Markdown-first: it never rewrites an artifact, produces no combined score, and never gates a build. Structural detectors run in-core (stdlib); meaning-level detectors reuse the advisory judge seam. This first piece is the shared **finding model** every detector emits and the JSON schema a presentation layer consumes.
+
+### 2. Purpose
+
+Studio's deterministic layer assures code (`validate`, `spec-coverage`, CPT markers); the specification documents themselves have no comparable signal — nothing flags a requirement duplicated across three docs, content in the wrong doc type, a drifted trace link, or two artifacts that contradict. A single, versioned finding shape lets every detector speak one contract and a UI present findings side-by-side.
+
+### 3. Actors
+
+| Actor | Role in Feature |
+|-------|-----------------|
+| `cpt-studio-actor-user` | Reviews the surfaced findings and decides what to act on |
+| `cpt-studio-actor-ai-agent` | Emits findings while assessing artifacts; consumes the model |
+
+### 4. References
+
+- **PRD**: [PRD.md](../PRD.md) — `cpt-studio-fr-core-traceability`
+- **Design**: [DESIGN.md](../DESIGN.md) — `cpt-studio-component-traceability-engine`
+- **Dependencies**: `cpt-studio-feature-spec-coverage`
+
+## 2. Actor Flows (CDSL)
+
+### Assess Artifact Quality
+
+- [ ] `p1` - **ID**: `cpt-studio-flow-artifact-quality-assess`
+
+**Actor**: `cpt-studio-actor-user`
+
+**Success Scenarios**:
+- User runs `cfs artifact-quality` → registered artifacts are scanned, findings are emitted as JSON plus a one-line human summary, nothing is rewritten and no exit code changes
+
+**Steps**:
+1. [ ] - `p1` - User invokes `cfs artifact-quality [--detectors ...]`; registered artifacts are scanned and findings emitted as JSON plus a one-line summary, nothing is rewritten (command lands in a later task; the finding model below is the contract it emits) - `inst-aq-assess-invoke`
+
+**Scale**: corpus size, per-artifact size, and finding-output bounds are the `cfs artifact-quality` command task's contract (the later task above) — this feature delivers only the finding model and its wire schema, which impose no scan and no output volume of their own.
+
+## 3. Processes / Business Logic (CDSL)
+
+### Artifact-Quality Finding Model
+
+- [x] `p1` - **ID**: `cpt-studio-algo-artifact-quality-finding-model`
+
+**Input**: a detector's assessment of one artifact (or artifact pair)
+
+**Output**: an `ArtifactFinding` (advisory, read-only) and its serialised `to_dict` shape
+
+**Steps**:
+1. [x] - `p1` - Model a `Locus` — where in an artifact a finding sits — validating its field types and, on construction, that the path is a canonical project-relative POSIX path (non-empty, no leading `/`, no `\`, no drive letter, no `.`/`..`/empty `//` segments, no control chars), the optional line is a 1-based int, and the optional anchor is a non-empty control-char-free string; serialising only the fields that were set - `inst-aq-locus`
+2. [x] - `p1` - Model an `ArtifactFinding` and validate it on construction — first field types, then values: advisory severity only (no `error`), a non-empty message, a structural finding carries no verdict and no judged-only metadata (`confidence`/`evidence_ok`), a judged finding must carry a detector-namespaced verdict (or `unjudgeable`), and `schema_version` pinned (an int, not a bool) to the one supported contract - `inst-aq-finding`
+3. [x] - `p1` - Serialise an `ArtifactFinding` to the wire shape — every required key plus `schema_version`, the optional `related`/`verdict`/`confidence` only when set, with no combined score and no edit payload - `inst-aq-finding-serialize`
+
+**Supporting**:
+- [x] - `p1` - Module imports and the model constants: `SCHEMA_VERSION`, the detector / severity / kind vocabularies, and the shared `unjudgeable` verdict - `inst-aq-imports`
+- [x] - `p1` - The versioned wire contract, handed out as a fresh deep copy by `finding_json_schema()` (never a mutable shared global) — `schema_version` pinned to the supported contract, the kind↔verdict rule encoded on the wire (structural carries no verdict or judged-only metadata, judged requires a verdict), path and non-blank patterns that mirror the constructor exactly (explicit whitespace class, not ECMA `\s`), optional keys only when set, and no score field or edit payload - `inst-aq-schema`
+
+## 4. States (CDSL)
+
+### Finding Lifecycle
+
+- [ ] `p1` - **ID**: `cpt-studio-state-artifact-quality-finding`
+
+A finding is **emitted** by a detector, **presented** to the user, and **acted on or dismissed** by them. It is never applied automatically. *(The lifecycle is realised once the detectors and command land in later tasks; the model here fixes the shape it moves through.)*
+
+## 5. Definitions of Done
+
+### Finding Model Contract
+
+- [ ] `p1` - **ID**: `cpt-studio-dod-artifact-quality-finding-model`
+
+The finding model is done when every detector can express its result as one `ArtifactFinding` — advisory, read-only, detector-namespaced verdict, no combined score — and a presentation layer can rely on the versioned wire contract from `finding_json_schema()`. *(Measured against the detectors as they land; the model + schema + their tests are the first, standalone deliverable.)*
+
+## 6. Implementation Modules
+
+| Module | Path | Responsibility |
+|---|---|---|
+| Artifact-Quality Finding Model | `skills/studio/scripts/studio/utils/artifact_quality.py` | The shared `ArtifactFinding` / `Locus` model, its `to_dict`, and the versioned JSON schema every detector and the presentation layer share |
+
+## 7. Acceptance Criteria
+
+- [x] A finding names exactly one detector, carries an advisory severity (`info` / `warn`, never `error`), and never carries a combined score or an edit payload — verified by `test_valid_structural_and_judged_construct`, `test_unknown_detector_raises`, `test_severity_error_is_rejected`, `test_no_combined_score_and_no_edit_payload`
+- [x] A structural finding has `verdict = None`; a judged finding carries a detector-namespaced verdict (or `unjudgeable`) — construction raises otherwise — verified by `test_structural_with_a_verdict_raises`, `test_judged_without_a_verdict_raises`, `test_unjudgeable_is_a_legal_judged_verdict`, `test_judged_finding_rejects_blank_verdict`
+- [x] `to_dict` emits the required keys plus `schema_version`, and omits `related` / `verdict` / `confidence` when unset — verified by `test_structural_to_dict_omits_optional_fields`, `test_judged_to_dict_includes_optionals_when_set`, `test_serialised_finding_keys_are_all_allowed_properties`
+- [x] `finding_json_schema()` returns the versioned wire contract (a fresh copy) that validates a serialised finding, versioned by `schema_version` — verified by `test_schema_is_versioned_and_well_formed`, `test_schema_pins_schema_version_and_encodes_kind_verdict_rule`, `test_finding_json_schema_returns_a_fresh_deep_copy`

--- a/skills/studio/scripts/studio/utils/artifact_quality.py
+++ b/skills/studio/scripts/studio/utils/artifact_quality.py
@@ -1,0 +1,312 @@
+"""Artifact-quality finding model — the shared, advisory unit every detector emits.
+
+Studio's deterministic layer assures *code*; this feature surfaces semantic-quality **findings** on
+Project Markdown artifacts (duplication, purpose-mismatch, gap, traceability-meaning, contradiction).
+This module is the contract they all speak: one :class:`ArtifactFinding` shape and the JSON schema a
+presentation layer consumes. It carries **no detection logic** — detectors (later tasks) import it.
+
+The model mirrors the two shipped ones — ``PdslFinding`` (deterministic, ``to_dict``, location) and
+``SemanticFinding`` (advisory verdict + evidence guard) — and holds their invariants:
+
+* **Advisory — never gates.** ``severity`` is only ``info`` / ``warn``; there is no ``error`` and no
+  exit-code authority. A finding is a suggestion a human acts on.
+* **Read-only.** A finding carries evidence and a *suggested* action — never an edit payload.
+* **No combined score.** Findings are individual signals; the model refuses a single quality number.
+* **Detector-namespaced verdict.** Judged detectors carry their own verdict vocabulary (traceability:
+  ``covered|partial|drifted|contradictory|uncovered``; contradiction: ``contradictory|consistent``;
+  purpose: ``mismatch|ok``), and every judged detector also admits ``unjudgeable``. Structural
+  detectors carry ``verdict=None`` — the finding itself is the signal.
+* **Honest-unjudgeable.** A judged detector with no judge wired emits ``unjudgeable`` — never a
+  silent "clean", never a dropped finding.
+
+@cpt-algo:cpt-studio-algo-artifact-quality-finding-model:p1
+"""
+# @cpt-begin:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-imports
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+#: Bumped on any breaking change to the finding shape, so a presentation-layer consumer can detect
+#: a contract change rather than mis-reading fields.
+SCHEMA_VERSION = 1
+
+#: The detectors this model serves (a finding names exactly one).
+DETECTORS = ("duplication", "purpose", "gap", "traceability", "contradiction")
+
+#: Advisory severities only — there is deliberately no ``error``: a finding can never gate.
+SEVERITIES = ("info", "warn")
+
+#: The two kinds of detector. ``structural`` findings carry ``verdict=None``; ``judged`` findings
+#: carry a detector-namespaced verdict (or ``unjudgeable``).
+KINDS = ("structural", "judged")
+
+#: The one verdict every judged detector shares — the honest "could not judge" outcome.
+VERDICT_UNJUDGEABLE = "unjudgeable"
+# @cpt-end:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-imports
+
+
+# @cpt-begin:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-locus
+@dataclass(frozen=True)
+class Locus:
+    """Where in an artifact a finding sits — enough for a UI to jump to it and quote it."""
+
+    artifact_path: str            # project-relative POSIX path of the Markdown artifact
+    anchor: Optional[str] = None  # a heading slug / section id, when the finding is section-scoped
+    line: Optional[int] = None    # 1-based line, when the finding is line-scoped
+
+    def __post_init__(self) -> None:
+        # Types first, then a canonical project-relative POSIX path and a 1-based line, so a UI
+        # never receives a locus it cannot resolve and no wrong type fails late in serialisation.
+        self._validate_types()
+        self._validate_path()
+        if self.line is not None and self.line < 1:
+            raise ValueError(f"line is 1-based; got {self.line}")
+        self._validate_anchor()
+
+    def _validate_types(self) -> None:
+        if not isinstance(self.artifact_path, str):
+            raise TypeError(f"artifact_path must be a str, got {type(self.artifact_path).__name__}")
+        if self.anchor is not None and not isinstance(self.anchor, str):
+            raise TypeError(f"anchor must be a str or None, got {type(self.anchor).__name__}")
+        if self.line is not None and type(self.line) is not int:  # bool is an int subclass
+            raise TypeError(f"line must be an int or None, got {type(self.line).__name__}")
+
+    def _validate_path(self) -> None:
+        if not self.artifact_path:
+            raise ValueError("artifact_path must be a non-empty project-relative POSIX path")
+        if self.artifact_path.startswith("/") or "\\" in self.artifact_path:
+            raise ValueError(
+                f"artifact_path must be project-relative POSIX (no leading '/', no '\\'): "
+                f"{self.artifact_path!r}")
+        if any(len(seg) == 2 and seg[1] == ":" and seg[0].isascii() and seg[0].isalpha()
+               for seg in self.artifact_path.split("/")):  # Windows drive-letter segment, any position
+            raise ValueError(
+                f"artifact_path must be project-relative (no drive letter): {self.artifact_path!r}")
+        if {"", ".", ".."} & set(self.artifact_path.split("/")):
+            raise ValueError(
+                f"artifact_path must be canonical — no '.', '..', or empty '//' segments: "
+                f"{self.artifact_path!r}")
+        if any(ord(ch) < 0x20 for ch in self.artifact_path):
+            raise ValueError(f"artifact_path must not contain control characters: {self.artifact_path!r}")
+
+    def _validate_anchor(self) -> None:
+        if self.anchor is not None and (not self.anchor.strip()
+                                        or any(ord(ch) < 0x20 for ch in self.anchor)):
+            raise ValueError(
+                f"anchor must be a non-empty, control-char-free identifier (or None): {self.anchor!r}")
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise, omitting the optional fields that were not set."""
+        out: Dict[str, object] = {"artifact_path": self.artifact_path}
+        if self.anchor is not None:
+            out["anchor"] = self.anchor
+        if self.line is not None:
+            out["line"] = self.line
+        return out
+# @cpt-end:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-locus
+
+
+# @cpt-begin:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-finding
+@dataclass(frozen=True)
+class ArtifactFinding:
+    """One advisory semantic-quality finding on a Project artifact — the unit every detector emits.
+
+    A finding names its ``detector`` and ``kind``, points at a ``primary`` locus (and an optional
+    ``related`` locus when a detector reports a second site), and may carry grep-verifiable
+    ``evidence`` and a ``suggested_action``. It never carries an edit payload or a score.
+
+    ``verdict`` is **detector-namespaced** and ``None`` for structural detectors; ``confidence`` and
+    ``evidence_ok`` are meaningful only for judged findings. Constructing an invalid finding raises,
+    so a malformed finding never reaches the report.
+    """
+
+    detector: str
+    severity: str
+    kind: str
+    message: str
+    primary: Locus
+    evidence: str = ""
+    suggested_action: str = ""
+    related: Optional[Locus] = None
+    verdict: Optional[str] = None
+    evidence_ok: bool = False
+    confidence: Optional[str] = None
+    schema_version: int = field(default=SCHEMA_VERSION)
+
+    def __post_init__(self) -> None:
+        # Reject wrong types before any value check or serialisation touches them (so a bad type
+        # fails here, not late in a consumer), then enforce the advisory-contract values, then the
+        # cross-field consistency rules.
+        self._validate_types()
+        self._validate_values()
+        self._validate_consistency()
+
+    def _validate_consistency(self) -> None:
+        # Cross-field rules the individual value checks can't express on their own.
+        if self.evidence_ok and not self.evidence.strip():
+            raise ValueError("evidence_ok is True but evidence is empty — nothing was verified")
+        if self.related is not None and self.related == self.primary:
+            raise ValueError("related locus must differ from primary (a finding is not related to "
+                             "itself)")
+        if self.verdict == VERDICT_UNJUDGEABLE and (self.confidence is not None or self.evidence_ok):
+            raise ValueError("an 'unjudgeable' finding carries no judged metadata "
+                             "(confidence must be None, evidence_ok False)")
+
+    def _validate_types(self) -> None:
+        for name in ("detector", "severity", "kind", "message", "evidence", "suggested_action"):
+            if not isinstance(getattr(self, name), str):
+                raise TypeError(f"{name} must be a str, got {type(getattr(self, name)).__name__}")
+        if not isinstance(self.primary, Locus):
+            raise TypeError(f"primary must be a Locus, got {type(self.primary).__name__}")
+        if self.related is not None and not isinstance(self.related, Locus):
+            raise TypeError(f"related must be a Locus or None, got {type(self.related).__name__}")
+        for name in ("verdict", "confidence"):
+            value = getattr(self, name)
+            if value is not None and not isinstance(value, str):
+                raise TypeError(f"{name} must be a str or None, got {type(value).__name__}")
+        if type(self.evidence_ok) is not bool:  # bool is an int subclass, keep it exact
+            raise TypeError(f"evidence_ok must be a bool, got {type(self.evidence_ok).__name__}")
+        if type(self.schema_version) is not int:  # excludes bool (True == 1)
+            raise TypeError(f"schema_version must be an int, got {type(self.schema_version).__name__}")
+
+    def _validate_values(self) -> None:
+        if self.detector not in DETECTORS:
+            raise ValueError(f"unknown detector {self.detector!r}; expected one of {DETECTORS}")
+        if self.severity not in SEVERITIES:
+            raise ValueError(f"advisory severity must be one of {SEVERITIES}, got {self.severity!r}")
+        if self.kind not in KINDS:
+            raise ValueError(f"kind must be one of {KINDS}, got {self.kind!r}")
+        if not self.message.strip():
+            raise ValueError("message must be non-empty — a finding must explain itself")
+        if self.kind == "structural":
+            if self.verdict is not None:
+                raise ValueError("a structural finding carries no verdict (verdict must be None)")
+            if self.confidence is not None or self.evidence_ok:
+                raise ValueError("a structural finding carries no judged metadata "
+                                 "(confidence must be None, evidence_ok False)")
+        if self.kind == "judged" and (self.verdict is None or not self.verdict.strip()):
+            raise ValueError("a judged finding must carry a non-empty verdict (or 'unjudgeable')")
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(
+                f"schema_version must be {SCHEMA_VERSION} (the only supported contract), "
+                f"got {self.schema_version}")
+# @cpt-end:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-finding
+
+    # @cpt-begin:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-finding-serialize
+    def to_dict(self) -> Dict[str, object]:
+        """Serialise to the wire shape the presentation layer consumes (see ``finding_json_schema``).
+
+        Emits every required key plus ``schema_version``, and the optional ``related`` / ``verdict`` /
+        ``confidence`` only when set — the exact shape ``finding_json_schema()`` describes.
+        """
+        out: Dict[str, object] = {
+            "detector": self.detector,
+            "severity": self.severity,
+            "kind": self.kind,
+            "message": self.message,
+            "primary": self.primary.to_dict(),
+            "evidence": self.evidence,
+            "evidence_ok": self.evidence_ok,
+            "suggested_action": self.suggested_action,
+            "schema_version": self.schema_version,
+        }
+        if self.related is not None:
+            out["related"] = self.related.to_dict()
+        if self.verdict is not None:
+            out["verdict"] = self.verdict
+        if self.confidence is not None:
+            out["confidence"] = self.confidence
+        return out
+    # @cpt-end:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-finding-serialize
+
+
+# @cpt-begin:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-schema
+#: The exact whitespace ``str.strip()`` removes (``str.isspace()``), as a regex character-class body.
+#: Anchor/message blankness is decided by ``str.strip()``; enumerating it explicitly — not ECMA
+#: ``\s``, which differs on U+0085/U+FEFF/U+001C–1F — lets the wire pattern mirror the constructor
+#: exactly under a standards-compliant validator.
+_PY_STRIP_WS = r"\t\n\x0b\x0c\r\x1c-\x1f \x85\xa0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000"
+
+#: The stable JSON contract a presentation/UI layer relies on — obtain a fresh, mutable copy via
+#: :func:`finding_json_schema`. Versioned by ``schema_version``; the optional keys (``related`` /
+#: ``verdict`` / ``confidence``) appear only when set. There is deliberately no combined-score field
+#: and no edit payload — the model is advisory and read-only.
+_FINDING_JSON_SCHEMA: Dict[str, object] = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ArtifactFinding",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["detector", "severity", "kind", "message", "primary", "evidence",
+                 "evidence_ok", "suggested_action", "schema_version"],
+    "properties": {
+        "detector": {"enum": list(DETECTORS)},
+        "severity": {"enum": list(SEVERITIES)},
+        "kind": {"enum": list(KINDS)},
+        # Non-blank: at least one char str.strip() would NOT remove. Explicit class (not ECMA `\S`)
+        # so the wire pattern mirrors str.strip() exactly, incl. U+0085/U+FEFF/U+001C-1F.
+        "message": {"type": "string", "minLength": 1, "pattern": rf"[^{_PY_STRIP_WS}]"},
+        "primary": {"$ref": "#/definitions/locus"},
+        "related": {"$ref": "#/definitions/locus"},
+        "evidence": {"type": "string"},
+        "evidence_ok": {"type": "boolean"},
+        "suggested_action": {"type": "string"},
+        # Non-blank when present — same explicit str.strip() class as message (not ECMA `\S`, which
+        # diverges on U+0085/U+FEFF), so a judged verdict mirrors the constructor exactly.
+        "verdict": {"type": "string", "pattern": rf"[^{_PY_STRIP_WS}]"},
+        "confidence": {"type": "string"},
+        "schema_version": {"const": SCHEMA_VERSION},
+    },
+    # Mirror the constructor's invariants on the wire so a hand-authored payload (not built through
+    # ArtifactFinding) can't smuggle a structural verdict, judged-only metadata on a structural
+    # finding, or a verdict-less judged finding past a validator. Per-detector verdict vocabularies
+    # are enforced by each detector, not this shared contract.
+    "allOf": [
+        {"if": {"properties": {"kind": {"const": "structural"}}},
+         "then": {"allOf": [{"not": {"required": ["verdict"]}},
+                            {"not": {"required": ["confidence"]}},
+                            {"properties": {"evidence_ok": {"const": False}}}]}},
+        {"if": {"properties": {"kind": {"const": "judged"}}},
+         "then": {"required": ["verdict"]}},
+        # evidence_ok claims the evidence quote verified, so it requires non-empty evidence.
+        {"if": {"properties": {"evidence_ok": {"const": True}}, "required": ["evidence_ok"]},
+         "then": {"properties": {"evidence": {"pattern": rf"[^{_PY_STRIP_WS}]"}}}},
+        # an 'unjudgeable' verdict means the judge could not judge — so no confidence/evidence_ok.
+        {"if": {"properties": {"verdict": {"const": VERDICT_UNJUDGEABLE}}, "required": ["verdict"]},
+         "then": {"allOf": [{"not": {"required": ["confidence"]}},
+                            {"properties": {"evidence_ok": {"const": False}}}]}},
+    ],
+    "definitions": {
+        "locus": {
+            "type": "object",
+            "additionalProperties": False,
+            "required": ["artifact_path"],
+            "properties": {
+                # Canonical project-relative POSIX path: one or more '/'-joined segments, each
+                # non-empty, not '.'/'..', and free of '\' and control chars. This mirrors the
+                # dataclass's per-segment check (leading, interior AND trailing) — the dataclass is
+                # authoritative, but the wire pattern must reject the same set (incl. traversal).
+                "artifact_path": {"type": "string",
+                                  "pattern": r"^(?![A-Za-z]:(?:/|$))(?!\.\.?(?:/|$))[^/\\\x00-\x1f]+"
+                                             r"(?:/(?![A-Za-z]:(?:/|$))(?!\.\.?(?:/|$))[^/\\\x00-\x1f]+)*$"},
+                # Non-blank (not all str.strip() whitespace) and control-free. Explicit classes,
+                # no ECMA `\s`/`.`, so the wire pattern mirrors the constructor exactly — NEL, BOM,
+                # line/paragraph separators all agree with str.strip() / ord < 0x20.
+                "anchor": {"type": "string", "minLength": 1,
+                           "pattern": rf"^(?![{_PY_STRIP_WS}]*$)[^\x00-\x1f]+$"},
+                "line": {"type": "integer", "minimum": 1},
+            },
+        },
+    },
+}
+
+
+def finding_json_schema() -> Dict[str, object]:
+    """Return a fresh, mutable deep copy of the wire contract (see ``_FINDING_JSON_SCHEMA``).
+
+    The schema is a shared contract, so it is not exposed as a mutable module global: each caller
+    gets its own copy and cannot alter the version other consumers validate against.
+    """
+    return copy.deepcopy(_FINDING_JSON_SCHEMA)
+# @cpt-end:cpt-studio-algo-artifact-quality-finding-model:p1:inst-aq-schema

--- a/tests/test_artifact_quality.py
+++ b/tests/test_artifact_quality.py
@@ -1,0 +1,570 @@
+"""Tests for the artifact-quality finding model (utils.artifact_quality).
+
+Pins the shared contract every detector emits: the model validates itself on construction, serialises
+to a stable shape (optional fields omitted when unset), and carries the advisory / read-only /
+no-score / honest-unjudgeable invariants. The JSON schema is checked to match what ``to_dict`` emits.
+"""
+import random
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "skills" / "studio" / "scripts"))
+
+from studio.utils.artifact_quality import (
+    ArtifactFinding,
+    Locus,
+    DETECTORS,
+    KINDS,
+    SEVERITIES,
+    finding_json_schema,
+    SCHEMA_VERSION,
+    VERDICT_UNJUDGEABLE,
+)
+
+
+SCHEMA = finding_json_schema()  # one snapshot; tests never mutate it
+
+def _structural(**over):
+    kw = dict(detector="duplication", severity="warn", kind="structural",
+              message="repeated content", primary=Locus("docs/a.md"))
+    kw.update(over)
+    return ArtifactFinding(**kw)
+
+
+def _judged(**over):
+    kw = dict(detector="traceability", severity="info", kind="judged", verdict="drifted",
+              message="link drifted", primary=Locus("docs/a.md", anchor="goals", line=12),
+              evidence="the requirement text", evidence_ok=True, confidence="medium")
+    kw.update(over)
+    return ArtifactFinding(**kw)
+
+
+def _ecma(pattern):
+    """Compile a JSON-Schema (ECMA-262) pattern for faithful matching under Python's re.
+
+    Python's ``$`` also matches just before a trailing newline; ECMA-262 ``$`` (no multiline, as a
+    JSON-Schema validator uses) matches only at the true end. Translate ``$`` -> ``\\Z`` so the test
+    reflects what a real validator does, not Python's newline quirk.
+
+    Only faithful for patterns built from explicit character classes. Python's ``\\s``/``\\S`` track
+    ``str.isspace()``, which differs from ECMA's whitespace set (U+0085/U+FEFF), so this helper would
+    silently report false agreement on such a pattern — refuse them rather than mislead a parity test.
+    """
+    for whitespace_token in (r"\s", r"\S"):
+        assert whitespace_token not in pattern, \
+            "_ecma() is not faithful for whitespace-class patterns (Python vs ECMA differ)"
+    return re.compile(pattern.replace("$", r"\Z"))
+
+
+def test_schema_anchor_pattern_agrees_with_constructor():
+    # Explicit-class pattern (no ECMA \\s / '.'), so _ecma() is faithful and the wire schema mirrors
+    # str.strip()/control exactly -- including the exotic cases the earlier \\s-based pattern got
+    # wrong: NEL (U+0085) is blank to both, BOM (U+FEFF) is kept by both, U+2028 is a valid char.
+    rx = _ecma(SCHEMA["definitions"]["locus"]["properties"]["anchor"]["pattern"])
+    good = ["goals", "a b", "a\u2028b", "sec-1", "\ufeff"]
+    bad = ["", "   ", "\x85", "\t", "a\nb"]
+    for anchor in good:
+        assert rx.match(anchor), f"schema should accept anchor {anchor!r}"
+        assert Locus("docs/a.md", anchor=anchor).anchor == anchor
+    for anchor in bad:
+        assert not rx.match(anchor), f"schema should reject anchor {anchor!r}"
+        with pytest.raises(ValueError):
+            Locus("docs/a.md", anchor=anchor)
+
+
+# --- construction + validation --------------------------------------------
+
+def test_valid_structural_and_judged_construct():
+    assert _structural().verdict is None
+    assert _judged().verdict == "drifted"
+
+
+def test_unknown_detector_raises():
+    with pytest.raises(ValueError, match="unknown detector"):
+        _structural(detector="typos")
+
+
+def test_severity_error_is_rejected():
+    # advisory only — there is deliberately no "error" severity, so a finding can never gate
+    with pytest.raises(ValueError, match="advisory severity"):
+        _structural(severity="error")
+
+
+def test_bad_kind_raises():
+    with pytest.raises(ValueError, match="kind must be"):
+        _structural(kind="fatal")
+
+
+def test_structural_with_a_verdict_raises():
+    with pytest.raises(ValueError, match="structural finding carries no verdict"):
+        _structural(verdict="covered")
+
+
+def test_judged_without_a_verdict_raises():
+    primary = Locus("docs/a.md")
+    with pytest.raises(ValueError, match="judged finding must carry a non-empty verdict"):
+        ArtifactFinding(detector="contradiction", severity="warn", kind="judged",
+                        message="x", primary=primary)
+
+
+def test_unjudgeable_is_a_legal_judged_verdict():
+    # an unjudgeable finding carries no judged metadata (the judge could not judge)
+    finding = _judged(verdict=VERDICT_UNJUDGEABLE, confidence=None, evidence_ok=False)
+    assert finding.verdict == VERDICT_UNJUDGEABLE
+    assert VERDICT_UNJUDGEABLE == "unjudgeable"
+
+
+def test_unsupported_schema_version_is_rejected():
+    # the versioned contract admits exactly the one version it defines
+    with pytest.raises(ValueError, match="schema_version must be"):
+        _structural(schema_version=SCHEMA_VERSION + 1)
+
+
+# --- serialisation ---------------------------------------------------------
+
+def test_locus_to_dict_omits_unset():
+    assert Locus("docs/a.md").to_dict() == {"artifact_path": "docs/a.md"}
+    assert Locus("docs/a.md", anchor="g", line=3).to_dict() == {
+        "artifact_path": "docs/a.md", "anchor": "g", "line": 3}
+
+
+@pytest.mark.parametrize("bad_path", ["", "/abs/a.md", "docs\\a.md", "../a.md", "a/../b.md"])
+def test_locus_rejects_non_relative_posix_paths(bad_path):
+    # empty / absolute / backslash / traversal all violate the project-relative POSIX contract
+    with pytest.raises(ValueError):
+        Locus(bad_path)
+
+
+def test_locus_rejects_non_positive_line():
+    with pytest.raises(ValueError, match="1-based"):
+        Locus("docs/a.md", line=0)
+
+
+def test_structural_to_dict_omits_optional_fields():
+    d = _structural().to_dict()
+    assert d["detector"] == "duplication"
+    assert d["kind"] == "structural"
+    assert d["schema_version"] == SCHEMA_VERSION
+    # unset optionals are absent, not null
+    for k in ("related", "verdict", "confidence"):
+        assert k not in d
+    # required keys always present
+    for k in ("detector", "severity", "kind", "message", "primary", "evidence",
+              "evidence_ok", "suggested_action", "schema_version"):
+        assert k in d
+
+
+def test_judged_to_dict_includes_optionals_when_set():
+    d = _judged(related=Locus("docs/b.md")).to_dict()
+    assert d["verdict"] == "drifted"
+    assert d["confidence"] == "medium"
+    assert d["related"] == {"artifact_path": "docs/b.md"}
+
+
+def test_no_combined_score_and_no_edit_payload():
+    # the model refuses a single quality number and never carries an applyable edit
+    d = _judged().to_dict()
+    for banned in ("score", "quality_score", "edit", "patch", "fix"):
+        assert banned not in d
+
+
+# --- the JSON schema contract ---------------------------------------------
+
+def test_schema_is_versioned_and_well_formed():
+    assert SCHEMA["title"] == "ArtifactFinding"
+    assert SCHEMA["additionalProperties"] is False
+    # no score / edit field is even *allowed* by the schema
+    props = SCHEMA["properties"]
+    assert "score" not in props
+    assert "edit" not in props
+    assert "schema_version" in SCHEMA["required"]
+
+
+def test_schema_pins_schema_version_and_encodes_kind_verdict_rule():
+    # schema_version is pinned to the one supported contract, not "any integer"
+    assert SCHEMA["properties"]["schema_version"] == {"const": SCHEMA_VERSION}
+    # the locus line is 1-based on the wire, mirroring the model
+    assert SCHEMA["definitions"]["locus"]["properties"]["line"]["minimum"] == 1
+    # structural => no verdict; judged => verdict required (mirrors the constructor)
+    conds = SCHEMA["allOf"]
+    structural = next(c for c in conds if c["if"]["properties"]["kind"]["const"] == "structural")
+    judged = next(c for c in conds if c["if"]["properties"]["kind"]["const"] == "judged")
+    assert {"not": {"required": ["verdict"]}} in structural["then"]["allOf"]
+    assert judged["then"] == {"required": ["verdict"]}
+
+
+def test_serialised_finding_keys_are_all_allowed_properties():
+    # NB: key-membership only — behavioural schema conformance is covered by the parity tests below
+    props = set(SCHEMA["properties"])
+    required = set(SCHEMA["required"])
+    for finding in (_structural(), _judged(related=Locus("docs/b.md", line=1))):
+        keys = set(finding.to_dict())
+        assert keys <= props, f"emitted keys not in schema: {keys - props}"
+        assert required <= keys, f"missing required keys: {required - keys}"
+
+
+def test_finding_rejects_non_str_confidence():
+    with pytest.raises(TypeError, match="confidence must be a str"):
+        _judged(confidence=123)
+
+
+def test_float_schema_version_is_rejected():
+    with pytest.raises(TypeError, match="schema_version must be an int"):
+        _structural(schema_version=4.5)
+
+
+# --- schema<->constructor parity: the wire pattern must reject exactly what the dataclass rejects,
+#     so a hand-authored payload can't smuggle a value past a validator the constructor would block.
+
+def test_schema_artifact_path_pattern_agrees_with_constructor():
+    rx = _ecma(SCHEMA["definitions"]["locus"]["properties"]["artifact_path"]["pattern"])
+    good = ["docs/a.md", "a/b/c.md", "a..b/c.md"]
+    bad = ["", "/abs.md", "docs\\a.md", "./x.md", "../x.md", "docs//a.md",
+           "a/./b.md", "a/../b.md", "docs/..", "a/", "docs/a\n.md"]
+    for path in good:
+        assert rx.match(path), f"schema pattern should accept {path!r}"
+        assert Locus(path).artifact_path == path  # constructor agrees
+    for path in bad:
+        assert not rx.match(path), f"schema pattern should reject {path!r} (traversal/malformed)"
+        with pytest.raises((ValueError, TypeError)):
+            Locus(path)  # constructor agrees
+
+
+def test_schema_message_pattern_agrees_with_constructor():
+    # Explicit-class pattern mirrors str.strip() exactly over the whole whitespace set, incl. the
+    # exotic U+001C-1F / U+0085 (blank to both) and U+FEFF (kept by both).
+    rx = re.compile(SCHEMA["properties"]["message"]["pattern"])
+
+    def ctor_accepts(message):
+        try:
+            _structural(message=message)
+            return True
+        except ValueError:
+            return False
+
+    for message in ("a real message", "\ufeff", "x\x1c", "a\nb", "", "   ", "\t", "\x85", "\x1c"):
+        assert bool(rx.search(message)) == ctor_accepts(message), \
+            f"schema/constructor disagree on message {message!r}"
+
+
+def test_finding_json_schema_returns_a_fresh_deep_copy():
+    # The wire contract is not a shared mutable global: each call yields an isolated copy.
+    first, second = finding_json_schema(), finding_json_schema()
+    assert first is not second
+    first["properties"]["severity"]["enum"].append("error")
+    assert "error" not in second["properties"]["severity"]["enum"]
+    assert "error" not in finding_json_schema()["properties"]["severity"]["enum"]
+
+
+# --- maintainer review: runtime type validation (fail at construction, not late) ---
+
+@pytest.mark.parametrize("bad", [123, None, 4.5, b"docs/a.md"])
+def test_locus_rejects_non_str_path(bad):
+    with pytest.raises(TypeError, match="artifact_path must be a str"):
+        Locus(bad)
+
+
+@pytest.mark.parametrize("bad_line", ["7", 4.5, True])
+def test_locus_rejects_non_int_line(bad_line):
+    with pytest.raises(TypeError, match="line must be an int"):
+        Locus("docs/a.md", line=bad_line)
+
+
+def test_locus_rejects_non_str_anchor():
+    with pytest.raises(TypeError, match="anchor must be a str"):
+        Locus("docs/a.md", anchor=3)
+
+
+def test_finding_rejects_non_locus_primary():
+    with pytest.raises(TypeError, match="primary must be a Locus"):
+        ArtifactFinding(detector="gap", severity="warn", kind="structural",
+                        message="x", primary="docs/a.md")
+
+
+def test_finding_rejects_non_str_message():
+    primary = Locus("docs/a.md")
+    with pytest.raises(TypeError, match="message must be a str"):
+        ArtifactFinding(detector="gap", severity="warn", kind="structural",
+                        message=123, primary=primary)
+
+
+def test_finding_rejects_non_locus_related():
+    with pytest.raises(TypeError, match="related must be a Locus"):
+        _judged(related="docs/b.md")
+
+
+def test_finding_rejects_non_str_verdict():
+    with pytest.raises(TypeError, match="verdict must be a str"):
+        _judged(verdict=123)
+
+
+def test_finding_rejects_non_bool_evidence_ok():
+    with pytest.raises(TypeError, match="evidence_ok must be a bool"):
+        _judged(evidence_ok="yes")
+
+
+# --- maintainer review: malformed paths / anchors, blank & structural-metadata rules ---
+
+@pytest.mark.parametrize("bad", ["./docs/a.md", "docs//a.md", "a/./b.md", "docs/a\n.md", "docs/a\tb.md"])
+def test_locus_rejects_malformed_paths(bad):
+    with pytest.raises(ValueError):
+        Locus(bad)
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "head\nline"])
+def test_locus_rejects_malformed_anchor(bad):
+    with pytest.raises(ValueError, match="anchor"):
+        Locus("docs/a.md", anchor=bad)
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_finding_rejects_blank_message(blank):
+    primary = Locus("docs/a.md")
+    with pytest.raises(ValueError, match="message must be non-empty"):
+        ArtifactFinding(detector="gap", severity="warn", kind="structural",
+                        message=blank, primary=primary)
+
+
+def test_structural_rejects_judged_only_metadata():
+    with pytest.raises(ValueError, match="no judged metadata"):
+        _structural(confidence="high")
+    with pytest.raises(ValueError, match="no judged metadata"):
+        _structural(evidence_ok=True)
+
+
+def test_bool_schema_version_is_rejected():
+    # True == 1 == SCHEMA_VERSION, so a value-equality check alone would let it through
+    with pytest.raises(TypeError, match="schema_version must be an int"):
+        _structural(schema_version=True)
+
+
+def test_schema_mirrors_the_tightened_invariants():
+    props = SCHEMA["properties"]
+    assert props["message"]["minLength"] == 1
+    locus = SCHEMA["definitions"]["locus"]["properties"]
+    assert "pattern" in locus["artifact_path"]
+    assert locus["anchor"]["minLength"] == 1
+    structural_then = next(c for c in SCHEMA["allOf"]
+                           if c["if"]["properties"]["kind"]["const"] == "structural")["then"]["allOf"]
+    assert {"not": {"required": ["confidence"]}} in structural_then
+    assert {"properties": {"evidence_ok": {"const": False}}} in structural_then
+
+
+# --- property-based / generated invariants (seed-deterministic; stdlib random, no Hypothesis dep) ---
+# Assert the load-bearing invariants over inputs neither the author nor the reviewers hand-picked.
+
+_PATH_ALPHABET = "abc/./../\\\t\n\x01 ."  # biased toward the tricky path characters
+
+
+def _rand_str(rng, alphabet, max_len):
+    return "".join(rng.choice(alphabet) for _ in range(rng.randint(0, max_len)))
+
+
+def test_property_locus_construction_is_total_and_safe():
+    # For ANY generated input, Locus either rejects with ValueError/TypeError or constructs and
+    # round-trips — it never raises an unexpected exception, and a constructed line is always >= 1.
+    rng = random.Random(20260903)
+    accepted = 0
+    for _ in range(400):
+        path = _rand_str(rng, _PATH_ALPHABET, 12)
+        anchor = None if rng.random() < 0.5 else _rand_str(rng, _PATH_ALPHABET, 5)
+        line = rng.choice([None, -2, 0, 1, 7, True, "3"])
+        try:
+            loc = Locus(path, anchor=anchor, line=line)
+        except (ValueError, TypeError):
+            continue  # rejection is a legal outcome
+        accepted += 1
+        assert loc.to_dict()["artifact_path"] == path
+        assert loc.line is None or loc.line >= 1
+    assert accepted > 0, "generator never produced a valid Locus — the accept-branch went vacuous"
+
+
+def test_property_schema_path_pattern_agrees_with_constructor_on_generated_paths():
+    # The wire regex must accept a generated path iff the constructor does — no smuggle gap either way.
+    rng = random.Random(31415926)
+    rx = _ecma(SCHEMA["definitions"]["locus"]["properties"]["artifact_path"]["pattern"])
+    seen = {True: 0, False: 0}
+    for _ in range(400):
+        path = _rand_str(rng, _PATH_ALPHABET, 14)
+        try:
+            Locus(path)
+            accepted_by_ctor = True
+        except (ValueError, TypeError):
+            accepted_by_ctor = False
+        seen[accepted_by_ctor] += 1
+        assert bool(rx.match(path)) == accepted_by_ctor, \
+            f"schema/constructor disagree on {path!r}: ctor={accepted_by_ctor}"
+    assert seen[True] > 0, "no path was accepted — the positive-agreement branch went vacuous"
+    assert seen[False] > 0, "no path was rejected — the negative-agreement branch went vacuous"
+
+
+def test_property_valid_finding_serialises_within_the_schema_shape():
+    # Any validly-constructed finding serialises to allowed keys only, always includes the required
+    # ones, and a structural finding never emits judged-only metadata.
+    rng = random.Random(27182818)
+    props = set(SCHEMA["properties"])
+    required = set(SCHEMA["required"])
+    for _ in range(300):
+        kind = rng.choice(KINDS)
+        judged = kind == "judged"
+        evidence_ok = rng.random() < 0.5 if judged else False
+        finding = ArtifactFinding(
+            detector=rng.choice(DETECTORS),
+            severity=rng.choice(SEVERITIES),
+            kind=kind,
+            message="m" + str(rng.randint(0, 99)),
+            primary=Locus("docs/a.md", line=rng.choice([None, 1, 5])),
+            # evidence must be non-empty when evidence_ok claims it verified
+            evidence=("quoted evidence" if evidence_ok else rng.choice(["", "quoted evidence"])),
+            suggested_action=rng.choice(["", "do the thing"]),
+            related=rng.choice([None, Locus("docs/b.md")]),
+            verdict=("drifted" if judged else None),
+            evidence_ok=evidence_ok,
+            confidence=(rng.choice([None, "high", "medium"]) if judged else None),
+        )
+        emitted = set(finding.to_dict())
+        assert emitted <= props
+        assert required <= emitted
+        if kind == "structural":
+            assert "verdict" not in emitted
+            assert "confidence" not in emitted
+            assert finding.to_dict()["evidence_ok"] is False
+
+
+# --- maintainer review round 3 (all Minor) -------------------------------------------------
+
+def test_locus_rejects_windows_drive_letter():
+    # a drive-letter segment is rejected in ANY position, not just leading
+    for bad in ("C:/x.md", "c:/x.md", "C:", "Z:/a/b.md", "sub/C:/x.md", "a/b/Z:/c.md"):
+        with pytest.raises(ValueError, match="drive letter"):
+            Locus(bad)
+    # a POSIX filename that merely contains a colon mid-name is still valid, any position
+    assert Locus("a:b.md").artifact_path == "a:b.md"
+    assert Locus("sub/a:b.md").artifact_path == "sub/a:b.md"
+
+
+def test_schema_path_pattern_rejects_drive_letter():
+    rx = _ecma(SCHEMA["definitions"]["locus"]["properties"]["artifact_path"]["pattern"])
+    assert not rx.match("C:/x.md")
+    assert not rx.match("C:")
+    assert not rx.match("sub/C:/x.md")  # embedded drive-letter segment also rejected
+    assert rx.match("a:b.md")  # colon mid-name allowed, matching the constructor
+    assert rx.match("sub/a:b.md")  # colon mid-name allowed in any segment
+
+
+def test_related_property_refs_the_locus_definition():
+    assert SCHEMA["properties"]["related"] == {"$ref": "#/definitions/locus"}
+
+
+def test_locus_and_finding_are_value_equal_and_hashable():
+    # frozen dataclasses -> structural equality + hashable (usable in sets / as dict keys).
+    # Bind separate instances so the equality is value-based, not identity (and not a self-compare).
+    loc, loc_copy = Locus("docs/a.md", line=3), Locus("docs/a.md", line=3)
+    assert loc == loc_copy
+    assert loc is not loc_copy
+    assert Locus("docs/a.md") != Locus("docs/b.md")
+    assert len({Locus("docs/a.md"), Locus("docs/a.md")}) == 1
+    finding, finding_copy = _structural(), _structural()
+    assert finding == finding_copy
+    assert finding is not finding_copy
+    assert len({finding, finding_copy}) == 1
+
+
+def test_message_whitespace_class_equals_str_strip_over_all_unicode():
+    # Codifies the exhaustive parity the review flagged: the message pattern's implicit whitespace
+    # class matches exactly the code points str.strip() removes (str.isspace()), across all Unicode.
+    rx = re.compile(SCHEMA["properties"]["message"]["pattern"])  # [^<whitespace class>]
+    strip_ws = {cp for cp in range(0x110000) if chr(cp).isspace()}
+    class_ws = {cp for cp in range(0x110000) if rx.search(chr(cp)) is None}
+    assert class_ws == strip_ws
+
+
+# tab / lf, a control, NEL (blank), U+2028 separator, BOM (kept) — the cases the anchor parity turns on
+_ANCHOR_ALPHA = "ab .-/" + chr(0x09) + chr(0x0a) + chr(0x01) + chr(0x85) + chr(0x2028) + chr(0xfeff)
+
+
+def test_property_schema_anchor_pattern_agrees_with_constructor_on_generated_anchors():
+    rng = random.Random(16180339)
+    rx = _ecma(SCHEMA["definitions"]["locus"]["properties"]["anchor"]["pattern"])
+    seen = {True: 0, False: 0}
+    for _ in range(400):
+        anchor = "".join(rng.choice(_ANCHOR_ALPHA) for _ in range(rng.randint(0, 8)))
+        try:
+            Locus("docs/a.md", anchor=anchor)
+            ok = True
+        except (ValueError, TypeError):
+            ok = False
+        seen[ok] += 1
+        assert bool(rx.match(anchor)) == ok, f"schema/constructor disagree on anchor {anchor!r}"
+    assert seen[True] > 0
+    assert seen[False] > 0
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_judged_finding_rejects_blank_verdict(blank):
+    # a judged finding needs a real verdict, not an empty/whitespace string (mirrors message)
+    with pytest.raises(ValueError, match="non-empty verdict"):
+        _judged(verdict=blank)
+
+
+def test_schema_verdict_is_non_blank_like_message():
+    verdict = SCHEMA["properties"]["verdict"]
+    assert verdict["type"] == "string"
+    # non-blank via the same explicit str.strip() class as message -> exact constructor parity,
+    # not ECMA \S (which diverges on U+0085 / U+FEFF)
+    assert verdict["pattern"] == SCHEMA["properties"]["message"]["pattern"]
+
+
+# --- maintainer review round 5: cross-field consistency ------------------------------------
+
+@pytest.mark.parametrize("empty", ["", "   "])
+def test_finding_rejects_evidence_ok_without_evidence(empty):
+    with pytest.raises(ValueError, match="evidence_ok is True but evidence is empty"):
+        _judged(evidence_ok=True, evidence=empty)
+
+
+def test_finding_rejects_related_equal_to_primary():
+    primary = Locus("docs/a.md", line=2)
+    same_as_primary = Locus("docs/a.md", line=2)
+    with pytest.raises(ValueError, match="related locus must differ from primary"):
+        _judged(primary=primary, related=same_as_primary)
+    # a different related locus is fine
+    assert _judged(primary=primary, related=Locus("docs/b.md")).related == Locus("docs/b.md")
+
+
+def test_unjudgeable_finding_rejects_judged_metadata():
+    with pytest.raises(ValueError, match="no judged metadata"):
+        _judged(verdict=VERDICT_UNJUDGEABLE, confidence="high", evidence_ok=False)
+    with pytest.raises(ValueError, match="no judged metadata"):
+        _judged(verdict=VERDICT_UNJUDGEABLE, confidence=None, evidence_ok=True)
+    # a well-formed unjudgeable finding carries neither
+    ok = _judged(verdict=VERDICT_UNJUDGEABLE, confidence=None, evidence_ok=False)
+    assert ok.verdict == VERDICT_UNJUDGEABLE
+
+
+def test_validation_order_type_error_precedes_value_error():
+    # __post_init__ runs types -> values -> consistency: a non-str field raises
+    # TypeError even when a value-stage violation (bad severity) is also present.
+    with pytest.raises(TypeError):
+        _structural(detector=123, severity="error")
+
+
+def test_validation_order_value_error_precedes_consistency_error():
+    # values run before cross-field consistency: a bad severity raises its
+    # ValueError even when a consistency violation (evidence_ok without evidence)
+    # is also present.
+    with pytest.raises(ValueError, match="advisory severity"):
+        _judged(severity="error", evidence_ok=True, evidence="")
+
+
+def test_schema_encodes_the_consistency_rules():
+    conds = SCHEMA["allOf"]
+    ev = next(c for c in conds if c["if"]["properties"].get("evidence_ok", {}).get("const") is True)
+    assert ev["then"]["properties"]["evidence"]["pattern"] == SCHEMA["properties"]["message"]["pattern"]
+    unj = next(c for c in conds if c["if"]["properties"].get("verdict", {}).get("const")
+               == VERDICT_UNJUDGEABLE)
+    assert {"not": {"required": ["confidence"]}} in unj["then"]["allOf"]
+    assert {"properties": {"evidence_ok": {"const": False}}} in unj["then"]["allOf"]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -15,6 +15,10 @@ from studio.utils.context import LoadedKit
 from studio.utils.doc_index import annotate_section_summary, diff_stale_sections
 from studio.utils.eval_harness import ReferencePresenceScorer, Scenario, ScorerKind, run_suite
 from studio.utils.eval_judge import Gold
+from studio.utils.artifact_quality import (
+    ArtifactFinding,
+    finding_json_schema,
+)
 from studio.utils.manifest import ManifestLayerState
 from studio.utils.okf import write_concept_file
 from studio.utils.change_summary import (
@@ -160,3 +164,15 @@ EventSelection.skipped_lines  # noqa: B018
 EventSelection.runless  # noqa: B018
 EventSelection.log_overridden  # noqa: B018
 RUN_UNATTRIBUTED  # noqa: B018
+
+# Artifact-quality finding model — public API consumed by detectors + the presentation layer,
+# which land in later tasks (feature `cpt-studio-feature-artifact-quality`; the scanning flow
+# `cpt-studio-flow-artifact-quality-assess` in architecture/features/artifact-quality.md), so these
+# are unreferenced within the scanned scope until then. REMOVAL TRIGGER — delete each entry once a
+# real consumer imports it: ArtifactFinding / finding_json_schema when the first detector or the
+# `cfs artifact-quality` command lands (i.e. once `cpt-studio-flow-artifact-quality-assess` is
+# implemented — grep that id here and check its `[ ]`→`[x]` in the feature doc). (VERDICT_UNJUDGEABLE
+# is now referenced in-module by the unjudgeable-metadata check, so it no longer needs an entry here.)
+# If a later refactor leaves one genuinely unused, delete its line rather than keep suppressing it.
+ArtifactFinding  # noqa: B018
+finding_json_schema  # noqa: B018


### PR DESCRIPTION
Adds the shared, advisory **finding model** every artifact-quality detector will emit — a frozen `ArtifactFinding` (with a `Locus`) plus a versioned `FINDING_JSON_SCHEMA` a presentation layer consumes. No detection logic here; the detectors and the `cfs artifact-quality` command are follow-ups.

## Why

Studio's deterministic layer assures *code* (`validate`, `spec-coverage`, CPT markers); the Project Markdown artifacts (Vision, PRD, epics, feature specs) have no comparable signal — nothing flags a requirement duplicated across three docs, content in the wrong doc type, a drifted trace link, or two artifacts that contradict. This is the first, standalone piece: one versioned finding shape so every detector speaks one contract and a UI can present findings side-by-side.

## The model — advisory and read-only

- **Never gates.** `severity` is only `info` / `warn` — there is deliberately no `error` and no exit-code authority.
- **No combined score, no edit payload.** Findings are individual signals carrying evidence and a *suggested* action.
- **Structural vs judged.** A structural finding carries `verdict = None`; a judged finding carries a detector-namespaced verdict (or `unjudgeable`).
- **Validated on construction.** Unknown detector / severity / kind, or a structural-with-verdict / judged-without-verdict, all raise — so a malformed finding never reaches the report.

## Tests & gates

- 13 unit tests: construction (valid + every raising case), `to_dict` shape (required keys + omitted-when-unset), the no-score / no-edit and advisory-severity invariants, the structural-vs-judged verdict rule, and the JSON-schema contract.
- **CPT-traced** — `@cpt` markers 1:1 with the new `architecture/features/artifact-quality.md`; `cfs validate` **PASS** (0 errors).
- Gates green locally: `spec-coverage` thresholds met (granularity 0.4605 ≥ 0.46 floor), `pylint`, `vulture-ci`, full suite, per-file coverage (`artifact_quality.py` **100%**).

Part of #114 — this delivers the shared finding model + JSON schema; the shared advisory seam and the `cfs artifact-quality` command are deferred scope tracked as later tasks, so the issue is referenced rather than auto-closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standardized, versioned format for reporting advisory quality findings on Project Markdown artifacts.
  - Findings can include severity, category, location, evidence, suggested actions, and optional evaluation details.
  - Findings are read-only and do not produce combined scores, editing instructions, or gating decisions.

- **Documentation**
  - Added Artifact Quality feature and architecture documentation, including planned future command-line support.

- **Tests**
  - Added coverage for finding validation, serialization, schema compliance, and advisory/read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
