### PR TITLE
docs: reconcile maintenance and specification guidance

### DIFF
--- a/.bootstrap/config/AGENTS.md
+++ b/.bootstrap/config/AGENTS.md
@@ -59,25 +59,13 @@ ALWAYS open and follow `{cf-studio-path}/config/rules/anti-patterns.md` WHEN rev
 
 NEVER edit files inside `{cf-studio-path}/.core/` or `{cf-studio-path}/.gen/` directly — they are read-only copies. ALWAYS edit the canonical source files under project root (`skills/`, `kits/`, `schemas/`, etc.) and then run `cfs update --source . --force` to sync changes into `{cf-studio-path}/`.
 
-### Specs-First Development Workflow
+### Code and specification changes
 
-ALWAYS update specs and documentation in `architecture/` FIRST BEFORE writing any code.
+Follow [Making Changes](../../../CONTRIBUTING.md#making-changes) for maintenance of Constructor Studio itself. Edit canonical source files directly when implementing or repairing behavior already described by the specifications. Preserve the applicable traceability markers; do not require an unrelated specification edit merely to change code.
 
-**Mandatory sequence for any code change**:
+When the requested change alters requirements, architecture, or a specified contract, update the affected artifacts in `architecture/` before implementing the changed contract. Validate affected specifications and traceability with the checks described in CONTRIBUTING.md.
 
-1. **Update specs** — modify or create relevant artifacts in `architecture/`:
-   - `architecture/PRD.md` — for new requirements or use cases
-   - `architecture/DESIGN.md` — for architectural changes or new components
-   - `architecture/DECOMPOSITION.md` — for new features or work breakdown
-   - `architecture/features/*.md` — for feature-level specs
-   - `architecture/specs/*.md` — for technical specs (CDSL, CLISPEC, etc.)
-   - `architecture/ADR/*.md` — for architecture decisions
-
-2. **Validate specs** — run `cfs validate` to ensure artifact integrity
-
-3. **Generate code via Constructor Studio** — use `/cf-generate` workflow to implement code from specs with traceability markers
-
-NEVER write code directly without first updating the corresponding specs. This ensures design-to-code traceability and prevents implementation drift from design intent.
+Use `/cf-generate` when the selected workflow calls for generation from specifications. Its prerequisites belong to that workflow; it is not a prerequisite for every maintenance edit.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ studio/                           # Project root
 
 ### Critical Rule
 
-> **Do not edit files under `.bootstrap/` directly when contributing.**
+> **Do not edit generated mirrors under `.bootstrap/.core/` or `.bootstrap/.gen/` directly when contributing.**
 > In this self-hosted repo, `.bootstrap/` is a bootstrap copy of a Constructor Studio version used
 > to develop Constructor Studio itself — similar to bootstrapping a compiler.
 > This is a repo-specific self-hosted setup, not the general user-project layout described in the README.
@@ -119,6 +119,8 @@ studio/                           # Project root
 > copy and agent integrations are in sync with the canonical source. Re-run `make update`
 > whenever you need to refresh the local bootstrap for manual verification, but do not commit
 > `.bootstrap/.core/`, `.bootstrap/.gen/`, or generated host integration files.
+
+The tracked `.bootstrap/config/AGENTS.md` and `.bootstrap/config/SKILL.md` are user-editable instructions for this repository. Edit them directly when changing local workflow guidance; they are not source-code mirrors. Generated kit outputs under `.bootstrap/config/kits/` still come from their canonical kit sources.
 
 The `make update` command runs `cfs update --source . --force`, which:
 1. Copies canonical sources into `.bootstrap/.core/`
@@ -384,6 +386,8 @@ list.
 ## Making Changes
 
 ### Code Changes
+
+For maintenance that preserves an existing specified contract, edit the canonical code directly and preserve its traceability markers. If requirements, architecture, or a specified contract change, update the affected specifications first. `/cf-generate` applies when the selected workflow calls for generation, rather than to every code edit.
 
 1. Edit canonical files under `skills/studio/scripts/studio/` (skill engine), `src/studio_proxy/` (CLI proxy), or other project-root source directories
 2. Do not patch mirrored files under `.bootstrap/` directly


### PR DESCRIPTION
The repository's agent instructions required specification edits and `/cf-generate` for every code change, while CONTRIBUTING.md documented direct maintenance of canonical source files. This aligns the two: maintenance can preserve the existing specified contract, and changes to requirements, architecture, or contracts still update specifications first.

The bootstrap clarification applies to this repository's tracked `.bootstrap/config/AGENTS.md` and `.bootstrap/config/SKILL.md`. Generated mirrors under `.bootstrap/.core/` and `.bootstrap/.gen/` remain protected, and generated kit configuration still comes from canonical kit sources. No version bump or runtime code changes.

Validation at `e4d46ae5007c785f1ce114a7356cbaf03b74ea82`:

- `git diff --check origin/main...HEAD` passed.
- `/opt/homebrew/bin/python3.12 skills/studio/scripts/studio.py validate-toc CONTRIBUTING.md` completed with two existing warnings: no description/frontmatter and a duplicate Prerequisites heading. The same warnings reproduce against upstream main.
- No Make targets ran. `make ci` requires `actionlint` and `act`, neither of which is installed locally. Remote CI remains outstanding.

The commit includes the required DCO sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributor guidance to clarify which generated files must not be edited directly.
  - Clarified that configuration guidance files can be edited by maintainers.
  - Added direction for editing canonical code, preserving traceability markers, and updating specifications when contracts change.
  - Revised workflow guidance for when generated artifacts should be produced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->