### PR TITLE
fix(ci): make ci fail loudly when act job discovery yields no jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,8 +372,18 @@ lint-ci:
 # event context that act cannot reconstruct for a linked worktree.
 # Runs jobs sequentially — stops on first failure.
 # Auto-detects arm64/amd64. Override: make ci ACT_FLAGS="--your-flags"
+# Job discovery failing outright, changing format, or an over-broad exclusion
+# emptying the list must never look like "nothing to do, success" -- an empty
+# job set fails loudly instead of letting a zero-iteration loop exit 0.
 ci: lint-ci
-	@for job in $$(act push --list $(ACT_FLAGS) 2>/dev/null | tail -n +2 | awk '{print $$2}' | grep -Ev '^(sonarqube|code-ranker)$$'); do \
+	@jobs="$$(act push --list $(ACT_FLAGS) 2>/dev/null | tail -n +2 | awk '{print $$2}' | grep -Ev '^(sonarqube|code-ranker)$$')"; \
+	if [ -z "$$jobs" ]; then \
+		echo "ERROR: 'act push --list' discovered no CI jobs to run -- refusing to report" >&2; \
+		echo "       success for a no-op. Check that act is installed/working and that" >&2; \
+		echo "       .github/workflows/*.yml still parses the way this Makefile expects." >&2; \
+		exit 1; \
+	fi; \
+	for job in $$jobs; do \
 		echo "▶ Running job: $$job"; \
 		act push -j $$job $(ACT_FLAGS) || exit 1; \
 	done


### PR DESCRIPTION
## Summary
- Fixes a gap surfaced by an `ainetx` review comment misfiled onto PR #136 (it's about `Makefile`, not that PR's diff — see constructorfabric/studio#136).
- `make ci`'s job-discovery loop silently reported success if `act push --list` failed, changed format, or the exclusion filter removed every discovered job — the `for` loop just ran zero times.
- Now captures the job list into a variable first and fails explicitly (exit 1, clear stderr message) if it's empty, before the loop runs.

## Test plan
- Verified both paths by stubbing `act` on PATH: empty `--list` now exits 1 with the new error (previously exited 0 silently); a normal list still runs each job and excludes `sonarqube`/`code-ranker` as before.
- `make -n ci` confirms the Makefile still parses/expands correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Continuous integration now reports an error and fails when no eligible jobs are discovered, instead of incorrectly completing successfully.
  * Existing job exclusions, sequential execution, and fail-fast behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->