### PR TITLE
change-summary: stop translating newlines inside a path, so both readers name one file alike

### DIFF
--- a/skills/studio/scripts/studio/utils/change_summary.py
+++ b/skills/studio/scripts/studio/utils/change_summary.py
@@ -893,15 +893,21 @@ def _git_records(project_root: Path, args: List[str]) -> Optional[List[str]]:
             cwd=str(project_root),
             env=_git_env(),
             capture_output=True,
-            text=True,
-            # Filesystem paths are bytes on POSIX and are not guaranteed to be UTF-8,
-            # so `text=True`'s strict default raises UnicodeDecodeError on a legal but
-            # undecodable filename -- escaping past the handler below and breaking the
-            # never-raises contract. The filesystem codec is what Python itself uses for
-            # paths, so the value round-trips to the same bytes when reopened, and the
-            # streamed sweep decodes with the same one, so both name one file alike.
-            encoding=_PATH_ENCODING,
-            errors=_PATH_ERRORS,
+            # Bytes, decoded per record below rather than by `text=True`.
+            #
+            # Sharing the codec with the streamed sweep was not enough to make the two
+            # readers name one file alike: `text=True` also turns on *universal
+            # newlines*, and `subprocess` exposes no way to switch that off. So a path
+            # containing CR came back translated -- measured, `sweep\rname.txt` decoded
+            # here as `sweep\nname.txt` -- while the sweep, decoding raw slices, kept
+            # the CR. Two consequences, and the second is the worse one: deduplication
+            # against this listing missed the file, so it was reported twice; and the
+            # translated name opens nothing, so a *tracked* file present on disk was
+            # reported as "file no longer present".
+            #
+            # A path may contain any byte but NUL and `/`, CR included, and only NUL is
+            # the record separator -- so nothing in the output needs translating and
+            # anything translated is corruption.
             timeout=_GIT_TIMEOUT,
             check=False,
         )
@@ -915,10 +921,12 @@ def _git_records(project_root: Path, args: List[str]) -> Optional[List[str]]:
         return None
     # A trailing NUL leaves one empty tail record; drop it without dropping
     # legitimately empty interior records, which would desynchronise the walk.
-    records = result.stdout.split("\0")
-    if records and not records[-1]:
-        records.pop()
-    return records
+    raw = result.stdout.split(b"\0")
+    if raw and not raw[-1]:
+        raw.pop()
+    # The same decode call the pump makes, on the same slices, so one path is one
+    # string whichever reader saw it.
+    return [record.decode(_PATH_ENCODING, _PATH_ERRORS) for record in raw]
 # @cpt-end:cpt-studio-algo-developer-experience-change-summary:p1:inst-change-summary-git-lines
 
 

--- a/tests/test_change_summary_core.py
+++ b/tests/test_change_summary_core.py
@@ -614,7 +614,10 @@ class TestPrivacy:
             """
             launches["run"] += 1
             issued.append(list(args))
-            return subprocess.CompletedProcess(args, 0, "", "")
+            # Mirrors what `subprocess` actually hands back for each call shape: the
+            # single-line reader asks for text, the record reader for bytes and decodes
+            # the slices itself. Returning a str to both fed `.split(b"\0")` a str.
+            return subprocess.CompletedProcess(args, 0, "" if _kwargs.get("text") else b"", b"")
 
         def _capture_popen(args, **_kwargs):
             """The streamed reader launches through `Popen`, which patching `run` does

--- a/tests/test_change_summary_links.py
+++ b/tests/test_change_summary_links.py
@@ -950,6 +950,8 @@ class TestTheCeilingIsSharedAndTheSweepIsStreamed:
         anything translated is corruption. Every newline shape is checked, because the
         translation rewrites lone CR, CRLF and neither in three different ways.
         """
+        if os.name == "nt":
+            pytest.skip("CR and LF are not legal file-name characters on Windows")
         repo = _repo_with_base(tmp_path)
         with open(os.path.join(os.fsencode(repo), raw), "wb") as handle:
             handle.write(b"x = 1\n")
@@ -971,6 +973,8 @@ class TestTheCeilingIsSharedAndTheSweepIsStreamed:
         reported as "file no longer present", which is a false statement about a
         present file rather than a merely incomplete one.
         """
