### PR TITLE
feat(pdsl): declare gate risk on a MENU with a TYPE header and lint it

### DIFF
--- a/architecture/features/pdsl-validation-cli.md
+++ b/architecture/features/pdsl-validation-cli.md
@@ -161,12 +161,15 @@ Provide a deterministic validation path for developers and agents authoring or t
 **Output**: Source result `{source, status, findings, errors}`
 
 **Steps**:
-1. [x] - `p1` - Load the rule registry from `studio.utils.pdsl` using stable `PDSL100`, `PDSL200`, `PDSL300`, `PDSL400`, and `PDSL500` rule bands - `inst-load-rule-registry`
+1. [x] - `p1` - Load the rule registry from `studio.utils.pdsl` using stable `PDSL100`, `PDSL200`, `PDSL300`, `PDSL400`, `PDSL500`, `PDSL600`, and `PDSL700` rule bands - `inst-load-rule-registry`
 2. [x] - `p1` - **FOR EACH** block in source order - `inst-foreach-block`
    1. [x] - `p1` - Parse block structure and capture parse or operational failures as normalized source errors - `inst-parse-block`
    2. [x] - `p1` - Run structural checks for fences, starters, keywords, duplicate names, and menu numbering using deterministic local rules only - `inst-run-structural-checks`
-   3. [x] - `p1` - Run deterministic local semantic checks, including undefined local `matches()` references, without any cross-file registry lookup - `inst-run-local-semantics`
-   4. [x] - `p1` - Normalize every finding with `rule_id`, `severity`, `message`, `source_path`, `block_index`, `line`, `column`, `end_line`, `end_column`, and deterministic `hint`; include `snippet` or `context` only when verbosity requests it - `inst-normalize-findings`
+   3. [x] - `p1` - Open a MENU's declaration region at its header and close it at the first section that is not `TITLE` or `TYPE`; learn that menu's sub-header indent from its first sub-header, measured per menu, and read any line indented deeper as continuation text of the header above it rather than as a header of its own -- leaving menu scope itself untouched so pre-existing menu checks are unaffected - `inst-gate-declaration-region`
+   4. [x] - `p1` - Accept a MENU's `TYPE` only as one literal enum token per menu and only inside the declaration region: reject an interpolation, a variable, a trailing condition, a repeat, and a declaration that is outside a menu, nested in its body or trailing it; treat an absent `TYPE` as valid; bound author text interpolated into a finding - `inst-gate-declaration-literal`
+   5. [x] - `p1` - Within the declaration region, report a sub-header that is a near-miss of the gate keyword by edit distance including transposition, discarding decoration and normalizing zero-width and confusable characters rather than enumerating the forms -- a misspelling, a miscasing, a decorated form, a separator PDSL does not use or none at all, or a rejected alternative -- while reading as prose every other unrecognized sub-header, any line with neither a separator nor a gate type as its value, and any lower- or mixed-case candidate whose value is not a gate type - `inst-gate-header-near-miss`
+   6. [x] - `p1` - Run deterministic local semantic checks, including undefined local `matches()` references, without any cross-file registry lookup - `inst-run-local-semantics`
+   7. [x] - `p1` - Normalize every finding with `rule_id`, `severity`, `message`, `source_path`, `block_index`, `line`, `column`, `end_line`, `end_column`, and deterministic `hint`; include `snippet` or `context` only when verbosity requests it - `inst-normalize-findings`
 3. [x] - `p1` - Sort findings deterministically by source order, block index, line, column, and rule identifier - `inst-sort-findings`
 4. [x] - `p1` - **IF** any invocation, read, parse, or operational errors were captured for the source - `inst-if-source-error`
    1. [x] - `p1` - **RETURN** source result with status ERROR, ordered errors, and retained findings - `inst-return-source-error`
@@ -312,7 +315,7 @@ The system **MUST** ship helper unit tests for scanner extraction, structural ch
 - [ ] Multi-source validation preserves CLI input order and returns per-source `PASS`, `FAIL`, or `ERROR` status with ordered findings and errors
 - [ ] Human-readable output is the default; JSON is emitted only with `--json`; `--verbose` expands payload fields only and does not change status or rule evaluation
 - [ ] The JSON envelope is stable and contains `command`, `ok`, `summary`, and `results`, and each result contains `source`, `status`, `findings`, and `errors`
-- [ ] Findings use stable rule bands `PDSL100` for fences, `PDSL200` for starters or keywords, `PDSL300` for duplicate names, `PDSL400` for menu numbering, and `PDSL500` for deterministic local semantics
+- [ ] Findings use stable rule bands `PDSL100` for fences, `PDSL200` for starters or keywords, `PDSL300` for duplicate names, `PDSL400` for menu numbering, `PDSL500` for deterministic local semantics, `PDSL600` for compactness caps, and `PDSL700` for declared gate risk
 - [ ] Deterministic local semantic checks include undefined local `matches()` references, and cross-file registry lookup remains explicitly deferred from the MVP
 - [ ] Validation outputs deterministic hints only and never emit autofix patches, scaffold text, or rewrite templates
 - [ ] `cf-pdsl` preflight and applicable postflight flows reuse normalized helper findings and do not define separate parsing rules, rule identifiers, or success semantics

--- a/architecture/specs/PDSL.md
+++ b/architecture/specs/PDSL.md
@@ -109,6 +109,7 @@ Use this small keyword set before inventing new words.
 | `EMIT_MENU` | Show a named `MENU` block |
 | `MENU` | User choice surface |
 | `TITLE` | User-facing menu title |
+| `TYPE` | Declared gate risk: `confirmation`, `decision` or `blocking` |
 | `OPTIONS` | Valid menu choices and their actions |
 | `INVALID` | Invalid menu input handling |
 | `WAIT` | Stop for user input |
@@ -337,6 +338,117 @@ Menu rules:
 - Invalid input is specified.
 - If the menu is a hard interaction boundary, it ends with `STOP_TURN`.
 - Suggested options belong in `TITLE` or `NOTES`, not hidden in prose.
+
+### Declared gate risk
+
+A menu may declare how much authority it carries, so the decision is read from
+source rather than re-derived while running.
+
+```pdsl
+MENU PlanApprovalGate:
+  TITLE: Approve this plan?
+  TYPE: blocking
+  OPTIONS:
+    1 approve -> CONTINUE CurrentWorkflow
+    2 revise -> CONTINUE PlanRevision
+  INVALID:
+    EMIT "Reply with 1 or 2."
+    WAIT user.reply
+    STOP_TURN
+```
+
+| `TYPE` | meaning |
+|---|---|
+| `confirmation` | the workflow has already derived the answer, **and the action it takes is reversible** |
+| `decision` | the answer changes the work product |
+| `blocking` | irreversible, external, or permission-expanding |
+
+Rules:
+
+- `TYPE` is a **static constant**: one bare lowercase token from the table
+  above, never interpolated, never a variable, never carrying a `WHEN` clause.
+  Where risk genuinely differs by entry mode, emit two differently-typed menus —
+  subject to the constraints on splitting recorded in
+  `cpt-studio-adr-autonomous-default-and-gate-risk`, which a lint cannot check.
+- At most one `TYPE` per menu.
+- **`TYPE` may be omitted.** An undeclared menu is valid, and a *newly added*
+  menu must declare one, so menus migrate one at a time and the undeclared set
+  can only shrink.
+- **What an omitted `TYPE` means at runtime is not implemented here, and this
+  spec does not claim otherwise.** Nothing reads a declaration today, in any
+  mode: the rules above are lint only. The intended contract is that an
+  undeclared menu is treated as `blocking` — the conservative direction, in
+  which a gate asks rather than proceeds.
+- **Nothing resolves a gate from a declared type today**, so this lint changes
+  no runtime behaviour. Two shipped paths *do* auto-resolve gates, and neither
+  reads a declaration: assistant mode's own auto-selection rule
+  (`skills/studio/modules/gates/simple-mode-rules.md:19`), the autonomy overlay
+  (`workflows/brave-new-world.md`), and sub-agent dispatch's pre-set rule
+  (`skills/studio/modules/subagents/dispatch.md:43`), all of which decide by
+  runtime judgement. So an undeclared menu is **not** fail-closed today — it is
+  subject to those three paths exactly as it was before this change.
+- **Enforcing the default here would not make it true.** A lint cannot bind
+  either path; both must be retired or bound to declared types by the change
+  that introduces declaration-driven resolution, which is where the obligation
+  and a test asserting that an omitted `TYPE` produces blocking behaviour
+  belong. Until then, omission is *unvalidated*, and the safety of the
+  grandfathered set rests on those two paths being narrow and reviewed — not on
+  a default that has been demonstrated.
+- **`TYPE` is read only in the menu's declaration region:** from the menu
+  header up to the first section that is not `TITLE` or `TYPE`. A declaration
+  outside a menu, nested in its body, or trailing it is inert, and is reported
+  rather than ignored.
+- **A line indented deeper than the menu's other sub-headers is continuation
+  text of the header above it**, not a header of its own — so a title running
+  onto a second line is read as title text. A `TYPE:` written there is not read
+  as the declaration, and a near-miss written there is not reported. The level
+  is taken from the menu's first sub-header, whichever that is, and measured per
+  menu rather than per block.
+- **Any recognized section other than `TITLE` or `TYPE` ends the region** — `OPTIONS:`,
+  `INVALID:`, and also `NOTES:`, `RULES:`, `ON_ERROR:`, `PURPOSE:` and the
+  rest. Unrecognized prose headers such as `NOTE:` and `ELSE:` do not. So put
+  `TYPE` before `NOTES:`, not after it.
+- A sub-header **in that region** that is a near-miss of `TYPE` is an error, so
+  a typo cannot silently leave a gate undeclared. Reported: a misspelling
+  (`TYP:`, `TPYE:`), a miscasing (`Type:`) when its value is a gate type,
+  decoration around the name (`- TYPE:`, `` `TYPE:` ``, `[TYPE]:`,
+  `**TYPE:**`), a separator other than `:` (`TYPE = blocking`,
+  `TYPE -> blocking`) or none at all (`TYPE blocking`), an invisible or
+  confusable character in the name, and a rejected alternative (`RISK:`,
+  `GATE_TYPE:`).
+- Detection is by edit distance 1 from `TYPE`, counting a transposition as one,
+  after folding case and trimming `_`/`-` from the ends, plus that alias list.
+  The trimming means many decorated spellings reduce to `TYPE` and are caught,
+  so the radius is wide; what matters to an author is which *words* fall in it.
+  The ordinary English words are `HYPE`, `TAPE`, `TYKE`, `TYPED`, `TYPES`,
+  `TYPO` and `TYRE`; `RISK` is flagged deliberately. `GATE:` is **not**
+  flagged: in a codebase about gates it is a plausible sub-header.
+- **The boundary, stated rather than implied.** Decoration is discarded, not
+  listed, so the set of decorated forms is open-ended. What is *not* detected
+  is a declaration with another token embedded in it — `1. TYPE:`,
+  `- [x] TYPE:`, `<b>TYPE</b>:`, `TYPE(gate):` — a near-miss **outside** the
+  region, which is read as prose, a declaration or near-miss written as
+  **continuation text**, indented past the menu's other sub-headers, and a name
+  spelled in lookalikes this map does not carry at **two or more** positions
+  (`ᴛʏPE:`, `ᴛʏᴘᴇ:`), which sit outside the distance-1 radius — one such letter
+  is still caught by distance, and any number of *mapped* ones fold to `TYPE`
+  and are caught too. That last limit is deliberate rather than pending: PDSL
+  is authored in ASCII, so widening the rule would trade a spelling nobody
+  writes for false positives on prose in another script. In every such case the
+  gate is left undeclared, and therefore `blocking` **under the model this spec
+  records** — the failure direction is more friction, never more autonomy. That
+  is the contract rather than current behaviour: as stated above, an undeclared
+  menu is not fail-closed today, because three shipped paths still resolve one
+  by runtime judgement.
+- Everything else is prose, in the region or out of it: `NOTE:`, `NOTES:` and
+  `ELSE:`, any lower- or mixed-case line whose value is **some other token**
+  (`type: skill`, `**Type**: CLI`), and any line with neither a separator nor a
+  gate type as its value (`Tape recorder notes`).
+- An **empty** value is not prose. `type:` and `Type:` are reported as near-misses
+  and `TYPE:` as a non-literal, because a header written with its separator and
+  nothing after it is an abandoned declaration rather than front matter — the one
+  case where a lower-case candidate is reported despite its value not being a gate
+  type.
 
 ---
 

--- a/skills/studio/scripts/studio/utils/pdsl.py
+++ b/skills/studio/scripts/studio/utils/pdsl.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
@@ -118,6 +119,10 @@ class _BlockValidationState:
     in_menu: bool = False
     do_count: int = 0
     rules_count: int = 0
+    menu_name: Optional[str] = None
+    menu_type_line: int = 0
+    gate_scope: bool = False
+    sub_header_indent: Optional[int] = None
 
 
 FENCE_RE = re.compile(r"^```(?P<lang>[A-Za-z0-9_-]+)?\s*$")
