### PR TITLE
fix(cascade,okf): resolve PR #111 round-3 CodeRabbit findings that missed main

### DIFF
--- a/skills/studio/scripts/studio/commands/cascade.py
+++ b/skills/studio/scripts/studio/commands/cascade.py
@@ -8,10 +8,9 @@ Thin CLI wrapper around ``studio.utils.cascade``.
 """
 
 import argparse
-import math
 from typing import List
 
-from ..utils.cascade import _TIER2_BREAK_EVEN_ESCALATIONS, route_query
+from ..utils.cascade import _TIER2_BREAK_EVEN_ESCALATIONS, _check_margin_threshold_value, route_query
 from ..utils.doc_index import _MAX_ESCALATION_KEY_LENGTH
 from ..utils.ui import ui
 
@@ -28,14 +27,25 @@ def _margin_threshold_arg(value: str) -> float:
     result, defeating that safety margin entirely; only a genuine positive
     finite number is accepted, mirroring ``commands/eval.py``'s
     ``_compliance_arg`` validator for the same class of hazard.
+
+    Parses the argparse string to ``float`` first (a string input like
+    ``"0.5"`` is a legitimate CLI value -- unlike the direct Python API in
+    ``utils/cascade.py``'s :func:`~studio.utils.cascade._validate_margin_threshold`,
+    which requires an already-numeric value and rejects a string outright),
+    then delegates the finite/positive check to the same shared
+    ``_check_margin_threshold_value`` helper :func:`_validate_margin_threshold`
+    uses, so both entry points enforce one identical policy instead of two
+    independently drifting copies of it.
     """
     try:
         parsed = float(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"invalid float value: {value!r}") from exc
-    if not math.isfinite(parsed) or parsed <= 0:
+    try:
+        _check_margin_threshold_value(parsed)
+    except ValueError as exc:
         raise argparse.ArgumentTypeError(
-            f"--margin-threshold must be a finite number > 0, got {value!r}")
+            f"--margin-threshold must be a finite number > 0, got {value!r}") from exc
     return parsed
 
 