+        if os.name == "nt":
+            pytest.skip("a carriage return is not a legal file-name character on Windows")
         repo = _repo_with_base(tmp_path)
         with open(os.path.join(os.fsencode(repo), b"tracked\rname.py"), "wb") as handle:
             handle.write(_code().encode("utf-8"))
@@ -989,6 +993,8 @@ class TestTheCeilingIsSharedAndTheSweepIsStreamed:
         the index and untracked on disk, so it appears in both listings — and with the
         two readers naming it differently the sweep's dedup missed it, so one file was
         two rows and every counter was inflated."""
+        if os.name == "nt":
+            pytest.skip("a carriage return is not a legal file-name character on Windows")
         repo = _make_repo(tmp_path / "r")
         with open(os.path.join(os.fsencode(repo), b"both\rname.py"), "wb") as handle:
             handle.write(b"x = 1\n")

--- a/tests/test_change_summary_links.py
+++ b/tests/test_change_summary_links.py
@@ -654,10 +654,18 @@ class TestTheListingIsAboutTheProjectNamedAndNothingElse:
 
         assert launches >= 3
         assert source.count("env=_git_env()") == launches, "every launch, not most of them"
-        # And every captured launch decodes with the codec the streamed reader uses, so
-        # the two readers of one path cannot disagree about its name.
-        assert source.count("encoding=_PATH_ENCODING,") == source.count("subprocess.run(")
-        assert "raw.decode(_PATH_ENCODING, _PATH_ERRORS)" in source
+        # And no reader of a *path* may use `text=True`, which switches on universal
+        # newlines as well as decoding and so translated CR inside a filename. Only
+        # `_git_query` may, because it reads refs, shas and timestamps -- values git
+        # itself forbids a control character in. Both record readers instead decode raw
+        # slices with the one shared call, which is what makes one path one string.
+        # Counted with the trailing comma, which is the keyword-argument form: the
+        # comments here discuss `text=True` several times, and a bare substring count
+        # measured the prose as well as the code.
+        assert source.count("text=True,") == 1, "only the single-line reader may translate"
+        assert source.count(".decode(_PATH_ENCODING, _PATH_ERRORS)") == 2, (
+            "the captured record reader and the streamed one, each decoding for itself"
+        )
 
     def test_a_failed_untracked_sweep_makes_the_listing_unavailable(self, tmp_path, monkeypatch):
         """`or []` turned a failed `ls-files` into an empty one, so the report came back
@@ -929,6 +937,75 @@ class TestTheCeilingIsSharedAndTheSweepIsStreamed:
 
         assert captured == streamed == ["café.py"]
         assert total == 1