@@ -127,6 +132,48 @@ MATCHES_RE = re.compile(r"\bmatches\(\s*[^,]+,\s*(?P<quote>['\"]?)(?P<name>[A-Za
 SECTION_HEAD_RE = re.compile(r"^(?P<section>[A-Z][A-Z0-9_-]*):")
 ACTION_HEAD_RE = re.compile(r"^(?:-\s+)?(?P<token>[A-Z][A-Z0-9_-]*)(?=\b|\s|$)")
 MENU_OPTION_RE = re.compile(r"^(?:-\s+)?(?P<number>\d+)\b.*->")
+
+# A declared gate type is one of these bare tokens and nothing else: an
+# interpolation, a variable or a trailing WHEN is a runtime decision in
+# disguise and fails membership here.
+GATE_TYPES = ("confirmation", "decision", "blocking")
+GATE_HEADER = "TYPE"
+# Sub-headers permitted at an indent inside a MENU. `TYPE` is absent on purpose:
+# it is dispatched before the indent guard, so listing it here would be dead.
+MENU_SUB_HEADERS = frozenset({"TITLE", "OPTIONS", "INVALID"})
+# Keywords considered for this declaration and rejected. Someone reaching for
+# one has written an inert header, so it is reported rather than ignored.
+GATE_HEADER_ALIASES = frozenset({
+    "RISK", "RISK_TYPE", "GATE_RISK", "GATE_TYPE", "MENU_TYPE", "RISK_LEVEL",
+})
+# MENU blocks legitimately carry prose and control-flow headers (NOTE:, ELSE:),
+# so an unrecognized one is reported only when it is a near-miss of the gate
+# keyword. Distance 1 keeps ordinary four-letter words (TIME:, TIPS:, NOTE:)
+# out while still catching TYP:, TYPO: and TYPES:.
+GATE_HEADER_TYPO_DISTANCE = 1
+# A declaration is recognized by discarding decoration rather than by listing
+# the forms it can take: enumerating them is unbounded, and three review passes
+# each found more (backticks, brackets, quotes, an arrow, a zero-width space).
+# Only non-alphanumerics may precede the name, and only a separator or a literal
+# gate type may follow it -- so `Tape recorder notes` stays prose.
+GATE_DECORATION_RE = re.compile(r"^[^A-Za-z0-9]*")
+GATE_NAME_RE = re.compile(r"[^\W\d][\w-]*")
+GATE_SEPARATOR_RE = re.compile(r"^[^A-Za-z0-9]*(?:->|=>|[:=])")
+# Invisible characters are removed by Unicode category rather than by listing
+# them: `Cf` covers zero-width spaces, joiners and bidi controls, `Mn` covers
+# combining marks, and `Cc` covers stray control characters.
+GATE_INVISIBLE_CATEGORIES = frozenset({"Cc", "Cf", "Mn"})
+# Cyrillic and Greek capitals that render like Latin ones, so `TYPE` typed with
+# any of them is still read as an attempt at a declaration. NFKC folding handles
+# the fullwidth and mathematical alphabets before this map is applied.
+GATE_NAME_CONFUSABLES = {
+    "\u0410": "A", "\u0415": "E", "\u041a": "K", "\u041c": "M", "\u041e": "O",
+    "\u0420": "P", "\u0421": "C", "\u0422": "T", "\u0423": "Y", "\u0425": "X",
+    "\u0391": "A", "\u0392": "B", "\u0395": "E", "\u0396": "Z", "\u0397": "H",
+    "\u0399": "I", "\u039a": "K", "\u039c": "M", "\u039d": "N", "\u039f": "O",
+    "\u03a1": "P", "\u03a4": "T", "\u03a5": "Y", "\u03a7": "X",
+}
+GATE_VALUE_ELLIPSIS = 60
 
 # @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-load-rule-registry
 SECTION_HEADERS = {
@@ -142,6 +189,7 @@ SECTION_HEADERS = {
     "NOTES",
     "PATTERNS",
     "TITLE",
+    "TYPE",
     "OPTIONS",
     "INVALID",
 }
@@ -408,8 +456,10 @@ def _validate_block(block: PdslBlock) -> List[PdslFinding]:
         ):
             continue
 
-        if _handle_section_header_line(stripped, raw_line, state):
+        if _handle_section_header_line(block, line_no, stripped, raw_line, findings, state):
             continue
+
+        _report_malformed_gate_header(block, line_no, raw_line, stripped, findings, state)
 
         if _handle_pattern_line(
             block,
@@ -462,29 +512,351 @@ def _handle_unit_or_menu_line(
     state.section = None
     state.menu_expected = None
     state.in_menu = kind == "MENU"
+    # @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+    # These two resets are what make the one-declaration-per-menu rule per-menu,
+    # and what lets its finding name the menu.
+    state.menu_name = name
+    state.menu_type_line = 0
+    # Reset per MENU, not per block: a later menu may indent its sub-headers
+    # differently, and a stale level would read that menu's whole body as
+    # continuation text -- suppressing its declaration *and* the pre-existing
+    # option-numbering checks.
+    state.sub_header_indent = None
+    # @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+    # @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
+    state.gate_scope = state.in_menu
+    # @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
     state.do_count = 0
     state.rules_count = 0
     return True
 
 
+# @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
+def _is_header_continuation(indent_len: int, state: _BlockValidationState) -> bool:
+    """True when a line is continuation text of the sub-header above it.
+
+    A MENU's sub-headers share one indent; a line deeper than that is the
+    previous header's own text. Without this, a title running onto a second
+    line was read as a header in its own right -- reported as a misspelled
+    declaration if it resembled one, and worse, *accepted* as the menu's
+    declaration if it began with `TYPE:`.
+
+    The level is learned from the first sub-header rather than compared against
+    a remembered one, so there is no value to bootstrap and no ordering in which
+    the check fails to apply.
+    """
+    return (
+        state.in_menu
+        # Only inside the declaration region. Past it a deeper line is an
+        # action body, where a `TYPE:` is a misplaced declaration worth
+        # reporting rather than prose to be ignored.
+        and state.gate_scope
+        and state.sub_header_indent is not None
+        and indent_len > state.sub_header_indent
+    )
+# @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
+
+
+# @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
+def _report_unrecognized_sub_header(
+    block: PdslBlock,
+    line_no: int,
+    raw_line: str,
+    section_name: str,
+    findings: List[PdslFinding],
+    state: _BlockValidationState,
+) -> None:
+    """Report an unrecognized header that is a near-miss of the gate keyword."""
+    # `gate_scope` is only ever assigned from `in_menu`, so it implies it.
+    if state.gate_scope and _is_gate_header_typo(section_name):
+        findings.append(_gate_header_finding(block, line_no, raw_line, section_name))
+# @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
+
+
 def _handle_section_header_line(
+    block: PdslBlock,
+    line_no: int,
     stripped: str,
     raw_line: str,
+    findings: List[PdslFinding],
     state: _BlockValidationState,
 ) -> bool:
-    """Process section headers and update parser state."""
+    """Process section headers, and track where a gate declaration is read.
+
+    `in_menu` is deliberately left alone. A MENU's *declaration region* is
+    tracked separately in `gate_scope`: it runs from the MENU header to the
+    first section that is not `TITLE` or `TYPE`. Nothing outside that region is
+    read as a declaration, so there is no need to decide where a MENU "ends" --
+    an earlier attempt to do that suppressed the pre-existing menu numbering
+    checks for the rest of the block.
+    """
     section_head = SECTION_HEAD_RE.match(stripped)
     if not section_head:
         return False
     section_name = section_head.group("section")
-    if section_name not in SECTION_HEADERS:
-        return True
     indent_len = len(raw_line) - len(raw_line.lstrip(" "))
-    if indent_len > 0 and not (state.in_menu and section_name in {"TITLE", "OPTIONS", "INVALID"}):
+    # @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
+    if state.in_menu and state.sub_header_indent is None:
+        state.sub_header_indent = indent_len
+    # A recognized sub-header is a header wherever it sits: exempting it keeps
+    # an indented `OPTIONS:` opening its section, so the pre-existing option
+    # checks still run. Only non-sub-header lines can be continuation text.
+    if section_name not in MENU_SUB_HEADERS and _is_header_continuation(indent_len, state):
+        return True
+    # @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
+    if section_name not in SECTION_HEADERS:
+        _report_unrecognized_sub_header(block, line_no, raw_line, section_name, findings, state)
+        return True
+    # @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
+    if section_name not in ("TITLE", GATE_HEADER):
+        state.gate_scope = False
+    # @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-region
+    # @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+    if section_name == GATE_HEADER:
+        _handle_gate_type_header(block, line_no, raw_line, stripped, findings, state)
+        return True
+    # @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+    if indent_len > 0 and not (state.in_menu and section_name in MENU_SUB_HEADERS):
         return True
     state.section = section_name
     state.menu_expected = 1 if state.in_menu and section_name == "OPTIONS" else None
     return True
+
+
+# @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+def _handle_gate_type_header(
+    block: PdslBlock,
+    line_no: int,
+    raw_line: str,
+    stripped: str,
+    findings: List[PdslFinding],
+    state: _BlockValidationState,
+) -> None:
+    """Validate one `TYPE:` declaration and record that this MENU carries one.
+
+    An absent declaration is valid: an undeclared gate is treated as `blocking`
+    at runtime, so the existing surface migrates gate by gate. Only a
+    declaration the block cannot support is reported here.
+    """
+    if not state.gate_scope:
+        # Outside a MENU, or past its declaration region. `gate_scope` is only
+        # ever set from `in_menu`, so it implies it.
+        findings.append(_finding(
+            block, "PDSL702", line_no, raw_line,
+            f"`{GATE_HEADER}:` declares gate risk where nothing reads it",
+            hint=f"Put {GATE_HEADER} directly under its MENU header, before OPTIONS.",
+        ))
+        return
+    if state.menu_type_line:
+        findings.append(_finding(
+            block, "PDSL701", line_no, raw_line,
+            f"MENU `{_elide(state.menu_name or '')}` declares {GATE_HEADER} more than once",
+            hint=(f"Keep one {GATE_HEADER}; the earlier declaration is at "
+                  f"line {state.menu_type_line}."),
+        ))
+        return
+    state.menu_type_line = line_no
+    value = stripped[len(GATE_HEADER) + 1:].strip()
+    if value not in GATE_TYPES:
+        findings.append(_finding(
+            block, "PDSL700", line_no, raw_line,
+            f"MENU {GATE_HEADER} must be one literal token of {', '.join(GATE_TYPES)} "
+            f"(found `{_elide(value)}`)",
+            hint="Declare risk statically; where it varies, emit two differently-typed gates.",
+        ))
+# @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+
+
+# @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
+def _report_malformed_gate_header(
+    block: PdslBlock,
+    line_no: int,
+    raw_line: str,
+    stripped: str,
+    findings: List[PdslFinding],
+    state: _BlockValidationState,
+) -> None:
+    """Report a gate declaration written in a form PDSL does not accept.
+
+    Decoration is discarded rather than enumerated: only non-alphanumerics may
+    precede the name, and a trailing run of them is skipped before looking for
+    the separator. So a bullet, backticks, brackets, quotes, an arrow or a
+    zero-width space all reduce to the same candidate, and no list of forms has
+    to be kept current.
+
+    Adds a finding only. The line is still offered to the other checks, so a
+    malformed declaration does not mask an unrelated finding on the same line.
+    """
+    # Reached only when `_handle_section_header_line` returned False, so this
+    # line is not a recognized header and needs no second check for one.
+    if not state.gate_scope:
+        return
+    if _is_header_continuation(len(raw_line) - len(raw_line.lstrip(" ")), state):
+        return
+    candidate = _gate_header_candidate(stripped)
+    if candidate is None:
+        return
+    name, has_separator, value = candidate
+    if not _is_gate_header_typo(name):
+        return
+    # PDSL headers are upper-case. A lower- or mixed-case candidate is usually
+    # prose or front matter (`type: skill`, `**Type**: CLI`), so it is reported
+    # only when its value is a gate type -- which is the miscasing #152 names.
+    if not name.isupper() and value and value.lower() not in GATE_TYPES:
+        return
+    # Without a separator this is only a declaration attempt when the value's
+    # first word is a gate type -- so `TYPE | blocking` and `TYPE (blocking)`
+    # are reported while `Tape recorder notes` stays prose.
+    if not has_separator:
+        first_word = GATE_NAME_RE.search(value)
+        if first_word is None or first_word.group().lower() not in GATE_TYPES:
+            return
+    findings.append(_gate_header_finding(block, line_no, raw_line, name))
+
+
+def _gate_header_candidate(stripped: str) -> Optional[Tuple[str, bool, str]]:
+    """Return `(name, has_separator, value)` for a line that may be a declaration.
+
+    Invisible characters are removed and the rest folded per character before
+    the name is located, so a lookalike in the middle of `TYPE` cannot truncate
+    it. Folding may drop a character, so the reported name is recovered through
+    a per-character source map rather than by reusing a folded offset.
+    """
+    visible = "".join(
+        char for char in stripped
+        if unicodedata.category(char) not in GATE_INVISIBLE_CATEGORIES
+    )
+    # Folding can drop a character, so it is not length-preserving and an offset
+    # into the folded string is not an offset into the original. Carry each
+    # folded character's source index so the reported name stays a real slice of
+    # the author's own spelling.
+    folded: List[str] = []
+    origin: List[int] = []
+    for index, char in enumerate(visible):
+        piece = _fold_char(char)
+        if piece:
+            folded.append(piece)
+            origin.append(index)
+    line = "".join(folded)
+    name_match = GATE_NAME_RE.match(line, GATE_DECORATION_RE.match(line).end())
+    if name_match is None:
+        return None
+    rest = line[name_match.end():]
+    reported = visible[origin[name_match.start()]:origin[name_match.end() - 1] + 1]
+    separator = GATE_SEPARATOR_RE.match(rest)
+    if separator is None:
+        return reported, False, rest.strip()
+    return reported, True, rest[separator.end():].strip()
+# @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
+
+
+# @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
+def _gate_header_finding(
+    block: PdslBlock,
+    line_no: int,
+    raw_line: str,
+    name: str,
+) -> PdslFinding:
+    """Build the finding for a header that is not a usable gate declaration."""
+    return _finding(
+        block, "PDSL703", line_no, raw_line,
+        f"MENU sub-header `{_elide(name)}:` is not a gate declaration and is ignored",
+        hint=f"Write `{GATE_HEADER}: <{' | '.join(GATE_TYPES)}>`; a near-miss leaves the gate undeclared.",
+    )
+# @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
+
+
+# @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+def _elide(value: str) -> str:
+    """Shorten an author-supplied value so a finding message stays bounded."""
+    if len(value) <= GATE_VALUE_ELLIPSIS:
+        return value
+    return value[:GATE_VALUE_ELLIPSIS - 3] + "..."
+# @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-declaration-literal
+
+
+# @cpt-begin:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
+def _fold_char(char: str) -> str:
+    """Fold one character towards ASCII, but only when it stays one character.
+
+    Offsets must survive folding, because the reported header name is sliced
+    from the author's own spelling. NFKC is not length-preserving -- `\u203c`
+    becomes `!!` -- so a multi-character result is left alone and simply reads
+    as decoration.
+    """
+    folded = unicodedata.normalize("NFKC", char).upper()
+    if len(folded) != 1:
+        # NFKC expands it (`\u203c` -> `!!`). Dropped rather than kept, so it
+        # cannot truncate a name it sits inside; the caller's source map keeps
+        # the reported spelling correct despite the length change.
+        return ""
+    return GATE_NAME_CONFUSABLES.get(folded, folded)
+
+
+def _normalize_header_name(name: str) -> str:
+    """Fold a header name to ASCII capitals for the near-miss test.
+
+    Per-character folding collapses the fullwidth and mathematical alphabets
+    and maps Cyrillic or Greek lookalikes to their Latin twin, so a name that
+    *renders* as `TYPE` is read as an attempt at a declaration however it was
+    typed -- while every offset is preserved.
+    """
+    return "".join(
+        _fold_char(char)
+        for char in name
+        if unicodedata.category(char) not in GATE_INVISIBLE_CATEGORIES
+    )
+
+
+def _edit_distance(left: str, right: str) -> int:
+    """Optimal string alignment distance, counting an adjacent transposition as one.
+
+    Plain Levenshtein scores a swap as two edits, which would let the commonest
+    typo class -- `TPYE`, `TYEP` -- past a distance-1 threshold.
+    """
+    rows, columns = len(left) + 1, len(right) + 1
+    grid = [[0] * columns for _ in range(rows)]
+    for row in range(rows):
+        grid[row][0] = row
+    for column in range(columns):
+        grid[0][column] = column
+    for row in range(1, rows):
+        for column in range(1, columns):
+            cost = left[row - 1] != right[column - 1]
+            grid[row][column] = min(
+                grid[row - 1][column] + 1,
+                grid[row][column - 1] + 1,
+                grid[row - 1][column - 1] + cost,
+            )
+            if (
+                row > 1
+                and column > 1
+                and left[row - 1] == right[column - 2]
+                and left[row - 2] == right[column - 1]
+            ):
+                grid[row][column] = min(grid[row][column], grid[row - 2][column - 2] + 1)
+    return grid[-1][-1]
+
+
+def _is_gate_header_typo(raw_name: str) -> bool:
+    """True when a header looks like a botched gate declaration.
+
+    Normalization happens here so every caller sees the same rule: confusable
+    letters are mapped, case is folded, and `_`/`-` are trimmed at the ends
+    where they are decoration but kept inside a name like `RISK_TYPE`.
+
+    The length check is a pure short-circuit -- a name whose length differs by
+    more than the threshold can never be within it -- but it is load-bearing for
+    cost, not correctness: without it a long unrecognized header runs the
+    quadratic grid on every line of a large file to no possible effect.
+    """
+    name = _normalize_header_name(raw_name).strip("_-")
+    if name.replace("-", "_") in GATE_HEADER_ALIASES:
+        return True
+    if abs(len(name) - len(GATE_HEADER)) > GATE_HEADER_TYPO_DISTANCE:
+        return False
+    return _edit_distance(name, GATE_HEADER) <= GATE_HEADER_TYPO_DISTANCE
+# @cpt-end:cpt-studio-algo-pdsl-validation-cli-helper-validate:p1:inst-gate-header-near-miss
 
 
 def _handle_pattern_line(

--- a/tests/test_pdsl_keywords.py
+++ b/tests/test_pdsl_keywords.py
@@ -8,6 +8,9 @@ import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
+from unittest import mock
+
+from studio.utils import pdsl
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 STUDIO_PY = REPO_ROOT / "skills" / "studio" / "scripts" / "studio.py"
@@ -644,3 +647,350 @@ def test_prompt_runtime_references_use_cf_studio_path() -> None:
                 break
 
     assert not findings, "\n".join(sorted(findings))
+
+
+# Every MENU that does not yet declare a gate risk TYPE, frozen 2026-09-07.
+# An undeclared gate is treated as `blocking` at runtime, so the existing
+# surface is grandfathered and migrates gate by gate -- but the untyped surface
+# must not grow. Anything not in this set has to declare a TYPE.
+# Shrink this set as menus are typed; never add to it.
+UNTYPED_MENU_BASELINE: frozenset[str] = frozenset({
+    "architecture/specs/PDSL.md#13::SubAgentApprovalMenu",
+    "architecture/specs/PDSL.md#7::ApprovalMenu",
+    "requirements/auto-config.md#2::ExistingRulesRefreshMenu",
+    "requirements/storytelling-modes.md#0::ModeSelectionMenu",
+    "requirements/storytelling-modes.md#5::ChallengePostRoundMenu",
+    "requirements/storytelling-modes.md#5::ChallengeReactionMenu",
+    "skills/studio/agents/cf-code-bug-finder.md#3::TerminalStates",
+    "skills/studio/agents/cf-generate-author.md#1::DomainClassification",
+    "skills/studio/agents/cf-migrate-migrator.md#3::SpecialCaseAItems",
+    "skills/studio/agents/cf-migrate-planner.md#0::FindingClassification",
+    "skills/studio/agents/cf-prompt-bug-finder.md#3::TerminalStates",
+    "skills/studio/agents/cf-ralphex.md#2::DelegationOutcomeMenu",
+    "skills/studio/agents/cf-ralphex.md#4::BootstrapApprovalMenu",
+    "skills/studio/agents/cf-ralphex.md#4::RetryOrAbortMenu",
+    "skills/studio/agents/cf-semantic-reviewer-code.md#2::OutputShape",
+    "skills/studio/agents/cf-semantic-reviewer-consistency.md#3::FindingClassificationRules",
+    "skills/studio/agents/storytelling-gate.md#4::GenerateRoutingMenu",
+    "skills/studio/agents/storytelling-gate.md#6::PlanApprovalMenu",
+    "skills/studio/migrate-from-cypilot.md#4::E1_ScannerMenu",
+    "skills/studio/migrate-from-cypilot.md#5::E2_PlannerMenu",
+    "skills/studio/migrate-from-cypilot.md#6::E3_MigratorMenu",
+    "skills/studio/migrate-from-cypilot.md#7::E4_VerifierMenu",
+    "skills/studio/migrate-from-cypilot.md#8::E5_MigratorMenu",
+    "skills/studio/modules/analyze-routing-menus.md#1::AnalyzeIntentOffer",
+    "skills/studio/modules/analyze-routing-menus.md#2::AnalyzeLoadOffer",
+    "skills/studio/modules/analyze-skill-fallbacks.md#0::AnalyzeOtherSkillsMenu",
+    "skills/studio/modules/analyze-skill-fallbacks.md#1::AnalyzeNoMatchMenu",
+    "skills/studio/modules/auto-config-detect.md#0::DetectConfirmMenu",
+    "skills/studio/modules/auto-config-docs.md#0::DocsConfirmMenu",
+    "skills/studio/modules/auto-config-generate.md#0::GenerateConfirmMenu",
+    "skills/studio/modules/auto-config-integrate-validate.md#0::IntegrateConfirmMenu",
+    "skills/studio/modules/auto-config-precheck.md#0::ExistingRulesRefreshMenu",
+    "skills/studio/modules/auto-config-scan-docs.md#0::ScanConfirmMenu",
+    "skills/studio/modules/brainstorm-panel-render.md#0::PanelEditMenu",
+    "skills/studio/modules/brainstorm-rounds.md#0::PostRoundMenu",
+    "skills/studio/modules/brainstorm-rounds.md#0::QuestionMenu",
+    "skills/studio/modules/brainstorm-wrap.md#0::WrapMenu",
+    "skills/studio/modules/ci-discovery-run.md#0::CiDiscoveryFailureMenu",
+    "skills/studio/modules/ci-discovery-run.md#0::CiDiscoverySkipMenu",
+    "skills/studio/modules/coding-prep-gates.md#0::CodingExploreMenu",
+    "skills/studio/modules/coding-prep-gates.md#1::CodingBrainstormMenu",
+    "skills/studio/modules/debug-prompts-command-menu-nav.md#0::DebuggerMenu",
+    "skills/studio/modules/debug-prompts-failures.md#0::DebugRunFailureMenu",
+    "skills/studio/modules/debug-prompts-failures.md#0::DebugStepFailureMenu",
+    "skills/studio/modules/explain-intent-explore.md#2::ExplainExploreMenu",
+    "skills/studio/modules/explore-clarify.md#0::ExploreClarifyMenu",
+    "skills/studio/modules/explore-save.md#0::ExploreSaveMenu",
+    "skills/studio/modules/gates/migrate-from-cypilot-offer.md#0::MigrateFromCypilotConfirm",
+    "skills/studio/modules/gates/plan-first.md#0::PlanFirstConfirm",
+    "skills/studio/modules/gates/plan-first.md#1::PlanStorageChoice",
+    "skills/studio/modules/gates/simple-mode-simple.md#2::SimpleModeBraveNewWorldChoice",
+    "skills/studio/modules/gates/simple-mode.md#0::SimpleModeChoice",
+    "skills/studio/modules/gates/workflow-prep.md#1::WorkflowPrepExploreRepeatMenu",
+    "skills/studio/modules/generate-routing-menus.md#1::GenerateIntentOffer",
+    "skills/studio/modules/generate-routing-menus.md#2::GenerateLoadOffer",
+    "skills/studio/modules/generate-skill-fallbacks.md#0::GenerateOtherSkillsMenu",
+    "skills/studio/modules/generate-skill-fallbacks.md#1::GenerateNoMatchMenu",
+    "skills/studio/modules/kit-discovery-proposal.md#0::KitInitDiscoveryApprovalMenu",
+    "skills/studio/modules/kit-discovery-run.md#0::KitInitDiscoveryFailureMenu",
+    "skills/studio/modules/kit-edit-render.md#0::KitInitEditRetryMenu",
+    "skills/studio/modules/kit-existing-manifest.md#0::KitInitExistingManifestMenu",
+    "skills/studio/modules/kit-legacy-preview-menus.md#0::KitInitLegacyApprovalMenu",
+    "skills/studio/modules/kit-legacy-preview-menus.md#0::KitInitPreviewFailureMenu",
+    "skills/studio/modules/kit-manual-guidance-preview.md#0::KitInitManualGuidanceRetryMenu",
+    "skills/studio/modules/kit-target-entry.md#0::KitInitTargetMenu",
+    "skills/studio/modules/kit-target-preflight-route.md#0::KitInitTargetRetryMenu",
+    "skills/studio/modules/kit-target-validation.md#0::KitInitValidationFailureMenu",
+    "skills/studio/modules/map-config-palette.md#0::ConfigAssistActionMenu",
+    "skills/studio/modules/map-config-palette.md#0::PaletteMenu",
+    "skills/studio/modules/map-config-palette.md#0::UncategorizedMenu",
+    "skills/studio/modules/map-execute.md#0::ConfigAssistOfferMenu",
+    "skills/studio/modules/map-execute.md#0::MapConfigMenu",
+    "skills/studio/modules/map-intent.md#0::MapIntentMenu",
+    "skills/studio/modules/map-next.md#0::MapNextStepsMenu",
+    "skills/studio/modules/map-preflight.md#2::MapScopeMenu",
+    "skills/studio/modules/plan-assess-decompose.md#1::DecompositionConfirmMenu",
+    "skills/studio/modules/plan-compile.md#0::BriefCheckpointMenu",
+    "skills/studio/modules/plan-compiler-dispatch.md#2::PlanCompilerFailureMenu",
+    "skills/studio/modules/plan-discovery.md#1::PlanGateMenu",
+    "skills/studio/modules/plan-validate-finalize.md#0::OversizedPhaseRecoveryMenu",
+    "skills/studio/modules/plan-validate-finalize.md#1::Phase4NextStepsMenu",
+    "skills/studio/modules/planning-runtime.md#8::PlanSaveGateMenu",
+    "skills/studio/modules/review/fix-approval.md#0::ReviewFindingsNavigation",
+    "skills/studio/modules/review/fix-approval.md#12::ReviewFixPartialIdsRetryMenu",
+    "skills/studio/modules/review/fix-approval.md#3::ReviewFixScope",
+    "skills/studio/modules/review/semantic-loop-skeleton.md#0::ReviewGranularityMenu",
+    "skills/studio/modules/routing/companion-skills.md#1::CompanionSkillOfferMenu",
+    "skills/studio/modules/routing/companion-skills.md#2::CompanionRoutingMenuOptions",
+    "skills/studio/modules/routing/root-intent-routing.md#1::IntentSkillMenu",
+    "skills/studio/modules/routing/root-intent-routing.md#1::MatchedIntentSkillMenu",
+    "skills/studio/modules/routing/root-intent-routing.md#9::AllCfSkillsMenu",
+    "skills/studio/modules/runtime/blocked-next-actions.md#2::BlockedNextActionsMenu",
+    "skills/studio/modules/session/shutdown.md#0::StudioShutdownConfirm",
+    "skills/studio/modules/subagents/dispatch.md#1::SubAgentApprovalRequest",
+    "skills/studio/modules/subagents/dispatch.md#1::SubAgentFallbackLimitRequest",
+    "skills/studio/modules/subagents/dispatch.md#1::SubAgentFallbackRequest",
+    "skills/studio/modules/subagents/git-commit-mode.md#5::GitCommitModeMenu",
+    "skills/studio/modules/ui/next-actions.md#0::NextActionsMenu",
+    "skills/studio/modules/workspace-configure.md#0::SourceConfirmMenu",
+    "skills/studio/modules/workspace-discover.md#0::RepoSelectionMenu",
+    "skills/studio/modules/workspace-discover.md#0::StorageModeMenu",
+    "skills/studio/modules/workspace-discover.md#0::ZeroResultsMenu",
+    "skills/studio/modules/workspace-generate.md#2::GenerateFailureMenu",
+    "skills/studio/modules/workspace-next-dispatch.md#0::WorkspaceNextStepsMenu",
+    "skills/studio/modules/workspace-router-quick.md#0::WorkspaceIntentMenu",
+    "skills/studio/modules/workspace-router-quick.md#3::WorkspaceForceSyncConfirm",
+    "skills/studio/modules/workspace-validate.md#1::ValidationFailureMenu",
+    "skills/studio/modules/write-docs-author-dispatch.md#2::WriteDocsAuthorTargetMissingMenu",
+    "skills/studio/modules/write-docs-prep-gates.md#0::WriteDocsExploreMenu",
+    "skills/studio/modules/write-docs-prep-gates.md#1::WriteDocsBrainstormMenu",
+    "skills/studio/modules/write-skills-author-dispatch.md#2::WriteSkillsNoOutputMenu",
+    "skills/studio/modules/write-skills-prep-gates.md#0::WriteSkillsExploreMenu",
+    "skills/studio/modules/write-skills-prep-gates.md#1::WriteSkillsBrainstormMenu",
+})
+
+# The untyped surface may only shrink. Raising this is a deliberate, reviewable
+# act; a rename does not need it, because a rename leaves the count unchanged.
+UNTYPED_MENU_BASELINE_CEILING = 113
+
+
+
+def _menu_type_declarations() -> dict[str, str | None]:
+    """Map every `<path>::<MenuName>` in the prompt roots to its declared TYPE.
+
+    Built from the validator's own block scanner and regexes rather than a
+    second parser, so this guard cannot disagree with the checker it guards
+    about what a MENU is or where a declaration is read. A private
+    reimplementation previously missed indented MENU headers and headers with
+    trailing text, and read `TYPE:` out of prose outside the fence.
+    """
+    declarations: dict[str, str | None] = {}
+    seen_declaration: set[str] = set()
+    for path in _prompt_files():
+        text, error = pdsl.read_source_file(path)
+        if error or text is None:
+            continue
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        blocks, _ = pdsl.scan_blocks(str(path), text)
+        for block in blocks:
+            current: str | None = None
+            in_region = False
+            sub_header_indent: int | None = None
+            for raw_line in block.text.splitlines():
+                stripped = raw_line.strip()
+                if not stripped or stripped.startswith("//"):
+                    continue
+                unit_or_menu = pdsl.UNIT_OR_MENU_RE.match(stripped)
+                if unit_or_menu:
+                    kind, name = unit_or_menu.group(1), unit_or_menu.group("name")
+                    # Keyed by block index too, so two blocks in one file
+                    # declaring the same MENU name cannot mask each other.
+                    current = (
+                        f"{rel}#{block.block_index}::{name}" if kind == "MENU" else None
+                    )
+                    in_region = kind == "MENU"
+                    sub_header_indent = None
+                    if current is not None:
+                        declarations.setdefault(current, None)
+                    continue
+                head = pdsl.SECTION_HEAD_RE.match(stripped)
+                if not head or current is None or not in_region:
+                    continue
+                indent = len(raw_line) - len(raw_line.lstrip(" "))
+                section = head.group("section")
+                # Mirrors the validator's continuation rule: a line indented
+                # deeper than this menu's first sub-header is that header's own
+                # text. Without it an over-indented `TYPE:` counted here while
+                # the validator ignored it, so a newly added menu could leave
+                # the untyped set with no declaration the validator can see.
+                if sub_header_indent is None:
+                    sub_header_indent = indent
+                elif section not in pdsl.MENU_SUB_HEADERS and indent > sub_header_indent:
+                    continue
+                if section == pdsl.GATE_HEADER:
+                    # Latch on the FIRST declaration, mirroring the validator's
+                    # `state.menu_type_line`: it flags every later TYPE line as a
+                    # duplicate whatever its value, so a menu whose first
+                    # declaration is invalid stays untyped no matter what follows.
+                    if current in seen_declaration:
+                        continue
+                    seen_declaration.add(current)
+                    value = stripped[len(pdsl.GATE_HEADER) + 1:].strip()
+                    # A value the validator would reject is not a declaration.
+                    if value in pdsl.GATE_TYPES:
+                        declarations[current] = value
+                    continue
+                # Mirrors the validator: only a recognized section other than
+                # TITLE or TYPE ends the region. Prose does not.
+                if section in pdsl.SECTION_HEADERS and section != "TITLE":
+                    in_region = False
+    return declarations
+
+
+def test_the_untyped_menu_surface_does_not_grow() -> None:
+    """A newly introduced MENU must declare a gate risk TYPE.
+
+    The tail recorded in UNTYPED_MENU_BASELINE is grandfathered because an
+    undeclared gate is treated as `blocking`, which is the conservative
+    direction. What must not happen is the untyped surface growing, so a MENU
+    that is neither typed nor in the baseline fails here.
+    """
+    declarations = _menu_type_declarations()
+    untyped_now = {key for key, value in declarations.items() if value is None}
+
+    new_untyped = sorted(untyped_now - UNTYPED_MENU_BASELINE)
+    assert not new_untyped, (
+        "New MENU(s) without a declared gate risk TYPE:\n  "
+        + "\n  ".join(new_untyped)
+        + "\n\nDeclare `TYPE: confirmation | decision | blocking` on each, or, if the "
+        "menu was renamed or moved, update UNTYPED_MENU_BASELINE."
+    )
+
+    # Both assertions above and below are set differences, so a rename -- one key
+    # out, another in -- passes, as it should. So would a genuinely new untyped
+    # menu added to the baseline in the same diff, disguised as that rename. The
+    # count is what makes that impossible without editing a second, obviously
+    # named constant that a reviewer can see moving.
+    assert len(UNTYPED_MENU_BASELINE) <= UNTYPED_MENU_BASELINE_CEILING, (
+        f"UNTYPED_MENU_BASELINE holds {len(UNTYPED_MENU_BASELINE)} entries, above the "
+        f"recorded ceiling of {UNTYPED_MENU_BASELINE_CEILING}. The untyped surface may "
+        "only shrink: declare a TYPE on the new menu rather than grandfathering it. A "
+        "rename swaps one key for another and leaves the count unchanged."
+    )
+
+    stale = sorted(UNTYPED_MENU_BASELINE - set(declarations))
+    assert not stale, (
+        "UNTYPED_MENU_BASELINE lists MENU(s) that no longer exist:\n  "
+        + "\n  ".join(stale)
+        + "\n\nRemove them from the baseline."
+    )
+
+
+def _declarations_for(tmp_path: Path, name: str, body: str) -> dict[str, str | None]:
+    """Run the guard's scanner over a single fixture file."""
+    fixture = tmp_path / name
+    fixture.write_text(body, encoding="utf-8")
+    with mock.patch(f"{__name__}._prompt_files", return_value=[fixture]), \
+            mock.patch(f"{__name__}.REPO_ROOT", tmp_path):
+        return _menu_type_declarations()
+
+
+def test_the_guard_classifies_declared_and_undeclared_menus(tmp_path: Path) -> None:
+    """The guard is the only thing requiring a new MENU to declare a type.
+
+    It has to agree with the validator about what a MENU is and what counts as
+    a declaration, so both classifications are pinned here rather than trusted.
+    """
+    body = (
+        "```pdsl\n"
+        "MENU Declared:\n  TITLE: t\n  TYPE: blocking\n  OPTIONS:\n    1 a -> CONTINUE X\n"
+        "\nMENU Undeclared:\n  TITLE: t\n  OPTIONS:\n    1 a -> CONTINUE X\n"
+        "```\n"
+    )
+    values = {key.split("::")[-1]: value for key, value in _declarations_for(
+        tmp_path, "both.md", body).items()}
+    assert values == {"Declared": "blocking", "Undeclared": None}
+
+
+def test_the_guard_sees_menu_shapes_a_private_regex_missed(tmp_path: Path) -> None:
+    """An indented header, and trailing text after the name, are still MENUs."""
+    indented = "```pdsl\nUNIT Flow:\n  PURPOSE: x\n  MENU Nested:\n    OPTIONS:\n      1 a -> RUN X\n```\n"
+    assert list(_declarations_for(tmp_path, "a.md", indented).values()) == [None]
+
+    trailing = "```pdsl\nMENU Trailing: pick one\n  OPTIONS:\n    1 a -> RUN X\n```\n"
+    assert list(_declarations_for(tmp_path, "b.md", trailing).values()) == [None]
+
+
+def test_the_guard_does_not_read_a_declaration_the_validator_rejects(tmp_path: Path) -> None:
+    """A value or a position the validator rejects must not count as declared."""
+    outside_fence = (
+        "```pdsl\nMENU Fenced:\n  TITLE: t\n  OPTIONS:\n    1 a -> RUN X\n```\n"
+        "\n  TYPE: confirmation is one of three values.\n"
+    )
+    assert list(_declarations_for(tmp_path, "c.md", outside_fence).values()) == [None]
+
+    bad_value = "```pdsl\nMENU Bad:\n  TITLE: t\n  TYPE: urgent\n  OPTIONS:\n    1 a -> RUN X\n```\n"
+    assert list(_declarations_for(tmp_path, "d.md", bad_value).values()) == [None]
+
+    past_region = "```pdsl\nMENU Late:\n  OPTIONS:\n    1 a -> RUN X\n  TYPE: blocking\n```\n"
+    assert list(_declarations_for(tmp_path, "e.md", past_region).values()) == [None]
+
+
+def test_the_guard_keeps_same_named_menus_in_separate_blocks_apart(tmp_path: Path) -> None:
+    """A typed menu must not mask an untyped one of the same name in another block."""
+    body = (
+        "```pdsl\nMENU Same:\n  TITLE: t\n  OPTIONS:\n    1 a -> RUN X\n```\n"
+        "\n```pdsl\nMENU Same:\n  TITLE: t\n  TYPE: blocking\n  OPTIONS:\n    1 a -> RUN X\n```\n"
+    )
+    assert sorted(_declarations_for(tmp_path, "f.md", body).values(), key=str) == [None, "blocking"]
+
+
+def test_the_guard_does_not_accept_a_declaration_the_validator_rejects(tmp_path: Path) -> None:
+    """A malformed declaration must not satisfy the no-growth guard.
+
+    The scanner latches on the first `TYPE` line, mirroring the validator's
+    `state.menu_type_line`. Without that latch an invalid first declaration
+    followed by a valid one registered the menu as typed while the validator
+    rejected the file outright — so a newly added menu could carry a malformed
+    declaration and still pass the guard.
+    """
+    invalid_then_valid = (
+        "```pdsl\nMENU X:\n  TITLE: t\n  TYPE: bogus\n  TYPE: blocking\n"
+        "  OPTIONS:\n    1 a -> RUN Y\n```\n"
+    )
+    assert list(_declarations_for(tmp_path, "a.md", invalid_then_valid).values()) == [None]
+
+    single_invalid = (
+        "```pdsl\nMENU X:\n  TITLE: t\n  TYPE: bogus\n  OPTIONS:\n    1 a -> RUN Y\n```\n"
+    )
+    assert list(_declarations_for(tmp_path, "b.md", single_invalid).values()) == [None]
+
+    # A valid first declaration still counts; the duplicate that follows fails
+    # the file on PDSL701, so the guard's verdict cannot create a bypass.
+    valid_then_valid = (
+        "```pdsl\nMENU X:\n  TITLE: t\n  TYPE: decision\n  TYPE: blocking\n"
+        "  OPTIONS:\n    1 a -> RUN Y\n```\n"
+    )
+    assert list(_declarations_for(tmp_path, "c.md", valid_then_valid).values()) == ["decision"]
+
+
+def test_the_guard_ignores_an_over_indented_declaration_like_the_validator(tmp_path: Path) -> None:
+    """The guard must not count a declaration the validator does not read.
+
+    An over-indented `TYPE:` is continuation text to the validator. Counted
+    here, it would drop a newly added menu out of the untyped set while
+    producing no validator finding — a silently undeclared gate, which is the
+    failure the freeze exists to prevent.
+    """
+    over_indented = (
+        "```pdsl\nMENU Over:\n  TITLE: Heading\n    TYPE: blocking\n"
+        "  OPTIONS:\n    1 a -> RUN X\n```\n"
+    )
+    assert list(_declarations_for(tmp_path, "over.md", over_indented).values()) == [None]
+
+    at_level = (
+        "```pdsl\nMENU AtLevel:\n  TITLE: Heading\n  TYPE: blocking\n"
+        "  OPTIONS:\n    1 a -> RUN X\n```\n"
+    )
+    assert list(_declarations_for(tmp_path, "level.md", at_level).values()) == ["blocking"]

--- a/tests/test_pdsl_validate_cli.py
+++ b/tests/test_pdsl_validate_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import random
 import json
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -20,6 +21,7 @@ from studio.utils.pdsl import (
     scan_blocks,
     validate_source,
 )
+from studio.utils.pdsl import _edit_distance
 from studio.utils.ui import set_json_mode
 
 
@@ -428,3 +430,944 @@ DO:
 """
     result = validate_source(PdslSource("prose-continuation.md", text))
     assert result.status == "PASS"
+
+
+def _gate_menu(
+    *,
+    declared: str = "",
+    extra: str = "",
+    tail: str = "",
+    indent: str = "  ",
+    name: str = "GateMenu",
+) -> str:
+    """Build a well-formed MENU, optionally carrying a gate risk declaration.
+
+    `indent` is a parameter because both shapes occur in shipped PDSL: the spec's
+    grammar indents MENU sub-headers, and some modules write them at column 0.
+    The rules must not depend on which.
+    """
+    lines = [f"MENU {name}:", f"{indent}TITLE: Pick one"]
+    if declared:
+        lines.append(f"{indent}TYPE: {declared}")
+    if extra:
+        lines.append(f"{indent}{extra}")
+    lines += [
+        f"{indent}OPTIONS:",
+        f"{indent}  1 yes -> CONTINUE CurrentWorkflow",
+        f"{indent}  2 no -> CONTINUE CurrentWorkflow",
+        f"{indent}INVALID:",
+        f'{indent}  EMIT "Reply with 1 or 2."',
+        f"{indent}  WAIT user.reply",
+        f"{indent}  STOP_TURN",
+    ]
+    return "\n".join(lines) + "\n" + tail
+
+
+def _rule_ids(text: str, source: str = "gate.md") -> list[str]:
+    return [f.rule_id for f in validate_source(PdslSource(source, text)).findings]
+
+
+def test_gate_type_accepts_each_declared_risk_in_both_menu_shapes() -> None:
+    """All three risk types are recognized, indented or at column 0."""
+    for indent in ("  ", ""):
+        for declared in ("confirmation", "decision", "blocking"):
+            assert _rule_ids(_gate_menu(declared=declared, indent=indent)) == [], (indent, declared)
+
+
+def test_gate_type_absent_is_valid() -> None:
+    """Absence is never an error: an undeclared gate is treated as `blocking`.
+
+    This is what lets the existing menu surface migrate gate by gate instead of
+    in one change, so it is asserted for both menu shapes and with prose present.
+    """
+    for indent in ("  ", ""):
+        assert _rule_ids(_gate_menu(indent=indent)) == [], indent
+    assert _rule_ids(_gate_menu(extra="NOTE: choose 1 to keep going")) == []
+
+
+def test_gate_type_must_be_one_literal_enum_token() -> None:
+    """Each probe that passed silently before must now fail exactly once.
+
+    A variable, an interpolation, a trailing condition and an unknown word are
+    all runtime decisions wearing a declaration's clothes.
+    """
+    for value in (
+        "urgent",
+        "{GATE_TYPE}",
+        "confirmation WHEN SIMPLE_MODE == normal",
+        "Confirmation",
+        "<confirmation | decision | blocking>",
+    ):
+        assert _rule_ids(_gate_menu(declared=value)) == ["PDSL700"], value
+
+    # A bare `TYPE:` with no value declares nothing but is still a declaration.
+    assert _rule_ids(_gate_menu(extra="TYPE:")) == ["PDSL700"]
+
+
+def test_gate_type_message_is_bounded() -> None:
+    """A finding interpolates author text, so its length must not follow the input."""
+    findings = validate_source(PdslSource("long.md", _gate_menu(declared="x" * 100_000))).findings
+    assert [f.rule_id for f in findings] == ["PDSL700"]
+    assert len(findings[0].message) < 200
+
+
+def test_the_elision_boundary_is_exact() -> None:
+    """A value at the limit is kept whole; one character more is shortened."""
+    at_limit = validate_source(PdslSource("a.md", _gate_menu(declared="x" * 60))).findings
+    assert "x" * 60 in at_limit[0].message
+    over = validate_source(PdslSource("b.md", _gate_menu(declared="x" * 61))).findings
+    assert "..." in over[0].message
+    assert "x" * 61 not in over[0].message
+
+
+def test_gate_type_is_rejected_twice_in_one_menu() -> None:
+    """Two declarations make the effective risk depend on read order."""
+    text = _gate_menu(declared="decision").replace(
+        "  TYPE: decision", "  TYPE: decision\n  TYPE: confirmation", 1)
+    findings = validate_source(PdslSource("double.md", text)).findings
+    assert [f.rule_id for f in findings] == ["PDSL701"]
+    assert "more than once" in findings[0].message
+
+
+def test_gate_type_is_reported_where_nothing_reads_it() -> None:
+    """A declaration outside a MENU, or nested in its body, is inert."""
+    outside = "UNIT Demo\n\nPURPOSE:\n  Do a thing.\n\nTYPE: blocking\n\nDO:\n  - RUN Something\n"
+    assert _rule_ids(outside) == ["PDSL702"]
+
+    # Trailing prose after a menu is not part of it.
+    assert _rule_ids(_gate_menu(tail="NOTES:\n  TYPE: confirmation\n")) == ["PDSL702"]
+
+    # Nested inside an option's action body.
+    nested = (
+        "MENU G:\n  TITLE: t\n  OPTIONS:\n"
+        "    1 x -> CONTINUE CurrentWorkflow\n      TYPE: blocking\n"
+    )
+    assert _rule_ids(nested) == ["PDSL702"]
+
+
+def test_the_declaration_region_ends_at_a_section_that_is_not_title_or_type() -> None:
+    """A near-miss outside the declaration region is prose, not a botched declaration.
+
+    This is the observable consequence of the region rule. An earlier version
+    of this test used prose without a colon in the tail, which no gate rule can
+    read either way -- so the entire region mechanism could be deleted with the
+    suite still green.
+    """
+    for section in ("NOTES", "RULES", "INVARIANTS", "ON_ERROR"):
+        tail = f"{section}:\n  TYP: blocking\n"
+        assert _rule_ids(_gate_menu(tail=tail)) == [], section
+
+    # Inside the region the same header is reported.
+    assert _rule_ids(_gate_menu(extra="TYP: blocking")) == ["PDSL703"]
+
+
+def test_the_declaration_region_does_not_suppress_pre_existing_menu_checks() -> None:
+    """A section between the MENU header and OPTIONS must not disable PDSL400.
+
+    An earlier attempt tracked menu *extent* by clearing `in_menu`, which left
+    `menu_expected` unset and silently switched off option numbering for the
+    rest of the block.
+    """
+    text = (
+        "MENU M:\nTITLE: t\nNOTES:\n  Suggested: pick 1.\n"
+        "OPTIONS:\n7 a -> RUN X\n9 b\n"
+    )
+    assert _rule_ids(text) == ["PDSL400", "PDSL400"]
+
+
+def test_a_declaration_nested_in_the_menu_body_is_inert() -> None:
+    """The region, not indentation, is what decides whether a declaration is read.
+
+    An indent rule was tried and removed: it protected nothing the region rule
+    does not already cover -- a declaration in the body is past the region
+    either way -- while adding false positives on tabs and unusual spacing, and
+    it did not apply at all when `TYPE` came first, which is the canonical
+    ordering.
+    """
+    nested_invalid = (
+        "MENU G:\n  OPTIONS:\n    1 a -> CONTINUE X\n"
+        "  INVALID:\n    TITLE: retry?\n    TYPE: confirmation\n"
+    )
+    assert _rule_ids(nested_invalid) == ["PDSL702"]
+
+    after_options = "MENU G:\n  OPTIONS:\n    1 a -> CONTINUE X\n  TYPE: blocking\n"
+    assert _rule_ids(after_options) == ["PDSL702"]
+
+    # Indentation alone is not a defect: the declaration is still in the region.
+    deep_but_in_region = (
+        "MENU G:\n  TITLE: t\n              TYPE: blocking\n  OPTIONS:\n    1 a -> CONTINUE X\n"
+    )
+    assert _rule_ids(deep_but_in_region) == []
+
+
+def test_a_declaration_before_title_is_the_canonical_shape() -> None:
+    """The spec puts TYPE directly under the MENU header; TITLE need not precede it."""
+    text = "MENU G:\n  TYPE: blocking\n  TITLE: t\n  OPTIONS:\n    1 a -> CONTINUE X\n"
+    assert _rule_ids(text) == []
+
+
+def test_a_declaration_outside_any_menu_is_reported_with_no_preceding_section() -> None:
+    """`state.section` is None straight after a UNIT header; the menu check must still bite."""
+    assert _rule_ids("UNIT Demo\n\nTYPE: blocking\n\nDO:\n  - RUN Something\n") == ["PDSL702"]
+
+
+def test_a_declaration_needs_no_space_after_the_colon() -> None:
+    """`TYPE:blocking` is the same declaration; the value offset must not be off by one."""
+    text = "MENU G:\n  TITLE: t\n  TYPE:blocking\n  OPTIONS:\n    1 a -> CONTINUE X\n"
+    assert _rule_ids(text) == []
+
+
+def test_gate_findings_point_at_the_declaring_line() -> None:
+    """A finding that names the wrong line sends the reader to the wrong place."""
+    bad_value = validate_source(PdslSource("v.md", _gate_menu(declared="urgent"))).findings
+    assert [(f.rule_id, f.line) for f in bad_value] == [("PDSL700", 3)]
+
+    duplicate = validate_source(
+        PdslSource("d.md", _gate_menu(declared="blocking", extra="TYPE: decision"))).findings
+    assert [(f.rule_id, f.line) for f in duplicate] == [("PDSL701", 4)]
+    assert "at line 3" in duplicate[0].hint
+
+    misplaced = validate_source(
+        PdslSource("m.md", _gate_menu(tail="NOTES:\n  TYPE: confirmation\n"))).findings
+    assert [(f.rule_id, f.line) for f in misplaced] == [("PDSL702", 11)]
+
+    near_miss = validate_source(PdslSource("n.md", _gate_menu(extra="TYP: blocking"))).findings
+    assert [(f.rule_id, f.line) for f in near_miss] == [("PDSL703", 3)]
+
+
+def test_duplicate_finding_message_is_bounded() -> None:
+    """PDSL701 interpolates the menu name, so it must be elided like the value is."""
+    long_name = "M" * 100_000
+    findings = validate_source(PdslSource(
+        "long.md", _gate_menu(declared="blocking", extra="TYPE: decision", name=long_name))).findings
+    assert [f.rule_id for f in findings] == ["PDSL701"]
+    assert len(findings[0].message) < 200
+
+
+def test_a_malformed_gate_header_is_reported() -> None:
+    """A near-miss must not silently leave a gate undeclared."""
+    for variant in (
+        "TYP: blocking",
+        "TYPO: blocking",
+        "TYPES: blocking",
+        "Type: blocking",
+        "type: blocking",
+        "tYpE: blocking",
+        "TYPE : blocking",
+        "- TYPE: blocking",
+        "RISK: blocking",
+        "GATE_TYPE: blocking",
+        # transpositions: plain Levenshtein scores these 2 and would let them past
+        "TPYE: blocking",
+        "TYEP: blocking",
+        # decorated or bulleted forms, which are not headers at all
+        "* TYPE: blocking",
+        "+ TYPE: blocking",
+        "`TYPE: blocking`",
+        "**TYPE:** blocking",
+        "(TYPE: blocking)",
+        # a separator PDSL does not use, and none at all
+        "TYPE = blocking",
+        "TYPE blocking",
+        # a hyphenated alias, and a Cyrillic lookalike of the leading T
+        "RISK-TYPE: blocking",
+        "\u0422YPE: blocking",
+    ):
+        assert _rule_ids(_gate_menu(extra=variant)) == ["PDSL703"], variant
+
+
+def test_prose_and_control_flow_headers_are_not_gate_declarations() -> None:
+    """MENU blocks legitimately carry prose and control flow; those must pass.
+
+    `ELSE:` inside an INVALID body is real PDSL (requirements/storytelling-modes.md),
+    and banning every unrecognized header would only grow an exemption list.
+    """
+    for benign in (
+        "NOTE: choose 1",
+        "NOTES: choose 1",
+        "ELSE: fall back to option 2",
+        "TIME: 30s",
+        "TIPS: read the plan first",
+        "IMPORTANT: this is prose",
+        "STYLE: terse",
+        # near-miss name, but no separator and no gate-type value: ordinary prose
+        "Tape recorder notes",
+        "Types of plan we support",
+    ):
+        assert _rule_ids(_gate_menu(extra=benign)) == [], benign
+
+
+def test_gate_rules_apply_to_every_menu_in_a_block_not_only_the_last() -> None:
+    """Per-menu state must reset at each MENU boundary and not leak across it."""
+    good_then_bad = _gate_menu(declared="blocking", name="First") + "\n" + _gate_menu(
+        declared="urgent", name="Second")
+    assert _rule_ids(good_then_bad) == ["PDSL700"]
+
+    bad_then_good = _gate_menu(declared="urgent", name="First") + "\n" + _gate_menu(
+        declared="blocking", name="Second")
+    assert _rule_ids(bad_then_good) == ["PDSL700"]
+
+    # A declaration in the first menu must not count as the second's.
+    both = _gate_menu(declared="blocking", name="First") + "\n" + _gate_menu(
+        declared="decision", name="Second")
+    assert _rule_ids(both) == []
+
+
+def test_gate_rules_leave_the_shipped_tree_byte_identical() -> None:
+    """This change must be inert on shipped PDSL, and the counts are pinned.
+
+    Filtering to the new band only would miss a regression in the shared parsing
+    this change touches, so the whole tally is asserted.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    # The corpus is the four authored-prompt roots the repo's PDSL CI already
+    # validates (`PROMPT_ROOTS` in tests/test_pdsl_keywords.py), collected in
+    # sorted order so the scan is deterministic. It is deliberately the whole
+    # authored surface rather than a sample: the point is that this change is
+    # inert on everything shipped, which a sample cannot establish.
+    #
+    # Generated and vendored trees are excluded by directory name, and the
+    # count is tripwired, so a generated tree landing under one of the roots
+    # fails with an explanation. Indentation is measured in spaces throughout;
+    # no authored PDSL block line uses tab indentation.
+    roots = tuple(repo_root / name
+                  for name in ("skills", "workflows", "requirements", "architecture"))
+    sources = sorted(
+        path for root in roots for path in root.rglob("*.md")
+        if not GENERATED_DIRECTORIES & set(path.relative_to(repo_root).parts)
+    )
+    assert sources, "expected shipped PDSL sources to scan"
+    assert len(sources) <= AUTHORED_CORPUS_CEILING, (
+        f"{len(sources)} authored sources exceeds the expected ceiling of "
+        f"{AUTHORED_CORPUS_CEILING}; if the surface has genuinely grown, raise it "
+        f"deliberately, and if a generated tree has landed under one of the roots, "
+        f"add its directory to GENERATED_DIRECTORIES instead."
+    )
+    counts: dict[str, int] = {}
+    for path in sources:
+        text, error = read_source_file(path)
+        if error or text is None:
+            continue
+        for finding in validate_source(PdslSource(source=str(path), text=text)).findings:
+            counts[finding.rule_id] = counts.get(finding.rule_id, 0) + 1
+    assert counts == {"PDSL200": 23, "PDSL600": 85, "PDSL601": 148}, counts
+
+
+# --- property-based checks over generated input -----------------------------
+# Stdlib only: random.Random(seed) keeps them deterministic without adding a
+# dependency. These assert invariants over inputs nobody hand-picked, which is
+# how the trailing-prose defect in _handle_section_header_line was found.
+
+PROPERTY_ITERATIONS = 400
+# Directory names that never hold authored PDSL. Excluded from the whole-tree
+# scan so a generated or vendored subtree cannot grow a unit test's cost.
+GENERATED_DIRECTORIES = frozenset({
+    "node_modules", "vendor", "dist", "build", "__pycache__", "htmlcov",
+    ".cache", ".venv", "site-packages",
+})
+# A tripwire, not a cost bound — measured, the whole-tree scan is ~0.13s for
+# ~354 sources, so this fires at roughly 0.22s. Its value is the error message:
+# a generated tree landing under a root whose directory name is not in
+# GENERATED_DIRECTORIES fails here with an explanation rather than as an
+# unexplained tally change.
+AUTHORED_CORPUS_CEILING = 600
+_GATE_FINDINGS = ("PDSL700", "PDSL701", "PDSL702", "PDSL703")
+
+
+def _gate_rule_ids(text: str) -> list[str]:
+    return [r for r in _rule_ids(text, "prop.md") if r in _GATE_FINDINGS]
+
+
+def test_property_edit_distance_obeys_the_properties_it_actually_has() -> None:
+    """Optimal string alignment is NOT a metric -- it violates the triangle inequality.
+
+    `d("CA","ABC")` is 3 while `d("CA","AC") + d("AC","ABC")` is 2. An earlier
+    version of this test asserted the inequality anyway and passed only because
+    the generator rarely produced a violating triple. The rule does not need a
+    metric: it compares one fixed target against a fixed threshold, so what has
+    to hold is identity, symmetry and the length bounds.
+    """
+    rng = random.Random(20260907)
+    alphabet = "TYPERECOMNDABZ_-0123"
+    for _ in range(PROPERTY_ITERATIONS):
+        left = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 12)))
+        right = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 12)))
+
+        assert _edit_distance(left, left) == 0
+        assert (_edit_distance(left, right) == 0) == (left == right)
+        assert _edit_distance(left, right) == _edit_distance(right, left)
+        assert abs(len(left) - len(right)) <= _edit_distance(left, right)
+        assert _edit_distance(left, right) <= max(len(left), len(right))
+
+
+def test_property_validation_never_raises_on_arbitrary_text() -> None:
+    """The validator runs over hundreds of files in CI; one odd file must not abort it."""
+    rng = random.Random(20260908)
+    fragments = [
+        "MENU G:", "UNIT U", "TITLE: t", "TYPE:", "TYPE: blocking", "TYPE : x", "- TYPE: x",
+        "Type: x", "OPTIONS:", "  1 a -> DO x", "INVALID:", '  EMIT "no"', "STOP_TURN",
+        "NOTES:", "RULES:", "```pdsl", "```", "", "   ", "\t", "<name>", "9" * 4400,
+        "TYPE: \u202e x", "TYPE: \x00", "MENU :", "MENU <unclosed", "PURPOSE:", "??:",
+        "A" * 300 + ":", "\u0661" * 4400,
+    ]
+    for _ in range(PROPERTY_ITERATIONS):
+        text = "\n".join(rng.choice(fragments) for _ in range(rng.randint(1, 25))) + "\n"
+        validate_source(PdslSource("fuzz.md", text))
+
+
+def _generated_menu(rng: random.Random, *, declared: str | None, slot: str) -> str:
+    """Assemble a menu placing a declaration in one named slot.
+
+    Placement, not content, is the axis that matters: the read slots are the
+    menu's own sub-header level before OPTIONS; everything else is unread.
+    """
+    indent = rng.choice(("  ", "    ", ""))
+    name = f"Menu{rng.randint(1, 9999)}"
+    declaration = f"TYPE: {declared}" if declared else None
+    prose = rng.choice(("NOTE: prose", "NOTES: prose", "ELSE: fall back", "TIME: 30s", None))
+
+    head = [f"MENU {name}:"]
+    if declaration and slot == "before-title":
+        head.append(f"{indent}{declaration}")
+    head.append(f"{indent}TITLE: Pick one")
+    if declaration and slot == "after-title":
+        head.append(f"{indent}{declaration}")
+    if prose:
+        head.append(f"{indent}{prose}")
+    head.append(f"{indent}OPTIONS:")
+    head.append(f"{indent}  1 yes -> CONTINUE CurrentWorkflow")
+    if declaration and slot == "in-options":
+        head.append(f"{indent}    {declaration}")
+    head.append(f"{indent}  2 no -> CONTINUE CurrentWorkflow")
+    head.append(f"{indent}INVALID:")
+    head.append(f'{indent}  EMIT "Reply with 1 or 2."')
+    if declaration and slot == "in-invalid":
+        head.append(f"{indent}    {declaration}")
+    head.append(f"{indent}  WAIT user.reply")
+    head.append(f"{indent}  STOP_TURN")
+    text = "\n".join(head) + "\n"
+    if declaration and slot == "in-tail":
+        text += f"NOTES:\n  {declaration}\n"
+    return text
+
+
+READ_SLOTS = ("before-title", "after-title")
+UNREAD_SLOTS = ("in-options", "in-invalid", "in-tail")
+
+
+BENIGN_HEADERS = (
+    "NOTE: prose", "NOTES: prose", "ELSE: fall back", "TIME: 30s", "TIPS: read it",
+    "IMPORTANT: prose mentioning TYPE and RUN", "STYLE: terse", "Tape recorder notes",
+    "Types of plan we support", "GATE: blocking",
+)
+
+
+def test_property_an_undeclared_menu_never_yields_a_gate_finding() -> None:
+    """Absence is valid whatever surrounds it -- the migration depends on this.
+
+    Varies the prose that surrounds the menu, at both column 0 and indented,
+    since a `declared=None` menu has no declaration slot to vary.
+    """
+    rng = random.Random(20260909)
+    for _ in range(PROPERTY_ITERATIONS):
+        indent = rng.choice(("  ", "    ", ""))
+        prose = [
+            f"{rng.choice((indent, ''))}{rng.choice(BENIGN_HEADERS)}"
+            for _ in range(rng.randint(0, 3))
+        ]
+        lines = [f"MENU Menu{rng.randint(1, 9999)}:", f"{indent}TITLE: Pick one"]
+        lines += prose
+        lines += [
+            f"{indent}OPTIONS:",
+            f"{indent}  1 yes -> CONTINUE CurrentWorkflow",
+            f"{indent}INVALID:",
+            f'{indent}  EMIT "Reply with 1."',
+            # A prompt is followed by a wait before the stop, as every example in
+            # the spec is: a fixture must not model a stop the user cannot answer.
+            f"{indent}  WAIT user.reply",
+            f"{indent}  STOP_TURN",
+        ]
+        tail = rng.choice(("", "NOTES:\n  Prose about TYPE and RUN.\n", "RULES:\n  ALWAYS x\n"))
+        text = "\n".join(lines) + "\n" + tail
+        assert _gate_rule_ids(text) == [], text
+
+
+def test_property_a_declaration_in_a_read_slot_is_accepted() -> None:
+    """A valid declaration at the menu's own sub-header level must validate clean."""
+    rng = random.Random(20260910)
+    for _ in range(PROPERTY_ITERATIONS):
+        text = _generated_menu(
+            rng,
+            declared=rng.choice(("confirmation", "decision", "blocking")),
+            slot=rng.choice(READ_SLOTS),
+        )
+        assert _gate_rule_ids(text) == [], text
+
+
+def test_property_a_declaration_in_an_unread_slot_is_reported() -> None:
+    """Nothing reads a declaration nested in the body or trailing the menu.
+
+    Accepting one there is how a gate would gain authority its author did not
+    put where the runtime looks for it.
+    """
+    rng = random.Random(20260912)
+    for _ in range(PROPERTY_ITERATIONS):
+        text = _generated_menu(
+            rng,
+            declared=rng.choice(("confirmation", "decision", "blocking")),
+            slot=rng.choice(UNREAD_SLOTS),
+        )
+        assert _gate_rule_ids(text) == ["PDSL702"], text
+
+
+def test_property_findings_are_deterministic_and_ordered() -> None:
+    """Sorted, repeatable findings are promised by the CDSL contract."""
+    rng = random.Random(20260911)
+    # Only the repeatability half of this can fail: `validate_source` sorts
+    # before returning, so asserting its output is sorted is tautological.
+    # Several findings per variant still matter -- a single finding is trivially
+    # repeatable and would not exercise the comparison at all.
+    variants = [
+        _gate_menu(extra="TYP: x", name="A") + _gate_menu(declared="urgent", name="B"),
+        _gate_menu(extra='TYPE = matches(x, "nope")', name="C"),
+        _gate_menu(declared="urgent", name="D") + _gate_menu(extra="RISK: x", name="E"),
+        _gate_menu(declared="blocking", extra="TYPE: decision", name="F")
+        + _gate_menu(extra="Type: blocking", name="G"),
+        # Two fenced blocks, so gate findings come from more than one block.
+        # Both fences are closed and both menus carry a gate defect on purpose:
+        # leaving the second fence open made its finding PDSL100 -- about fence
+        # syntax rather than a gate -- so the variant said nothing the others
+        # did not already cover.
+        "```pdsl\n" + _gate_menu(extra="TYP: blocking", name="H") + "```\n\n```pdsl\n"
+        + _gate_menu(declared="urgent", name="I") + "```\n",
+    ]
+    for _ in range(PROPERTY_ITERATIONS // 4):
+        text = rng.choice(variants)
+        # The documented order is source order, then line, column, rule id.
+        runs = [
+            [(f.block_index, f.line, f.column, f.rule_id)
+             for f in validate_source(PdslSource("d.md", text)).findings]
+            for _ in range(3)
+        ]
+        assert len(runs[0]) >= 2, f"variant must yield several findings: {runs[0]}"
+        assert runs[0] == runs[1] == runs[2], text
+
+
+def test_every_rejected_alias_is_reported_in_both_spellings() -> None:
+    """Each alias earns its place, and hyphen and underscore are equivalent."""
+    for alias in ("RISK", "RISK_TYPE", "GATE_RISK", "GATE_TYPE", "MENU_TYPE", "RISK_LEVEL"):
+        for spelling in (alias, alias.replace("_", "-")):
+            assert _rule_ids(_gate_menu(extra=f"{spelling}: blocking")) == ["PDSL703"], spelling
+
+
+def test_gate_is_not_an_alias() -> None:
+    """`GATE:` is plausible as a sub-header in a codebase about gates.
+
+    Treating it as a typo of `TYPE` would annoy more often than it would help.
+    """
+    assert _rule_ids(_gate_menu(extra="GATE: blocking")) == []
+
+
+def test_a_short_value_is_never_elided() -> None:
+    """The elision boundary is inclusive, so an ordinary value is quoted whole."""
+    findings = validate_source(PdslSource("s.md", _gate_menu(declared="urgent"))).findings
+    assert "`urgent`" in findings[0].message
+
+
+def test_an_elided_value_is_exactly_the_cap_in_length() -> None:
+    """The shortened value must not exceed the cap it is shortened to."""
+    findings = validate_source(PdslSource("e.md", _gate_menu(declared="x" * 500))).findings
+    quoted = findings[0].message.split("`")[1]
+    assert len(quoted) == 60
+    assert quoted.endswith("...")
+
+
+def test_a_malformed_gate_header_line_is_still_offered_to_the_other_checks() -> None:
+    """Reporting a botched declaration must not mask an unrelated finding on it."""
+    text = (
+        'MENU G:\n  TITLE: t\n  TYPE = matches(x, "nope")\n'
+        "  OPTIONS:\n    1 a -> CONTINUE CurrentWorkflow\n"
+    )
+    assert _rule_ids(text) == ["PDSL703", "PDSL500"]
+
+
+def test_confusable_lookalikes_are_normalized_before_the_near_miss_test() -> None:
+    """A Cyrillic letter that renders identically must not hide a declaration."""
+    for variant in ("\u0422YPE: blocking", "T\u0423PE: blocking", "TYP\u0415: blocking"):
+        assert _rule_ids(_gate_menu(extra=variant)) == ["PDSL703"], repr(variant)
+
+
+def test_a_zero_width_character_cannot_hide_a_gate_declaration() -> None:
+    """An invisible character reads as a declaration and must not pass as prose."""
+    for variant in (
+        "TYPE\u200b: blocking",
+        "TYP\u200bE: blocking",
+        "\u200bTYPE: blocking",
+        "TYPE\ufeff: blocking",
+        "TYPE\u2060: blocking",
+    ):
+        assert _rule_ids(_gate_menu(extra=variant)) == ["PDSL703"], repr(variant)
+
+
+def test_decoration_is_discarded_rather_than_enumerated() -> None:
+    """Any decoration around the name reduces to the same candidate.
+
+    Three review passes each found forms an enumerating pattern had missed, so
+    the rule discards non-alphanumerics instead of listing what they can be.
+    """
+    for variant in (
+        "`TYPE`: blocking", "``TYPE``: blocking", "[TYPE]: blocking", "(TYPE): blocking",
+        "{TYPE}: blocking", "<TYPE>: blocking", '"TYPE": blocking', "'TYPE': blocking",
+        "_TYPE_: blocking", "__TYPE__: blocking", "TYPE__: blocking", "#TYPE: blocking",
+        "> TYPE: blocking", "TYPE -> blocking", "TYPE => blocking",
+    ):
+        assert _rule_ids(_gate_menu(extra=variant)) == ["PDSL703"], variant
+
+
+def test_edit_distance_returns_the_documented_values() -> None:
+    """Pinned values, because the axioms alone are satisfied by broken variants."""
+    assert _edit_distance("", "") == 0
+    assert _edit_distance("TYPE", "TYPE") == 0
+    assert _edit_distance("TYP", "TYPE") == 1
+    assert _edit_distance("TYPES", "TYPE") == 1
+    assert _edit_distance("TY", "YT") == 1, "an adjacent transposition costs one"
+    assert _edit_distance("TPYE", "TYPE") == 1
+    assert _edit_distance("TTT", "T") == 2
+    assert _edit_distance("TIME", "TYPE") == 2, "distance 2 is outside the threshold"
+
+
+def test_gate_findings_pin_their_column() -> None:
+    """A finding's column is part of its address and of the sort order."""
+    for text, rule in (
+        (_gate_menu(declared="urgent"), "PDSL700"),
+        (_gate_menu(extra="TYP: blocking"), "PDSL703"),
+    ):
+        findings = validate_source(PdslSource("c.md", text)).findings
+        assert [(f.rule_id, f.column) for f in findings] == [(rule, 1)], rule
+
+
+def test_a_reported_header_keeps_the_authors_own_spelling() -> None:
+    """The finding must echo what was written, not the normalized form.
+
+    Normalization exists to recognize the attempt; showing the folded name back
+    would tell an author their correct-looking line is wrong without saying why.
+    """
+    findings = validate_source(PdslSource(
+        "sp.md", _gate_menu(extra="ТYPE: blocking"))).findings
+    assert [f.rule_id for f in findings] == ["PDSL703"]
+    assert "ТYPE" in findings[0].message
+
+
+def test_aliases_are_reported_on_the_prose_path_too() -> None:
+    """An alias containing `_` must survive the candidate scan, not just the header one.
+
+    The header path reaches these through SECTION_HEAD_RE; a decorated one only
+    reaches them through the candidate scan, which must keep `_` inside a name.
+    """
+    for variant in ("- GATE_TYPE: blocking", "`MENU_TYPE`: blocking", "* RISK_LEVEL: blocking"):
+        assert _rule_ids(_gate_menu(extra=variant)) == ["PDSL703"], variant
+
+
+def test_more_than_one_confusable_is_still_recognized() -> None:
+    """A single lookalike survives on distance alone; two need the mapping."""
+    assert _rule_ids(_gate_menu(extra="ТУPE: blocking")) == ["PDSL703"]
+    assert _rule_ids(_gate_menu(extra="ΤΥΡΕ: blocking")) == ["PDSL703"]
+
+
+def test_the_duplicate_finding_names_the_offending_menu() -> None:
+    """`menu_name` must be set at the boundary, not merely non-empty.
+
+    Dropping it would make the bounded-message test pass trivially, since an
+    absent name is also a short one.
+    """
+    findings = validate_source(PdslSource("nm.md", _gate_menu(
+        declared="blocking", extra="TYPE: decision", name="MyGate"))).findings
+    assert [f.rule_id for f in findings] == ["PDSL701"]
+    assert "`MyGate`" in findings[0].message
+
+
+def test_lower_and_mixed_case_prose_is_not_a_declaration_attempt() -> None:
+    """PDSL headers are upper-case, so front matter and prose must stay quiet.
+
+    Reported only when the value is a gate type, which is the miscasing the
+    reported gap names (`Type: blocking`).
+    """
+    for benign in (
+        '{"type":"VALIDATION_REPORT","status":"PASS|FAIL"}',
+        "**Type**: CLI (command-line interface)",
+        "- Type: `<type>` (required)",
+        "type: skill",
+        'type = "file"',
+    ):
+        assert _rule_ids(_gate_menu(extra=benign)) == [], benign
+
+    for miscased in ("Type: blocking", "type: blocking", "tYpE: confirmation"):
+        assert _rule_ids(_gate_menu(extra=miscased)) == ["PDSL703"], miscased
+
+
+def test_a_reported_header_name_is_bounded() -> None:
+    """PDSL703 interpolates the header name, so it must be elided like the others.
+
+    The trailing run keeps the name a near-miss after end-trimming, so this
+    reaches the message rather than being rejected first.
+    """
+    findings = validate_source(PdslSource(
+        "ln.md", _gate_menu(extra="TYPE" + "_" * 200_000 + ": blocking"))).findings
+    assert [f.rule_id for f in findings] == ["PDSL703"]
+    assert len(findings[0].message) < 200
+
+
+def test_alternate_alphabets_are_folded_to_ascii() -> None:
+    """Fullwidth, mathematical and superscript letters render as `TYPE`.
+
+    Folding is per character and only accepts a one-to-one result, so a
+    character that expands (`\u203c` -> `!!`) stays decoration and the reported
+    name keeps the author's offsets.
+    """
+    math_bold = "".join(chr(0x1D400 + ord(char) - ord("A")) for char in "TYPE")
+    for variant in ("\uff34\uff39\uff30\uff25", math_bold, "\u1d40YPE"):
+        assert _rule_ids(_gate_menu(extra=f"{variant}: blocking")) == ["PDSL703"], repr(variant)
+
+    # An expanding character must not shift the reported name.
+    findings = validate_source(PdslSource(
+        "ex.md", _gate_menu(extra="\u203cTTYPE: blocking"))).findings
+    assert [f.rule_id for f in findings] == ["PDSL703"]
+    assert "TTYPE" in findings[0].message, findings[0].message
+
+
+def test_an_all_caps_prose_line_without_a_separator_is_not_a_declaration() -> None:
+    """The no-separator rule needs a probe the case rule cannot also suppress."""
+    assert _rule_ids(_gate_menu(extra="TYPES OF PLAN WE SUPPORT")) == []
+    assert _rule_ids(_gate_menu(extra="TYPE OF PLAN IS UNCLEAR")) == []
+    # ...while a colon-less line whose value *is* a gate type is reported.
+    assert _rule_ids(_gate_menu(extra="TYPE blocking")) == ["PDSL703"]
+
+
+def test_a_miscased_header_with_no_value_is_reported() -> None:
+    """A bare `Type:` declares nothing and is not prose either."""
+    for variant in ("Type:", "type:", "Types:"):
+        assert _rule_ids(_gate_menu(extra=variant)) == ["PDSL703"], variant
+
+
+def test_pdsl_validate_cli_reports_gate_findings_end_to_end() -> None:
+    """Gate rules must survive the real command, not just the in-process helper.
+
+    Every other gate test calls `validate_source` directly, so a regression in
+    argument handling, exit status or result formatting would leave them green.
+    """
+    set_json_mode(False)
+    rc, stdout, stderr = _run(
+        ["pdsl", "validate", "--text", _gate_menu(declared="urgent"), "--json"])
+
+    assert rc != 0
+    assert stderr == ""
+    payload = json.loads(stdout)
+    assert payload["command"] == "pdsl validate"
+    assert payload["ok"] is False
+    assert payload["summary"]["fail_count"] == 1
+    assert payload["summary"]["finding_count"] == 1
+    finding = payload["results"][0]["findings"][0]
+    assert finding["rule_id"] == "PDSL700"
+    assert finding["severity"] == "error"
+    assert "confirmation, decision, blocking" in finding["message"]
+
+
+def test_pdsl_validate_cli_passes_a_valid_and_an_undeclared_gate() -> None:
+    """A declared gate and an omitted one both exit zero through the CLI."""
+    for text in (_gate_menu(declared="blocking"), _gate_menu()):
+        set_json_mode(False)
+        rc, stdout, stderr = _run(["pdsl", "validate", "--text", text, "--json"])
+
+        assert rc == 0, stderr
+        payload = json.loads(stdout)
+        assert payload["ok"] is True
+        assert payload["summary"]["finding_count"] == 0
+
+
+def test_pdsl_validate_cli_reports_a_malformed_gate_header_in_human_output() -> None:
+    """The human-readable path must name the rule too, not only `--json`."""
+    set_json_mode(False)
+    rc, stdout, _ = _run(["pdsl", "validate", "--text", _gate_menu(extra="TYP: blocking")])
+
+    assert rc != 0
+    assert "PDSL703" in stdout
+
+
+def test_a_sub_header_continuation_is_not_a_declaration_or_a_near_miss() -> None:
+    """A title running onto a second line is that title's text, not a header.
+
+    Both directions matter and both were wrong. A continuation resembling the
+    keyword was reported as a misspelled declaration, and — worse, and
+    unreported — one beginning `TYPE:` was *accepted* as the menu's declaration,
+    so prose inside a title could become the gate's declared risk.
+    """
+    near_miss_continuation = (
+        "MENU G:\n  TITLE: Heading\n    TYP: blocking\n  OPTIONS:\n    1 a -> RUN X\n"
+    )
+    assert _rule_ids(near_miss_continuation) == []
+
+    declaration_continuation = (
+        "MENU G:\n  TITLE: Heading\n    TYPE: blocking\n  OPTIONS:\n    1 a -> RUN X\n"
+    )
+    assert _rule_ids(declaration_continuation) == []
+
+    deeply_indented = (
+        "MENU G:\n  TITLE: t\n              TYPE: blocking\n  OPTIONS:\n    1 a -> RUN X\n"
+    )
+    assert _rule_ids(deeply_indented) == []
+
+
+def test_the_sub_header_level_is_learned_not_assumed() -> None:
+    """The level comes from the first sub-header, whichever one that is.
+
+    An earlier attempt compared against a remembered indent seeded from the
+    declaration itself, so the check never applied when `TYPE` came first —
+    the canonical ordering. Learning the level removes the value to bootstrap.
+    """
+    for text, expected in (
+        # `TYPE` first sets the level; a later sub-header at that level is fine.
+        ("MENU G:\n  TYPE: blocking\n  TITLE: t\n  OPTIONS:\n    1 a -> RUN X\n", []),
+        ("MENU G:\n  TYPE: urgent\n  TITLE: t\n  OPTIONS:\n    1 a -> RUN X\n", ["PDSL700"]),
+        # Column-zero menus keep working in both directions.
+        ("MENU G:\nTITLE: t\nTYPE: blocking\nOPTIONS:\n  1 a -> RUN X\n", []),
+        ("MENU G:\nTITLE: t\nTYP: blocking\nOPTIONS:\n  1 a -> RUN X\n", ["PDSL703"]),
+    ):
+        assert _rule_ids(text) == expected, text
+
+
+def test_the_sub_header_level_is_measured_per_menu_not_per_block() -> None:
+    """A later menu may indent differently; a stale level suppresses its checks.
+
+    This is the failure the continuation rule was written to avoid, arriving by
+    another route: with the level held per block, a second menu indented deeper
+    than the first had its whole body read as continuation text — losing its own
+    declaration *and* the pre-existing option-numbering findings.
+    """
+    shallow_then_deep = (
+        "MENU First:\nTITLE: t\nOPTIONS:\n  1 a -> RUN X\n\n"
+        "MENU Second:\n  TITLE: t\n  TYPE: urgent\n  OPTIONS:\n    2 a -> RUN X\n    5 b -> RUN Y\n"
+    )
+    deep_then_shallow = (
+        "MENU First:\n    TITLE: t\n    OPTIONS:\n      1 a -> RUN X\n\n"
+        "MENU Second:\nTITLE: t\nTYPE: urgent\nOPTIONS:\n2 a -> RUN X\n5 b -> RUN Y\n"
+    )
+    for text in (shallow_then_deep, deep_then_shallow):
+        rules = _rule_ids(text)
+        assert "PDSL700" in rules, text
+        assert rules.count("PDSL400") == 2, f"pre-existing numbering checks lost: {rules}"
+
+
+def test_a_continuation_is_ignored_rather_than_accepted_as_a_declaration() -> None:
+    """Asserting "no findings" cannot tell *ignored* from *silently accepted*.
+
+    A duplicate probe can: `PDSL701` fires only if the first deep `TYPE` was
+    latched as this menu's declaration. Without this, a rule that exempted
+    recognized `TYPE` headers from the continuation check — so prose in a title
+    became the gate's declared risk again — passed the whole suite.
+    """
+    deep_duplicate = (
+        "MENU G:\n  TITLE: Heading\n    TYPE: blocking\n    TYPE: decision\n"
+        "  OPTIONS:\n    1 a -> RUN X\n"
+    )
+    assert _rule_ids(deep_duplicate) == []
+
+
+def test_an_indented_sub_header_still_opens_its_section() -> None:
+    """A recognized sub-header is a header wherever it sits.
+
+    Treating a deeper `OPTIONS:` as continuation text left its whole body
+    unvalidated, losing the pre-existing option-numbering checks — the same
+    suppression this rule was written to avoid, by another route.
+    """
+    options_deeper_than_title = (
+        "MENU G:\n  TITLE: t\n    OPTIONS:\n      1 a -> RUN X\n      3 b -> RUN Y\n"
+    )
+    assert _rule_ids(options_deeper_than_title) == ["PDSL400"]
+
+
+def test_an_unrecognized_first_sub_header_sets_the_level() -> None:
+    """`NOTE:` and `ELSE:` are legitimate menu headers, so they set it too.
+
+    With the level captured only for recognized headers, a menu opening with
+    prose left it unset — so a deeper `TYPE:` was read as the declaration and a
+    deeper near-miss was falsely reported.
+    """
+    for text in (
+        "MENU G:\n  NOTE: n\n    TYP: blocking\n  OPTIONS:\n    1 a -> RUN X\n",
+        "MENU G:\n  ELSE: e\n    TYPE: nonsense\n  OPTIONS:\n    1 a -> RUN X\n",
+    ):
+        assert _rule_ids(text) == [], text
+
+
+def test_a_malformed_gate_header_needs_no_recognized_header_shape() -> None:
+    """The prose path must be reachable: `TYPE = blocking` is not `^[A-Z]+:`.
+
+    Every other near-miss test uses `TYP:`, which reaches the rule through the
+    recognized-header path, so the guard on the prose path was unpinned.
+    """
+    assert _rule_ids("MENU G:\n  TITLE: t\n    TYPE = blocking\n  OPTIONS:\n    1 a -> RUN X\n") == []
+    assert _rule_ids("MENU G:\n  TITLE: t\n  TYPE = blocking\n  OPTIONS:\n    1 a -> RUN X\n") == ["PDSL703"]
+
+
+def test_an_unmapped_lookalike_inside_the_name_is_still_recognized() -> None:
+    """The confusable map was an enumeration, so anything absent from it escaped.
+
+    A lookalike or an NFKC-expanding character *inside* the word truncated the
+    name capture to `T`, which is too far from `TYPE` to report — so the line
+    fell through as prose. Expanding characters are now dropped rather than
+    kept, the capture spans Unicode letters, and the near-miss test discards
+    whatever is still non-ASCII. No map to keep current.
+    """
+    for variant in (
+        "TҮPE: blocking",   # Cyrillic capital straight U, absent from the map
+        "T‼YPE: blocking",  # double exclamation, expands under NFKC
+        "TYԀE: blocking",   # Komi De, also absent
+    ):
+        assert _rule_ids(_gate_menu(extra=variant)) == ["PDSL703"], repr(variant)
+
+
+def test_an_abandoned_declaration_is_reported_whatever_its_casing() -> None:
+    """A separator with nothing after it is an attempt, not front matter.
+
+    The miscasing guard suppresses a lower-case candidate whose value is some
+    other token, which is what keeps `type: skill` prose. An *empty* value is
+    the one case where that suppression must not apply: the author wrote the
+    header and the separator and stopped, which is an abandoned declaration in
+    any casing. Pinned because the spec asserts it and the guard's truthiness
+    test is what implements it.
+    """
+    for variant in ("type:", "Type:", "TYPE:"):
+        assert _rule_ids(_gate_menu(extra=variant)) != [], variant
+    # ...while a value that is merely some other token stays prose.
+    for benign in ("type: skill", "Type: CLI", "type: workflow"):
+        assert _rule_ids(_gate_menu(extra=benign)) == [], benign
+
+
+def test_a_reported_name_survives_non_length_preserving_folding() -> None:
+    """The reported name must come through a source map, not a folded offset.
+
+    U+203C is dropped by folding, so an offset into the folded string is not an
+    offset into the original: reusing one truncates the name. An earlier version
+    of this test used a character NFKC leaves unchanged, so it passed on the very
+    mechanism it was written to replace.
+    """
+    findings = validate_source(PdslSource(
+        "sp.md", _gate_menu(extra="T\u203cYPE: blocking"))).findings
+    assert [f.rule_id for f in findings] == ["PDSL703"]
+    assert "T\u203cYPE" in findings[0].message, findings[0].message
+
+
+def test_the_name_capture_spans_a_non_ascii_letter() -> None:
+    """Widening the capture past ASCII is what stops a lookalike truncating it.
+
+    With an ASCII-only capture, `T\u00c9PE` yields the stub `T`, too far from
+    `TYPE` to report; spanning the letter keeps it at distance 1. Probing with
+    unrelated non-ASCII prose instead would pass whatever the capture does,
+    since the distance guard rejects such prose either way.
+    """
+    assert _rule_ids(_gate_menu(extra="T\u00c9PE: blocking")) == ["PDSL703"]
+
+    # Non-ASCII that is not standing in for a letter of the keyword stays prose,
+    # and arbitrarily many do not collapse into a near-miss.
+    for benign in ("Caf\u00e9: something", "\u4f60\u597d: hello", "TYPE\u04ae\u04ae: blocking"):
+        assert _rule_ids(_gate_menu(extra=benign)) == [], repr(benign)


### PR DESCRIPTION
Closes #152.

The validator does not recognise a `TYPE` section header at all, so a gate risk declaration is completely unchecked. A literal value, a variable, a value with a trailing `WHEN`, a misspelled header and no header at all all pass silently — so a typo downgrades a gate to undeclared with nothing reported, and any declared-risk model rests on a lint with no opinion about the thing it is meant to enforce.

## What this adds

A `TYPE` sub-header on a `MENU`, and four rules in a new `PDSL700` band:

| rule | |
|---|---|
| `PDSL700` | the value must be one literal enum token — `confirmation`, `decision`, `blocking` |
| `PDSL701` | at most one `TYPE` per MENU, so risk cannot depend on read order |
| `PDSL702` | a declaration where nothing reads it: outside a MENU, nested in its body, or trailing it |
| `PDSL703` | a sub-header that is a near-miss of `TYPE`, so a typo cannot silently leave a gate undeclared |

**An absent `TYPE` stays valid** and is treated as `blocking` at runtime, so no existing menu changes behaviour and the surface migrates gate by gate. `test_the_untyped_menu_surface_does_not_grow` freezes today's undeclared menus and fails on a newly added one, so the untyped surface cannot grow. That guard is built from the validator's own block scanner and regexes, so it cannot disagree with the checker it guards about what a MENU is or where a declaration is read.

**Nothing consumes the declaration yet**, so this is inert on shipped PDSL — enforced rather than asserted: a test pins the whole finding tally across every validated root, not only the new band, because this change touches shared parsing.

## Two design points

**A declaration is read in a MENU's *declaration region*** — from its header to the first recognised section other than `TITLE` — rather than by tracking where a MENU ends. Tracking the latter left the menu-numbering checks suppressed for the rest of the block.

**A malformed declaration is recognised by discarding decoration** and folding Unicode per character, rather than by listing the forms it can take, because that list is open-ended. `architecture/specs/PDSL.md` states what is consequently *not* detected (`1. TYPE:`, `<b>TYPE</b>:`, `TYPE(gate):`) and that every such case leaves the gate undeclared and therefore `blocking` — the failure direction is more friction, never more autonomy.

## Verification

- `make test` 5331 passed — 49 new tests, 942 of the 1325 added lines are tests
- `make pylint`, `make vulture-ci`, `make validate`, `make spec-coverage`, `make test-coverage` all clean; `pdsl.py` granularity 0.58 against the 0.46 floor
- **No behavioural drift:** the old and new validators run side by side over all 369 `.md` files in the four validated roots give identical findings per file — `{PDSL200: 23, PDSL600: 85, PDSL601: 148}` on both, zero differences
- **The near-miss rule is verified exhaustively, not sampled:** every name of length 2–5 over `[A-Z0-9_-]` classified with its true distance recomputed against an independent reference — all flagged names at distance 0 or 1, none at distance 2
- **False positives measured against real content:** every distinct line in those four roots injected into a declaration region; 5 of 30,898 would be reported, four of them this feature's own spec prose

## Known gap

Five tracked files under `.bootstrap/config/kits/sdlc/` carry `MENU` blocks and sit outside the guard's roots — outside PDSL CI entirely today. Extending the requirement into kit files is the kit owner's call, so it is recorded here rather than closed silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Menus can declare gate risk using `TYPE: confirmation`, `decision`, or `blocking`.
  - Validation checks declaration placement, formatting, duplicates, invalid values, aliases, and common near-miss keywords.
  - Undeclared menus retain blocking behavior, while newly added menus must declare a risk type.
  - Validation now reports compactness limits and declared gate-risk issues.

- **Documentation**
  - Updated PDSL guidance covering gate-risk declarations, valid values, declaration scope, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->