--- a/skills/studio/scripts/studio/utils/cascade.py
+++ b/skills/studio/scripts/studio/utils/cascade.py
@@ -126,6 +126,22 @@ def _as_candidate(section: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _validate_margin_threshold(margin_threshold: Optional[float]) -> None:
+    """Reject a non-finite or non-positive ``margin_threshold`` before it can
+    reach row 4's comparison.
+
+    ``commands/cascade.py``'s ``_margin_threshold_arg`` enforces this same
+    rule for the CLI, but a direct Python caller of :func:`route_tier1`/
+    :func:`route_query` bypasses argparse entirely -- without this check
+    here too, a non-positive or non-finite threshold would make
+    ``tfidf_result["margin"] >= margin_threshold`` fire on virtually any
+    finite margin, silently defeating the "no finite value is yet proven
+    safe" design basis this module's own docstring documents.
+    """
+    if margin_threshold is not None and not (math.isfinite(margin_threshold) and margin_threshold > 0):
+        raise ValueError(f"margin_threshold must be a finite number > 0, got {margin_threshold!r}")
+
+
 # @cpt-begin:cpt-studio-algo-traceability-validation-cascade:p1:inst-cascade-tier1
 def _route_tier1_heading_nav_miss(
     tfidf_ranked: List[Dict[str, Any]], has_tfidf_signal: bool, tfidf_result: Dict[str, Any],
@@ -177,6 +193,7 @@ def route_tier1(path: Path, query: str, *, margin_threshold: Optional[float] = N
     assumption (validated against a single ~166-page, ~9-section document,
     deliberately no cap on section count or file size) this cost relies on.
     """
+    _validate_margin_threshold(margin_threshold)
     nav_first_match = find_sections(path, query)["first_match"]
     # Unconditional, even when heading-nav already found a hit: fusing the
     # two signals (this function's whole purpose, see the module docstring)

--- a/skills/studio/scripts/studio/utils/cascade.py
+++ b/skills/studio/scripts/studio/utils/cascade.py
@@ -138,7 +138,22 @@ def _validate_margin_threshold(margin_threshold: Optional[float]) -> None:
     finite margin, silently defeating the "no finite value is yet proven
     safe" design basis this module's own docstring documents.
     """
-    if margin_threshold is not None and not (math.isfinite(margin_threshold) and margin_threshold > 0):
+    if margin_threshold is None:
+        return
+    # isinstance guards math.isfinite() itself: it raises TypeError for any
+    # non-numeric argument, which would propagate out before the ValueError
+    # below ever runs -- defeating this function's own documented contract
+    # for exactly the direct-Python-caller case its docstring exists for
+    # (the CLI's argparse type already coerces to float before this is
+    # ever reached, so only a direct caller can hit this). bool is
+    # deliberately excluded even though it subclasses int: True/False are
+    # not meaningful margin thresholds, and isfinite(True) would otherwise
+    # silently accept one.
+    if (
+        isinstance(margin_threshold, bool)
+        or not isinstance(margin_threshold, (int, float))
+        or not (math.isfinite(margin_threshold) and margin_threshold > 0)
+    ):
         raise ValueError(f"margin_threshold must be a finite number > 0, got {margin_threshold!r}")
 
 

--- a/skills/studio/scripts/studio/utils/cascade.py
+++ b/skills/studio/scripts/studio/utils/cascade.py
@@ -67,6 +67,7 @@ option that fits what this codebase can actually guarantee.
 
 from __future__ import annotations
 
+import logging
 import math
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
@@ -76,6 +77,8 @@ from .heading_nav import find_sections
 from .okf import get_okf_status
 from .read_gate import check_gate
 from .tfidf import score_sections
+
+logger = logging.getLogger(__name__)
 
 #: Real, measured per-query token rates (see the design session's findings).
 _OKF_BUILD_COST_TOKENS = 301_187
@@ -126,35 +129,61 @@ def _as_candidate(section: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _check_margin_threshold_value(value: float) -> None:
+    """Raise ``ValueError`` unless ``value`` is a finite number > 0.
+
+    The single source of truth for the "finite and positive" rule, shared
+    by :func:`_validate_margin_threshold` (the direct Python API, which
+    requires ``value`` to already be numeric -- no string coercion) and
+    ``commands/cascade.py``'s ``_margin_threshold_arg`` (the CLI, which
+    parses the argparse string to ``float`` *first* and then delegates the
+    finite/positive check here, translating a ``ValueError`` into
+    ``argparse.ArgumentTypeError``). Before this was extracted, both call
+    sites duplicated this exact check independently -- accepting different
+    input domains (the CLI coerced ``"0.5"`` to ``0.5`` and accepted it,
+    while this function rejects a bare string outright) was an accident of
+    that duplication, not an intentional difference in policy, and the two
+    copies could silently drift further apart on any future edit to just
+    one of them.
+
+    isinstance guards ``math.isfinite()`` itself: it raises ``TypeError``
+    for any non-numeric argument, which would propagate out before the
+    ``ValueError`` below ever runs. bool is deliberately excluded even
+    though it subclasses int: True/False are not meaningful margin
+    thresholds, and ``isfinite(True)`` would otherwise silently accept one.
+    """
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not (math.isfinite(value) and value > 0)
+    ):
+        raise ValueError(f"margin_threshold must be a finite number > 0, got {value!r}")
+
+
 def _validate_margin_threshold(margin_threshold: Optional[float]) -> None:
     """Reject a non-finite or non-positive ``margin_threshold`` before it can
     reach row 7's comparison.
 
     ``commands/cascade.py``'s ``_margin_threshold_arg`` enforces this same
-    rule for the CLI, but a direct Python caller of :func:`route_tier1`/
-    :func:`route_query` bypasses argparse entirely -- without this check
-    here too, a non-positive or non-finite threshold would make
+    rule for the CLI (via the shared :func:`_check_margin_threshold_value`),
+    but a direct Python caller of :func:`route_tier1`/:func:`route_query`
+    bypasses argparse entirely -- without this check here too, a
+    non-positive or non-finite threshold would make
     ``tfidf_result["margin"] >= margin_threshold`` fire on virtually any
     finite margin, silently defeating the "no finite value is yet proven
     safe" design basis this module's own docstring documents.
+
+    A rejection is logged (not just raised) so a direct Python caller --
+    which has no argparse error surface of its own to fall back on -- still
+    leaves a structured trace of what was rejected and why.
     """
     if margin_threshold is None:
         return
-    # isinstance guards math.isfinite() itself: it raises TypeError for any
-    # non-numeric argument, which would propagate out before the ValueError
-    # below ever runs -- defeating this function's own documented contract
-    # for exactly the direct-Python-caller case its docstring exists for
-    # (the CLI's argparse type already coerces to float before this is
-    # ever reached, so only a direct caller can hit this). bool is
-    # deliberately excluded even though it subclasses int: True/False are
-    # not meaningful margin thresholds, and isfinite(True) would otherwise
-    # silently accept one.
-    if (
-        isinstance(margin_threshold, bool)
-        or not isinstance(margin_threshold, (int, float))
-        or not (math.isfinite(margin_threshold) and margin_threshold > 0)
-    ):
-        raise ValueError(f"margin_threshold must be a finite number > 0, got {margin_threshold!r}")
+    try:
+        _check_margin_threshold_value(margin_threshold)
+    except ValueError:
+        logger.warning("rejected invalid margin_threshold: %r", margin_threshold)
+        raise
 
 
 # @cpt-begin:cpt-studio-algo-traceability-validation-cascade:p1:inst-cascade-tier1

--- a/skills/studio/scripts/studio/utils/cascade.py
+++ b/skills/studio/scripts/studio/utils/cascade.py
@@ -128,7 +128,7 @@ def _as_candidate(section: Dict[str, Any]) -> Dict[str, Any]:
 
 def _validate_margin_threshold(margin_threshold: Optional[float]) -> None:
     """Reject a non-finite or non-positive ``margin_threshold`` before it can
-    reach row 4's comparison.
+    reach row 7's comparison.
 
     ``commands/cascade.py``'s ``_margin_threshold_arg`` enforces this same
     rule for the CLI, but a direct Python caller of :func:`route_tier1`/
@@ -207,6 +207,13 @@ def route_tier1(path: Path, query: str, *, margin_threshold: Optional[float] = N
     oversight -- see ``tfidf.py``'s own module docstring for the scale
     assumption (validated against a single ~166-page, ~9-section document,
     deliberately no cap on section count or file size) this cost relies on.
+
+    Raises ``ValueError`` if ``margin_threshold`` is not ``None`` and not a
+    finite number > 0 (see :func:`_validate_margin_threshold`). This is
+    checked unconditionally as the very first step, before ``nav_first_match``
+    is even computed -- so it raises even for a query that would otherwise
+    hit row 1 (``no_signal_from_either_method``), which never reads
+    ``margin_threshold`` at all.
     """
     _validate_margin_threshold(margin_threshold)
     nav_first_match = find_sections(path, query)["first_match"]
@@ -431,6 +438,10 @@ def route_query(
     query attempt, so a caller retrying this same query after a transient
     failure or timeout can pass the same key again and not double-count
     the Tier-2 escalation (constructorfabric/studio#136).
+
+    Raises ``ValueError`` for an invalid ``margin_threshold`` -- this calls
+    :func:`route_tier1` first, which validates it unconditionally before
+    doing anything else (see that function's own docstring).
     """
     tier1 = route_tier1(path, query, margin_threshold=margin_threshold)
     result: Dict[str, Any] = {"query": query, **tier1}

--- a/skills/studio/scripts/studio/utils/okf.py
+++ b/skills/studio/scripts/studio/utils/okf.py
@@ -292,19 +292,21 @@ def _match_sections_by_hash(
 
 def _concept_file_is_valid(concept_path: Path) -> bool:
     """Minimal content-validity check for a concept file already confirmed
-    to exist on disk: real content always opens with the YAML frontmatter
-    block :func:`_build_frontmatter` writes. A physical-presence check
-    alone (``is_file()``) can't tell a genuine concept file from one
-    truncated, emptied, or corrupted after the fact -- this catches that
-    without needing full YAML parsing, which is more than this check needs
-    to answer "is there real content here at all".
+    to exist on disk: real content always opens *and closes* the YAML
+    frontmatter block :func:`_build_frontmatter` writes. A physical-presence
+    check alone (``is_file()``) can't tell a genuine concept file from one
+    truncated, emptied, or corrupted after the fact -- checking only the
+    opening ``---`` doesn't either, since a file truncated right after it
+    still passes that alone; requiring the closing delimiter too catches
+    that without needing full YAML parsing, which is more than this check
+    needs to answer "is there real content here at all".
     """
     try:
         content = concept_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         logger.debug("okf concept file unreadable at %s: %s", concept_path, exc)
         return False
-    return content.startswith("---\n")
+    return content.startswith("---\n") and "\n---\n" in content[4:]
 
 
 def _resolve_section_status(

--- a/skills/studio/scripts/studio/utils/okf.py
+++ b/skills/studio/scripts/studio/utils/okf.py
@@ -290,23 +290,51 @@ def _match_sections_by_hash(
     return matched_by_position
 
 
+#: Every frontmatter key :func:`_build_frontmatter` always writes. A file
+#: with valid opening/closing delimiters but missing one of these (or with
+#: nothing but whitespace for its value) was never actually produced by
+#: this module's own writer -- truncated, hand-edited, or corrupted instead.
+_REQUIRED_FRONTMATTER_FIELDS = ("title", "description", "resource", "generated")
+
+
 def _concept_file_is_valid(concept_path: Path) -> bool:
-    """Minimal content-validity check for a concept file already confirmed
-    to exist on disk: real content always opens *and closes* the YAML
-    frontmatter block :func:`_build_frontmatter` writes. A physical-presence
-    check alone (``is_file()``) can't tell a genuine concept file from one
-    truncated, emptied, or corrupted after the fact -- checking only the
-    opening ``---`` doesn't either, since a file truncated right after it
-    still passes that alone; requiring the closing delimiter too catches
-    that without needing full YAML parsing, which is more than this check
-    needs to answer "is there real content here at all".
+    """Content-validity check for a concept file already confirmed to exist
+    on disk: real content always opens *and closes* the YAML frontmatter
+    block :func:`_build_frontmatter` writes, that frontmatter always carries
+    every one of :data:`_REQUIRED_FRONTMATTER_FIELDS` with a non-blank
+    value, and there's always a non-blank body after it.
+
+    A physical-presence check alone (``is_file()``) can't tell a genuine
+    concept file from one truncated, emptied, or corrupted after the fact.
+    Checking only the delimiters doesn't fully catch it either: a file
+    truncated right after the opening ``---`` fails that, but a file with
+    *both* delimiters present and otherwise-empty or partial frontmatter
+    (say, a hand-edited file missing ``description``, or one truncated
+    right at the closing ``---`` with no body at all) would still pass a
+    delimiters-only check while never having been a real generated concept
+    file. Parsing each field with a simple per-line regex (rather than a
+    full YAML parser this codebase doesn't otherwise depend on for this)
+    is enough to answer "is there real, complete content here" without
+    pulling in a heavier dependency.
     """
     try:
         content = concept_path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as exc:
         logger.debug("okf concept file unreadable at %s: %s", concept_path, exc)
         return False
-    return content.startswith("---\n") and "\n---\n" in content[4:]
+    if not content.startswith("---\n"):
+        return False
+    closing = content.find("\n---\n", 4)
+    if closing == -1:
+        return False
+    frontmatter = content[4:closing]
+    body = content[closing + len("\n---\n"):]
+    if not body.strip():
+        return False
+    return all(
+        re.search(rf"(?m)^{field}:[ \t]*\S", frontmatter) is not None
+        for field in _REQUIRED_FRONTMATTER_FIELDS
+    )
 
 
 def _resolve_section_status(

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -225,6 +225,26 @@ class TestRouteTier1:
         assert result["tier"] == "resolved"
         assert result["reason"] == "heading_nav_tfidf_agree_large_margin"
 
+    @pytest.mark.parametrize("bad_threshold", [0, -1, float("nan"), float("inf")])
+    def test_margin_threshold_rejects_invalid_values_at_the_callable_api(
+        self, tmp_path: Path, monkeypatch, bad_threshold,
+    ):
+        """A direct Python caller bypasses commands/cascade.py's argparse
+        validation entirely -- without a check here too, a non-positive or
+        non-finite threshold would make the row-4 margin comparison fire on
+        virtually any finite margin, defeating the "no finite value is yet
+        proven safe" design basis."""
+        monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+        f = _write(tmp_path, _DIFFUSE_MARGIN_SAMPLE)
+        with pytest.raises(ValueError, match="margin_threshold"):
+            route_tier1(f, "widget", margin_threshold=bad_threshold)
+
+    def test_route_query_also_rejects_an_invalid_margin_threshold(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+        f = _write(tmp_path, _DIFFUSE_MARGIN_SAMPLE)
+        with pytest.raises(ValueError, match="margin_threshold"):
+            route_query(f, "widget", margin_threshold=-1.0)
+
     def test_route_tier1_never_touches_okf(self, tmp_path: Path, monkeypatch):
         """The module docstring guarantees route_tier1 stays free and
         deterministic by never touching the OKF bundle, but nothing

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -5,14 +5,16 @@ See constructorfabric/studio#104.
 
 from __future__ import annotations
 
+import argparse
 import json
+import logging
 import re
 from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from studio.commands.cascade import cmd_retrieve
+from studio.commands.cascade import _margin_threshold_arg, cmd_retrieve
 from studio.utils import cascade
 from studio.utils.cascade import route_query, route_tier1, route_tier2
 from studio.utils.doc_index import get_or_build_doc_index
@@ -256,6 +258,21 @@ class TestRouteTier1:
         with pytest.raises(ValueError, match=f"^{expected}$"):
             route_tier1(f, "widget", margin_threshold=bad_threshold)
 
+    def test_margin_threshold_rejection_emits_a_diagnostic_log(self, tmp_path: Path, monkeypatch, caplog):
+        """studio#135 round-4 review: a direct Python caller of route_tier1
+        (not going through the CLI's argparse, which has its own error
+        surface) previously got a bare ValueError with no structured log
+        trace. _validate_margin_threshold now logs a warning, with the
+        rejected value safely %r-repr'd, immediately before raising."""
+        monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+        f = _write(tmp_path, _DIFFUSE_MARGIN_SAMPLE)
+        with caplog.at_level(logging.WARNING, logger="studio.utils.cascade"):
+            with pytest.raises(ValueError):
+                route_tier1(f, "widget", margin_threshold=-1)
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.WARNING
+        assert "-1" in caplog.records[0].getMessage()
+
     @pytest.mark.parametrize("bad_threshold", _BAD_MARGIN_THRESHOLDS)
     def test_route_query_rejects_the_same_invalid_margin_thresholds_as_route_tier1(
         self, tmp_path: Path, monkeypatch, bad_threshold,
@@ -324,6 +341,40 @@ class TestRouteTier1:
         result = route_fn(f, "widget", margin_threshold=accepted_threshold)  # must not raise
         assert result["tier"] == expected_tier
         assert result["reason"] == expected_reason
+
+    @pytest.mark.parametrize(
+        "bad_threshold", [t for t in _BAD_MARGIN_THRESHOLDS if not isinstance(t, str)],
+    )
+    def test_cli_arg_parser_rejects_the_same_numeric_boundary_values_as_the_direct_api(
+        self, bad_threshold,
+    ):
+        """studio#135 round-4 review: commands/cascade.py's
+        _margin_threshold_arg and this module's _validate_margin_threshold
+        used to implement the finite-and-positive rule as two independently
+        maintained checks that could silently drift apart. Both now
+        delegate to the same _check_margin_threshold_value helper -- this
+        reuses _BAD_MARGIN_THRESHOLDS (minus the non-numeric-string entry,
+        which exercises the CLI's *intentionally different* input domain,
+        see the next test) to prove every numeric value the direct API
+        rejects is also rejected at the CLI once coerced through argparse's
+        own string input.
+        """
+        with pytest.raises(argparse.ArgumentTypeError):
+            _margin_threshold_arg(str(bad_threshold))
+
+    def test_cli_arg_parser_accepts_a_numeric_string_the_direct_api_rejects(self):
+        """The one deliberate difference between the two entry points: the
+        CLI's natural input is a string, so parsing "0.5" to 0.5 first and
+        then applying the shared finite/positive check is correct CLI
+        behavior -- unlike _validate_margin_threshold (the direct Python
+        API), which requires an already-numeric value and correctly rejects
+        the bare string "0.5" (see
+        test_margin_threshold_rejects_invalid_values_at_the_callable_api).
+        Both entry points share one identical accept/reject policy for the
+        finite-and-positive check itself; they differ only in what they
+        accept as *input* before that check ever runs.
+        """
+        assert _margin_threshold_arg("0.5") == 0.5
 
     def test_route_tier1_never_touches_okf(self, tmp_path: Path, monkeypatch):
         """The module docstring guarantees route_tier1 stays free and

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -6,6 +6,7 @@ See constructorfabric/studio#104.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from unittest import mock
 
@@ -225,7 +226,17 @@ class TestRouteTier1:
         assert result["tier"] == "resolved"
         assert result["reason"] == "heading_nav_tfidf_agree_large_margin"
 
-    @pytest.mark.parametrize("bad_threshold", [0, -1, float("nan"), float("inf")])
+    #: Non-finite/non-positive numeric values, plus a non-numeric string and
+    #: a bool -- the latter two exist to pin down a real bug (studio#135's
+    #: review): math.isfinite() raises TypeError for either, which would
+    #: propagate out before the intended ValueError ever ran, defeating
+    #: _validate_margin_threshold's documented contract for exactly the
+    #: direct-Python-caller case its docstring exists for. bool is checked
+    #: separately from the numeric cases since it subclasses int and would
+    #: otherwise slip past a bare isinstance(x, (int, float)) check.
+    _BAD_MARGIN_THRESHOLDS = [0, -1, float("nan"), float("inf"), "0.5", True]
+
+    @pytest.mark.parametrize("bad_threshold", _BAD_MARGIN_THRESHOLDS)
     def test_margin_threshold_rejects_invalid_values_at_the_callable_api(
         self, tmp_path: Path, monkeypatch, bad_threshold,
     ):
@@ -236,14 +247,36 @@ class TestRouteTier1:
         proven safe" design basis."""
         monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
         f = _write(tmp_path, _DIFFUSE_MARGIN_SAMPLE)
-        with pytest.raises(ValueError, match="margin_threshold"):
+        expected = re.escape(f"margin_threshold must be a finite number > 0, got {bad_threshold!r}")
+        with pytest.raises(ValueError, match=f"^{expected}$"):
             route_tier1(f, "widget", margin_threshold=bad_threshold)
 
-    def test_route_query_also_rejects_an_invalid_margin_threshold(self, tmp_path: Path, monkeypatch):
+    @pytest.mark.parametrize("bad_threshold", _BAD_MARGIN_THRESHOLDS)
+    def test_route_query_rejects_the_same_invalid_margin_thresholds_as_route_tier1(
+        self, tmp_path: Path, monkeypatch, bad_threshold,
+    ):
+        """route_query shares _validate_margin_threshold with route_tier1 via
+        the same call path -- mirrors that test's full matrix instead of a
+        single hard-coded value, so a future refactor that decoupled the two
+        validation paths would be caught here rather than silently letting
+        an invalid threshold through route_query specifically."""
         monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
         f = _write(tmp_path, _DIFFUSE_MARGIN_SAMPLE)
-        with pytest.raises(ValueError, match="margin_threshold"):
-            route_query(f, "widget", margin_threshold=-1.0)
+        expected = re.escape(f"margin_threshold must be a finite number > 0, got {bad_threshold!r}")
+        with pytest.raises(ValueError, match=f"^{expected}$"):
+            route_query(f, "widget", margin_threshold=bad_threshold)
+
+    @pytest.mark.parametrize("route_fn", [route_tier1, route_query])
+    def test_a_large_finite_margin_threshold_is_accepted_not_just_rejected_values(
+        self, tmp_path: Path, monkeypatch, route_fn,
+    ):
+        """The accept path, not just the reject path: a legitimately large
+        but finite threshold (e.g. an explicit, permissive opt-in) must not
+        itself be treated as invalid by either entry point."""
+        monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+        f = _write(tmp_path, _DIFFUSE_MARGIN_SAMPLE)
+        result = route_fn(f, "widget", margin_threshold=1e10)  # must not raise
+        assert "tier" in result
 
     def test_route_tier1_never_touches_okf(self, tmp_path: Path, monkeypatch):
         """The module docstring guarantees route_tier1 stays free and

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -234,7 +234,12 @@ class TestRouteTier1:
     #: direct-Python-caller case its docstring exists for. bool is checked
     #: separately from the numeric cases since it subclasses int and would
     #: otherwise slip past a bare isinstance(x, (int, float)) check.
-    _BAD_MARGIN_THRESHOLDS = (0, -1, float("nan"), float("inf"), "0.5", True)
+    #: 0 and -1 are both finite and only violate ``> 0``; nan/inf/-inf are
+    #: all non-finite; -0.0 is finite, non-positive (``-0.0 > 0`` is False),
+    #: and adjacent to the boundary -- a case none of the other values pin
+    #: down, since 0 and -1 don't distinguish "wrong sign" from "IEEE
+    #: negative zero specifically".
+    _BAD_MARGIN_THRESHOLDS = (0, -1, float("nan"), float("inf"), float("-inf"), -0.0, "0.5", True)
 
     @pytest.mark.parametrize("bad_threshold", _BAD_MARGIN_THRESHOLDS)
     def test_margin_threshold_rejects_invalid_values_at_the_callable_api(
@@ -242,7 +247,7 @@ class TestRouteTier1:
     ):
         """A direct Python caller bypasses commands/cascade.py's argparse
         validation entirely -- without a check here too, a non-positive or
-        non-finite threshold would make the row-4 margin comparison fire on
+        non-finite threshold would make the row-7 margin comparison fire on
         virtually any finite margin, defeating the "no finite value is yet
         proven safe" design basis."""
         monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
@@ -266,17 +271,59 @@ class TestRouteTier1:
         with pytest.raises(ValueError, match=f"^{expected}$"):
             route_query(f, "widget", margin_threshold=bad_threshold)
 
-    @pytest.mark.parametrize("route_fn", [route_tier1, route_query])
-    def test_a_large_finite_margin_threshold_is_accepted_not_just_rejected_values(
-        self, tmp_path: Path, monkeypatch, route_fn,
+    @pytest.mark.parametrize("bad_threshold", _BAD_MARGIN_THRESHOLDS)
+    def test_margin_threshold_is_validated_even_when_heading_nav_finds_no_hits(
+        self, tmp_path: Path, monkeypatch, bad_threshold,
     ):
-        """The accept path, not just the reject path: a legitimately large
-        but finite threshold (e.g. an explicit, permissive opt-in) must not
-        itself be treated as invalid by either entry point."""
+        """Real behavior change introduced by this PR, with no prior direct
+        test coverage (studio#135 round-2 review): _validate_margin_threshold
+        is now called unconditionally as the very first statement of
+        route_tier1, before nav_first_match is even computed. Previously,
+        margin_threshold was only read/compared at row 7 -- a query that
+        escalates at row 1 instead (heading-nav: 0 hits, so
+        tfidf_result["margin"] is never reached) would have returned the
+        escalate result silently regardless of how invalid margin_threshold
+        was. Pins down that the same invalid threshold now raises ValueError
+        here too, before row 1 even runs."""
+        monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+        f = _write(tmp_path)  # heading-nav has zero hits for "making up" (row 1, see test_row1_*)
+        expected = re.escape(f"margin_threshold must be a finite number > 0, got {bad_threshold!r}")
+        with pytest.raises(ValueError, match=f"^{expected}$"):
+            route_tier1(f, "making up", margin_threshold=bad_threshold)
+
+    @pytest.mark.parametrize("route_fn", [route_tier1, route_query])
+    @pytest.mark.parametrize(
+        "accepted_threshold, expected_tier, expected_reason",
+        [
+            # Tiny-but-positive: proves the smallest legitimate values pass
+            # validation, and (well below _DIFFUSE_MARGIN_SAMPLE's actual
+            # measured margin of 99.0 for "widget") resolves at Tier 1.
+            (1e-9, "resolved", "heading_nav_tfidf_agree_large_margin"),
+            # Enormous but finite: proves a large value isn't itself
+            # rejected by validation either -- but since it's far above the
+            # fixture's real margin (99.0), row 7's comparison correctly
+            # still escalates. Asserting this exact tier/reason, rather than
+            # a large threshold always meaning "resolved", is what catches a
+            # mutation that broke the margin comparison itself (e.g. flipped
+            # the operator, or dropped it so any finite threshold resolves).
+            (1e10, "escalate", "diffuse_margin"),
+        ],
+    )
+    def test_a_large_or_tiny_finite_margin_threshold_is_accepted_not_just_rejected_values(
+        self, tmp_path: Path, monkeypatch, route_fn, accepted_threshold, expected_tier, expected_reason,
+    ):
+        """The accept path, not just the reject path: neither a tiny-but-
+        positive nor an enormous finite threshold is itself treated as
+        invalid by either entry point. Asserts the actual tier/reason the
+        fixture produces for each, not just that some dict with a "tier" key
+        came back -- a mutation that returned an arbitrary tier value, or
+        broke the row-7 margin comparison, would still pass a bare "tier" in
+        result check but not this one."""
         monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
         f = _write(tmp_path, _DIFFUSE_MARGIN_SAMPLE)
-        result = route_fn(f, "widget", margin_threshold=1e10)  # must not raise
-        assert "tier" in result
+        result = route_fn(f, "widget", margin_threshold=accepted_threshold)  # must not raise
+        assert result["tier"] == expected_tier
+        assert result["reason"] == expected_reason
 
     def test_route_tier1_never_touches_okf(self, tmp_path: Path, monkeypatch):
         """The module docstring guarantees route_tier1 stays free and

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -234,7 +234,7 @@ class TestRouteTier1:
     #: direct-Python-caller case its docstring exists for. bool is checked
     #: separately from the numeric cases since it subclasses int and would
     #: otherwise slip past a bare isinstance(x, (int, float)) check.
-    _BAD_MARGIN_THRESHOLDS = [0, -1, float("nan"), float("inf"), "0.5", True]
+    _BAD_MARGIN_THRESHOLDS = (0, -1, float("nan"), float("inf"), "0.5", True)
 
     @pytest.mark.parametrize("bad_threshold", _BAD_MARGIN_THRESHOLDS)
     def test_margin_threshold_rejects_invalid_values_at_the_callable_api(

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -109,6 +109,25 @@ class TestGetOkfStatus:
         by_heading = {e["heading"]: e for e in status["entries"]}
         assert by_heading["Introduction"]["status"] == "missing"
 
+    def test_truncated_right_after_the_opening_delimiter_reports_missing(self, tmp_path: Path, monkeypatch):
+        """CodeRabbit PR #111: a concept file cut off right after the
+        opening ``---`` still starts with it, so checking only that would
+        report a genuinely unusable file as current. The closing delimiter
+        must be present too."""
+        monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+        f = _write(tmp_path)
+        index = get_or_build_doc_index(f)
+        intro = index["retrieval_sections"][0]
+        write_concept_file(f, intro["line_start"], description="d", body="b")
+        assert get_okf_status(f)["entries"][0]["status"] == "current"
+
+        bundle_dir = _okf_bundle_dir(f)
+        (bundle_dir / "01-introduction.md").write_text("---\n", encoding="utf-8")
+
+        status = get_okf_status(f)
+        by_heading = {e["heading"]: e for e in status["entries"]}
+        assert by_heading["Introduction"]["status"] == "missing"
+
     def test_editing_the_source_after_writing_reports_stale(self, tmp_path: Path, monkeypatch):
         monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
         f = _write(tmp_path)

--- a/tests/test_okf.py
+++ b/tests/test_okf.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from studio.commands.okf import cmd_okf_status
 from studio.utils.doc_index import get_or_build_doc_index
 from studio.utils.okf import (
+    _concept_file_is_valid,
     _okf_bundle_dir,
     get_okf_status,
     load_okf_manifest,
@@ -297,6 +300,78 @@ class TestGetOkfStatus:
         assert all(e["status"] == "current" for e in after_details)
         after_files = sorted(e["concept_file"] for e in after_details)
         assert after_files == sorted(before_files.values())
+
+
+class TestConceptFileIsValid:
+    """studio#135 round-4 review: delimiters alone (opening and closing
+    ``---``) were being treated as sufficient for "this concept file is
+    current" -- a file with both delimiters present but missing a required
+    generated field, or with degenerate/empty content between them, was
+    incorrectly reported valid rather than being rebuilt.
+    """
+
+    _VALID_FRONTMATTER_LINES = (
+        'title: "Introduction"',
+        'description: "d"',
+        'resource: "doc.md#L1-L4"',
+        'generated: { by: "test", at: "2024-01-01T00:00:00Z" }',
+    )
+
+    @staticmethod
+    def _build(frontmatter_lines, body="Real body content.\n"):
+        return "---\n" + "\n".join(frontmatter_lines) + "\n---\n\n" + body
+
+    def test_well_formed_file_is_valid(self, tmp_path: Path):
+        f = tmp_path / "concept.md"
+        f.write_text(self._build(self._VALID_FRONTMATTER_LINES), encoding="utf-8")
+        assert _concept_file_is_valid(f) is True
+
+    @pytest.mark.parametrize("missing_field", ["title", "description", "resource", "generated"])
+    def test_missing_a_required_field_is_invalid(self, tmp_path: Path, missing_field):
+        lines = [
+            line for line in self._VALID_FRONTMATTER_LINES
+            if not line.startswith(f"{missing_field}:")
+        ]
+        f = tmp_path / "concept.md"
+        f.write_text(self._build(lines), encoding="utf-8")
+        assert _concept_file_is_valid(f) is False
+
+    @pytest.mark.parametrize("blank_field", ["title", "description", "resource", "generated"])
+    def test_a_required_field_with_only_a_blank_value_is_invalid(self, tmp_path: Path, blank_field):
+        lines = [
+            f"{blank_field}: " if line.startswith(f"{blank_field}:") else line
+            for line in self._VALID_FRONTMATTER_LINES
+        ]
+        f = tmp_path / "concept.md"
+        f.write_text(self._build(lines), encoding="utf-8")
+        assert _concept_file_is_valid(f) is False
+
+    def test_empty_frontmatter_is_invalid(self, tmp_path: Path):
+        f = tmp_path / "concept.md"
+        f.write_text("---\n---\n\nReal body content.\n", encoding="utf-8")
+        assert _concept_file_is_valid(f) is False
+
+    def test_valid_frontmatter_with_empty_body_is_invalid(self, tmp_path: Path):
+        f = tmp_path / "concept.md"
+        f.write_text(self._build(self._VALID_FRONTMATTER_LINES, body=""), encoding="utf-8")
+        assert _concept_file_is_valid(f) is False
+
+    def test_valid_frontmatter_with_whitespace_only_body_is_invalid(self, tmp_path: Path):
+        f = tmp_path / "concept.md"
+        f.write_text(self._build(self._VALID_FRONTMATTER_LINES, body="   \n\n"), encoding="utf-8")
+        assert _concept_file_is_valid(f) is False
+
+    def test_a_real_write_concept_file_output_is_valid(self, tmp_path: Path, monkeypatch):
+        """The existing writer's own output (via write_concept_file) must
+        still pass -- the strengthened check must not reject genuine
+        content, only degenerate/incomplete content."""
+        monkeypatch.setattr("studio.utils.files.find_studio_directory", lambda *_a, **_k: tmp_path)
+        f = _write(tmp_path)
+        index = get_or_build_doc_index(f)
+        intro = index["retrieval_sections"][0]
+        write_concept_file(f, intro["line_start"], description="d", body="b")
+        bundle_dir = _okf_bundle_dir(f)
+        assert _concept_file_is_valid(bundle_dir / "01-introduction.md") is True
 
 
 class TestWriteConceptFile:


### PR DESCRIPTION
## Summary
- Addresses Problem 3 of #134: two CodeRabbit-flagged fixes from #111's own review that never landed on `main` because the fix commit was pushed ~49 minutes after a maintainer merged #111.
- `route_tier1`/`route_query` now validate `margin_threshold` themselves (`_validate_margin_threshold`), rejecting non-finite or non-positive values — `commands/cascade.py`'s CLI-level validator only guarded that one entry point, so any direct Python caller could pass `0`/negative/`nan`/`inf` and defeat the "no finite margin is yet proven safe" design basis documented in `cascade.py`'s own module docstring.
- `_concept_file_is_valid` now also requires the closing frontmatter delimiter, not just the opening one — a concept file truncated right after `"---\n"` previously passed validation and could be handed to Tier 2 as a usable OKF summary.
- Cherry-picked from this session's pre-merge branch (original commit `33a37620`), applied cleanly against current `main`, no conflicts.

## Test plan
- [x] `pytest tests/test_cascade.py tests/test_okf.py -q` — 73 passed


## Update: review round (ainetx) — 3 Minor, all fixed
- **Non-numeric `margin_threshold` raised `TypeError` instead of the documented `ValueError`.** `_validate_margin_threshold` called `math.isfinite()` before checking the input was even numeric, so a direct Python caller passing a string (or any other non-numeric) hit an unhandled `TypeError`. **Fix:** added an `isinstance` guard (bool excluded, since it subclasses int but isn't a meaningful threshold), plus a test proving a non-numeric/bool input now raises the documented `ValueError`.
- **`route_query`'s invalid-threshold test coverage was a single hard-coded value while `route_tier1`'s was a full parametrized matrix** (`[0, -1, nan, inf]`) — the two share the same validator via the same call path, so a future refactor that decoupled them could slip through unnoticed. **Fix:** mirrored the same matrix (now including the non-numeric/bool cases above) onto the `route_query` test.
- **Both tests asserted only a substring match on the error message** (`match="margin_threshold"`), which would still pass even if the message lost its actual explanation. **Fix:** tightened both to a full-message regex, and added an accept-path test (a large finite threshold must not itself be rejected) for both `route_tier1` and `route_query`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid margin thresholds—including zero, negative, infinite, non-numeric, and boolean values—are now rejected consistently with a clear validation error.
  * Valid finite thresholds, including very small and large values, continue to route requests as expected.
  * Tier 1 routing now evaluates heading navigation and TF-IDF together, resolving clear matches and escalating ambiguous results appropriately.
  * Incomplete concept files—including missing frontmatter fields, closing delimiters, or non-blank content—are now correctly identified as invalid or missing.
  * Duplicate Tier 2 escalations are now avoided, with graceful handling when escalation resources are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->