+
+    @pytest.mark.parametrize("raw", [b"cr\rname.py", b"crlf\r\nname.py", b"lf\nname.py"],
+                             ids=["cr", "crlf", "lf"])
+    def test_both_readers_keep_the_bytes_git_gave_them(self, tmp_path, raw):
+        """The codec was shared, but `text=True` also switches on *universal newlines*,
+        and `subprocess` offers no way to turn that off.
+
+        So the captured reader translated a CR in a path to LF while the streamed one,
+        decoding raw slices, kept it. A path may hold any byte but NUL and `/`, and only
+        NUL separates records here — nothing in this output needs translating, so
+        anything translated is corruption. Every newline shape is checked, because the
+        translation rewrites lone CR, CRLF and neither in three different ways.
+        """
+        repo = _repo_with_base(tmp_path)
+        with open(os.path.join(os.fsencode(repo), raw), "wb") as handle:
+            handle.write(b"x = 1\n")
+        expected = raw.decode(cs._PATH_ENCODING, cs._PATH_ERRORS)
+        args = ["ls-files", "--others", "--exclude-standard", "-z"]
+
+        captured = cs._git_records(repo, args)
+        streamed, total = cs._git_records_bounded(repo, args, 5)
+
+        assert captured == [expected], "the captured reader must not translate"
+        assert streamed == [expected]
+        assert total == 1
+
+    def test_a_tracked_path_holding_a_cr_is_not_reported_as_deleted(self, tmp_path):
+        """The consequence that mattered more than the missed dedup.
+
+        A translated name opens nothing, so `_link_changed_entry` found no file where
+        git had just said one changed — and a *tracked* file sitting on disk was
+        reported as "file no longer present", which is a false statement about a
+        present file rather than a merely incomplete one.
+        """
+        repo = _repo_with_base(tmp_path)
+        with open(os.path.join(os.fsencode(repo), b"tracked\rname.py"), "wb") as handle:
+            handle.write(_code().encode("utf-8"))
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "cr")
+
+        report = _report(repo)
+
+        assert report.available is True, report.reason
+        assert report.deleted == 0, "the file is present"
+        assert [(f.path, f.reason) for f in report.files] == [("tracked\rname.py", cs.REASON_OK)]
+        assert [f.references for f in report.files] == [(MARKER,)], "and it was read"
+
+    def test_a_cr_path_in_both_listings_is_deduplicated(self, tmp_path):
+        """The reported failure, end to end. `git rm --cached` leaves one file deleted in
+        the index and untracked on disk, so it appears in both listings — and with the
+        two readers naming it differently the sweep's dedup missed it, so one file was
+        two rows and every counter was inflated."""
+        repo = _make_repo(tmp_path / "r")
+        with open(os.path.join(os.fsencode(repo), b"both\rname.py"), "wb") as handle:
+            handle.write(b"x = 1\n")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-q", "-m", "cr")
+        # The base must *contain* the file, or `git diff` never reports it and only the
+        # sweep sees it — which is one row whether or not the readers agree, and the
+        # first version of this test passed the very mutation it was written to catch.
+        _point_ref(repo, "refs/remotes/upstream/main", _git(repo, "rev-parse", "HEAD"))
+        _commit(repo, "later.txt")
+        _git(repo, "rm", "-q", "--cached", "both\rname.py")
+
+        report = _report(repo)
+
+        rows = [f.path for f in report.files]
+        assert rows.count("both\rname.py") == 1, f"one file, one row: {rows}"
+        assert "both\nname.py" not in rows, "and not a second row under a translated name"
 
     def test_a_stream_that_fails_part_way_is_a_tool_failure_not_a_shorter_listing(
         self, tmp_path, monkeypatch, caplog,

--- a/tests/test_change_summary_links.py
+++ b/tests/test_change_summary_links.py
@@ -1307,6 +1307,84 @@ class TestTheCeilingIsSharedAndTheSweepIsStreamed:
         assert cs._git_records_bounded(tmp_path, ["ls-files", "-z"], 5) == (["a.py", "b.py"], 2)
         assert cs._git_records_bounded(tmp_path, ["ls-files", "-z"], 1) == (["a.py"], 2)
 
+    def test_text_mode_translates_a_cr_which_is_why_these_readers_take_bytes(self):
+        """The mechanism behind the fix, pinned without a CR file name or git.
+
+        The three tests above need a real path containing CR, which Windows rejects, so
+        they skip there and this regression class had no platform-independent cover.
+        A mock cannot supply it: patching `subprocess.run` replaces the very code that
+        does the translating, so a faked `stdout` proves nothing about text mode. What
+        *is* portable is the translation itself — so this drives a real subprocess whose
+        output holds a CR, reads it both ways, and shows they disagree.
+
+        Any Python interpreter will do, so it runs everywhere the suite does.
+        """
+        emit = [sys.executable, "-c",
+                r"import sys; sys.stdout.buffer.write(b'cr\rname.py\x00')"]
+
+        as_text = subprocess.run(
+            emit, capture_output=True, text=True,
+            encoding=cs._PATH_ENCODING, errors=cs._PATH_ERRORS, check=True,
+        ).stdout
+        as_bytes = subprocess.run(emit, capture_output=True, check=True).stdout
+
+        assert as_bytes.split(b"\0")[0] == b"cr\rname.py", "the bytes git actually wrote"
+        assert as_text.split("\0")[0] == "cr\nname.py", (
+            "text mode rewrites the CR -- this is the corruption the fix avoids"
+        )
+        assert as_text.split("\0")[0] != as_bytes.split(b"\0")[0].decode(
+            cs._PATH_ENCODING, cs._PATH_ERRORS,
+        ), "so the two readers could not have agreed while one used text mode"
+
+    def test_both_readers_agree_on_a_cr_record_without_touching_the_filesystem(
+        self, tmp_path, monkeypatch,
+    ):
+        """The paired decode, portable: identical bytes in, identical strings out.
+
+        The fake for `run` honours the `text`/`encoding` keywords the way `subprocess`
+        itself does — decode, then translate newlines — rather than ignoring them. That
+        is what makes this catch a reader switching back to text mode *on the value*
+        instead of on a type error: with `text=True` restored it returns the translated
+        string, exactly as the real thing would, and the comparison below fails on the
+        corrupted path. The test above proves the fake's translation is faithful.
+        """
+        record = b"cr\rname.py\0crlf\r\nname.py\0"
+        expected = ["cr\rname.py", "crlf\r\nname.py"]
+
+        def _fake_run(*_a, **kwargs):
+            if not (kwargs.get("text") or kwargs.get("encoding")):
+                return subprocess.CompletedProcess([], 0, record, b"")
+            decoded = record.decode(kwargs.get("encoding") or "utf-8",
+                                    kwargs.get("errors") or "strict")
+            translated = decoded.replace("\r\n", "\n").replace("\r", "\n")
+            return subprocess.CompletedProcess([], 0, translated, "")
+
+        class _Emitting:
+            def __init__(self, *_a, **_k):
+                self.stdout = io.BytesIO(record)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_exc):
+                return False
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(cs.subprocess, "run", _fake_run)
+        monkeypatch.setattr(cs.subprocess, "Popen", _Emitting)
+
+        captured = cs._git_records(tmp_path, ["ls-files", "-z"])
+        streamed, total = cs._git_records_bounded(tmp_path, ["ls-files", "-z"], 5)
+
+        assert captured == expected, "the captured reader keeps both newline shapes"
+        assert streamed == expected
+        assert total == 2
+
     def test_a_launch_failure_is_a_warning_and_a_miss_is_not(self, tmp_path, monkeypatch, caplog):
         """The tool failing and git answering "no" must not look alike in a log."""
         repo = _make_repo(tmp_path / "r")


### PR DESCRIPTION
Follows #154. A path containing a carriage return was reported under a name that opens nothing, and a tracked file present on disk came back as deleted.

## The defect

#154 gave both readers of the changed-file listing the same codec, so they would agree about a path's name under any locale. That was not sufficient. `text=True` switches on **universal newlines** as well as decoding, and `subprocess` exposes no way to turn it off — so the captured reader translated CR *inside a filename* while the streamed sweep, decoding raw slices, kept it.

Measured, on a repository holding `sweep\rname.txt`:

```
text=True path : 'sweep\nname.txt'
raw-bytes path : 'sweep\rname.txt'
EQUAL? False
```

## Two consequences, the second worse than the first

**Deduplication misses the file.** The sweep is deduplicated against the diff by string comparison, so a path appearing in both listings — `git rm --cached` on a file present in the base commit leaves it deleted in the index and untracked on disk — became two contradictory rows for one file, inflating every counter.

**A present file is reported as deleted.** This is the one that matters. The translated name opens nothing, so the entry resolver found no file where git had just said one changed:

```
rows: [('tracked\nname.txt', 'A', 'file no longer present')]
deleted: 1
```

That is a false statement about a file sitting right there, not a merely incomplete listing — the failure class this module exists to prevent, arriving through the decode rather than through the counting. After the fix:

```
rows: [('tracked\rname.txt', 'A', '')]
deleted: 0
```

## The fix

The captured reader takes bytes and decodes each record with the same call the pump makes:

```python
raw = result.stdout.split(b"\0")
if raw and not raw[-1]:
    raw.pop()
return [record.decode(_PATH_ENCODING, _PATH_ERRORS) for record in raw]
```

Nothing in `-z` output needs translating: only NUL separates records, and a path may contain any byte but NUL and `/`. So anything translated is corruption.

`_git_query` keeps `text=True` deliberately — it reads refs, shas and timestamps, values git itself forbids a control character in, and it never carries a path.

## Tests

| test | what it pins |
|---|---|
| `test_both_readers_keep_the_bytes_git_gave_them` | parametrized `cr` / `crlf` / `lf` — the translation rewrites each differently, so all three are checked; `lf` is the control |
| `test_a_tracked_path_holding_a_cr_is_not_reported_as_deleted` | the worse consequence: the row resolves, is read, and `deleted == 0` |
| `test_a_cr_path_in_both_listings_is_deduplicated` | the reported consequence, end to end through `git rm --cached` |
| `test_every_git_call_site_runs_with_the_sanitised_environment` | strengthened: one `text=True` in the module, one shared decode call per record reader |

Reverting the fix fails four of the five; `lf` passes, as it should.

**One thing worth flagging about my own test.** The first version of the deduplication test passed the very mutation it was written to catch — the file was committed *after* the base ref, so `git diff` never reported it and only the sweep saw it, which is one row whether or not the readers agree. The base now contains the file. The structural check needed a second correction too: it counted `text=True` as a substring, and the comments here discuss it several times, so it was measuring the prose. It counts the keyword-argument form now.

## Gates

Pinned to `bb364ada`, on `main` @ `ac9e06e9`.

| Gate | Result |
|---|---|
| `make test` | **5,570 passed**, 4 skipped, 15 xfailed |
| `cfs validate` | 0 errors |
| `spec-coverage --system studio` | **0.4603** against the 0.46 floor, unchanged — the fix adds no lines to the module's traced blocks |
| `make pylint` / `make vulture-ci` | 10.00 / clean |

No behaviour changes for a path without a CR, which is why the granularity and the rest of the suite are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file paths containing carriage returns, CRLF sequences, newlines, or non-UTF-8 bytes.
  * Prevented valid tracked files from being incorrectly reported as deleted.
  * Maintained consistent results across captured and streamed Git output.
  * Continued removing duplicate file listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Round 1

CR and LF are both in the 1--31 range Windows forbids in a file name, so all three parametrized cases would have failed there rather than skipped -- `lf` included, which I had picked as the control without thinking that through. Guarded in `b2246a39` with the convention this file already uses twice, for a tab and for POSIX permission bits. CI is ubuntu-only so nothing was red, but these are precisely the tests a contributor on Windows would want to run, and they would have raised `OSError` from `open()` rather than skipping with a reason.

## Round 2

The three filesystem tests skip on Windows, so this regression class had no cover there. Two portable tests close it, and the mocking suggestion needed a correction to work at all: patching `subprocess.run` replaces the code that does the translating, so a fake `stdout` proves nothing about text mode -- my first attempt failed the mutation only because the text branch then split bytes with a str separator, which is a real failure for the wrong reason.

So the job is split. One test drives a real subprocess whose output holds a CR -- any Python interpreter, no git and no odd file name -- and reads it both ways, pinning the translation itself. The other runs both readers over identical faked output, with the fake honouring the `text`/`encoding` keywords the way `subprocess` does, so restoring `text=True` fails it on the corrupted value (`'cr\nname.py' != 'cr\rname.py'`) rather than on a type error. The first licenses the second, by proving the real translation is exactly what the fake performs.
