### PR TITLE
cf-ux: let the cf skill execute under claude -p, and refuse to score a run where it did not

### DIFF
--- a/tests/prompts/cf-ux/README.md
+++ b/tests/prompts/cf-ux/README.md
@@ -28,7 +28,7 @@ the `llm-rubric` asserts; sub-100ms text guards catch skill-load failures.
 | Env | Effect |
 |---|---|
 | `REQUEST_TIMEOUT_MS=900000` | promptfoo python-worker timeout (default 300s is too short for sandbox init + cold codex). |
-| `CF_UX_SHARED_SANDBOX=/path` | Reuse a pre-initialized sandbox; skip setup/teardown. |
+| `CF_UX_SHARED_SANDBOX=/path` | Reuse a pre-initialized sandbox; skip setup/teardown. **Point this only at a throwaway directory** — the Claude provider runs with `--permission-mode bypassPermissions`, which is safe against the per-run temp sandbox it normally builds, but writes wherever this says. |
 | `CF_UX_KEEP_SANDBOX=1` | Keep the sandbox after the run; print its path. |
 
 ## Layout
@@ -38,11 +38,37 @@ tests/prompts/cf-ux/
 ├── promptfooconfig.yaml
 ├── providers/
 │   ├── _sandbox.py          — tmpdir + local cfs init context manager
-│   ├── claude_provider.py   — claude -p, JSON output, returns metadata
+│   ├── claude_provider.py   — claude -p, bypassPermissions, stream-json
 │   ├── codex_provider.py    — codex exec, approval=never, workspace-write
 │   └── grader_claude.py     — claude -p --disable-slash-commands (judge)
 └── README.md
 ```
+
+## A run that did not load the skill is an error, not a score
+
+The Claude provider decides from the tool-call trace whether the `cf` skill
+actually executed, and returns a promptfoo **error** when it did not — before
+the rubric ever sees the text.
+
+This matters because the failure is silent and looks like success. Skill
+*execution* asks for permission and `-p` has nobody to ask, so without
+`--permission-mode bypassPermissions` the skill is denied, the agent answers the
+request directly, and the answer is plausible enough for the rubric to pass it.
+The suite then reports confidently on an agent that never loaded Studio. Any
+measurement built on that — question counts, gate behaviour, UX assertions —
+describes the fallback path.
+
+So the check is positive rather than a substring search over the answer: a
+`Skill` tool-use event naming `cf`, whose result is not an error. The metadata
+carries `skill_state` (`ran` / `failed` / `absent`) and `skills_invoked`, and an
+unscored answer is kept under `unscored_output` for diagnosis rather than
+graded. A transcript with no terminal `result` event is an error too — there is
+then no answer to grade and no trace to trust.
+
+Expect errors, not just failures, if the CLI's invocation contract changes
+again. That is the intended behaviour: an error says the suite could not
+measure, which is different from Studio behaving badly, and the two were
+previously indistinguishable.
 
 ## Current baseline (pilot)
 
@@ -88,10 +114,10 @@ and drive the next skill-hardening iteration.
 
 ## Next steps
 
-- Parse `claude -p --output-format stream-json` to capture tool-call
-  traces and assert directly on `Skill` invocations / sub-agent
-  dispatches (would replace several llm-rubric blocks with deterministic
-  checks).
+- Assert directly on sub-agent dispatches from the tool-call trace, the way
+  the `Skill` invocation now is (would replace several llm-rubric blocks
+  with deterministic checks). The stream-json parsing this needs is already
+  in `claude_provider.py`; what is missing is the per-scenario assertions.
 - Cover write-paths end-to-end (`cf-generate` actually creating an ADR
   after inputs are collected) with `--sandbox workspace-write` + per-
   test fresh sandbox.

--- a/tests/prompts/cf-ux/README.md
+++ b/tests/prompts/cf-ux/README.md
@@ -83,8 +83,12 @@ or no trace to trust:
 Metadata: `skill_state` (`ran` / `failed` / `absent`), `skills_invoked` (the
 names), `skill_call_inputs` (those inputs verbatim, for when a name did not
 resolve), `unparsed_lines`, and `unscored_output` — the answer that was withheld
-from the grader, kept for diagnosis. Every return, answer or error, carries
-`duration_s` and `sandbox`.
+from the grader, kept for diagnosis. Every return *that reached the CLI*, answer
+or error, carries `duration_s` and `sandbox`; a failure before the sandbox
+exists — setup error, setup timeout — has no sandbox path to name. The
+missing-`result` case adds `events_seen` and `last_event_type`, which is what
+tells a budget ceiling apart from a format regression without reading the tail
+by hand.
 
 Expect errors, not just failures, if the CLI's invocation contract changes
 again. That is the intended behaviour: an error says the suite could not

--- a/tests/prompts/cf-ux/README.md
+++ b/tests/prompts/cf-ux/README.md
@@ -58,12 +58,33 @@ The suite then reports confidently on an agent that never loaded Studio. Any
 measurement built on that — question counts, gate behaviour, UX assertions —
 describes the fallback path.
 
-So the check is positive rather than a substring search over the answer: a
-`Skill` tool-use event naming `cf`, whose result is not an error. The metadata
-carries `skill_state` (`ran` / `failed` / `absent`) and `skills_invoked`, and an
-unscored answer is kept under `unscored_output` for diagnosis rather than
-graded. A transcript with no terminal `result` event is an error too — there is
-then no answer to grade and no trace to trust.
+So the check is positive rather than a substring search over the answer: one
+`Skill` tool-use event whose input names `cf`, and a non-error `tool_result`
+bound to *that* call's id. Each half of that matters.
+
+- The name is compared **whole**, after dropping any `plugin:` namespace. The
+  prompt is `/cf <request>`, so the argument text carries "cf" on every
+  scenario here — under substring containment a competing skill that quoted the
+  user message back counted as this one running.
+- The result must belong to the cf call. "Some `Skill` call succeeded" and
+  "some call named cf" can both hold while the cf call is the one that errored.
+- No result at all is not a non-error result. A trace cut off after the call is
+  refused, not read as a success.
+
+Three more shapes are errors for the same reason — there is no answer to grade,
+or no trace to trust:
+
+| Shape | Why it cannot be scored |
+|---|---|
+| No terminal `result` event | Nothing to grade, and the transcript is incomplete. Names both causes: the `--max-budget-usd` ceiling reached mid-turn ends the stream exactly as an unhonoured `--output-format` does. |
+| `result` with a non-success `subtype` | The turn stopped short (`error_max_turns`, `error_during_execution`), so `result` holds a fragment, not an answer — even when the skill did load. An *absent* subtype is not treated this way: an unfamiliar shape should not manufacture failures. |
+| A line that will not parse | Counted in `unparsed_lines` rather than dropped silently, because a lost line can be a lost `tool_result` and the verdict above is read off exactly those. |
+
+Metadata: `skill_state` (`ran` / `failed` / `absent`), `skills_invoked` (the
+names), `skill_call_inputs` (those inputs verbatim, for when a name did not
+resolve), `unparsed_lines`, and `unscored_output` — the answer that was withheld
+from the grader, kept for diagnosis. Every return, answer or error, carries
+`duration_s` and `sandbox`.
 
 Expect errors, not just failures, if the CLI's invocation contract changes
 again. That is the intended behaviour: an error says the suite could not

--- a/tests/prompts/cf-ux/providers/claude_provider.py
+++ b/tests/prompts/cf-ux/providers/claude_provider.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from _sandbox import SandboxError, sandbox
 
@@ -38,26 +39,48 @@ DEFAULT_EFFORT = os.environ.get("CF_UX_CLAUDE_EFFORT", "low")
 # there the agent writes where it is told to.
 PERMISSION_MODE = "bypassPermissions"
 
+#: Cost ceiling for one scenario. Named because the error text for a transcript
+#: that stops early has to be able to point at it as a cause.
+MAX_BUDGET_USD = "0.30"
+
 #: The tool Claude Code reports when it executes a skill.
 _SKILL_TOOL = "Skill"
-#: The skill this suite exists to measure. Matched loosely against the tool
-#: input, since only `cf-*` skills are installed in the sandbox and the input's
-#: key for the skill name is not part of any stable contract.
+#: The skill this suite exists to measure, compared whole against each string in
+#: the tool input. Substring containment will not do: the prompt is `/cf …`, so
+#: the input's *argument* text carries "cf" on every scenario in this suite, and
+#: a competing skill (`superpowers:brainstorming`) quoting the user message back
+#: would have counted as this one running.
 _SKILL_NAME = "cf"
+#: Skill identifiers may be namespaced (`plugin:skill`); the trailing segment is
+#: the name. Splitting on these and not on `-` is what keeps a hypothetical
+#: `cf-generate` distinct from `cf`.
+_NAME_SEPARATORS = (":", "/")
+#: What a skill identifier can look like. Used to tell the name in a tool input
+#: from the request text sitting beside it, so `skills_invoked` reports names
+#: and not prose.
+_NAME_SHAPE = re.compile(r"[A-Za-z0-9_.:/-]{1,64}")
 #: What a *failed* execution looks like in the transcript: `<error>Execute
 #: skill: cf</error>`. The previous guard searched for "skills failed to load",
 #: which the CLI never emits, so it could not fire.
 _SKILL_ERROR_MARK = "Execute skill:"
+#: The terminal event's subtype when the turn ran to completion. Anything else
+#: (`error_max_turns`, `error_during_execution`) leaves `result` holding a
+#: fragment rather than an answer.
+_RESULT_OK = "success"
 
 
-def _stream_events(raw: str) -> list[dict[str, Any]]:
+def _stream_events(raw: str) -> tuple[list[dict[str, Any]], int]:
     """Parse `--output-format stream-json`: one JSON object per line.
 
-    A line that will not parse is skipped rather than fatal — the stream is a
-    transcript, and one malformed entry says nothing about the rest. Whether the
-    run is usable at all is decided by :func:`_result_event`, which fails closed.
+    Returns the events and *how many lines would not parse*. A malformed line is
+    skipped rather than fatal — the stream is a transcript, and one bad entry
+    says nothing about the rest — but it is counted and reported, because a
+    dropped line can be a dropped `tool_result`, and this module decides what a
+    run means from exactly those. Silently discarding one would let the count of
+    evidence shrink without the verdict admitting it.
     """
     events: list[dict[str, Any]] = []
+    unparsed = 0
     for line in raw.splitlines():
         line = line.strip()
         if not line:
@@ -65,14 +88,20 @@ def _stream_events(raw: str) -> list[dict[str, Any]]:
         try:
             event = json.loads(line)
         except json.JSONDecodeError:
+            unparsed += 1
             continue
         if isinstance(event, dict):
             events.append(event)
-    return events
+    return events, unparsed
 
 
 def _result_event(events: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """The terminal `result` event, which carries the answer and the totals."""
+    """The terminal `result` event, which carries the answer and the totals.
+
+    Last one wins: the stream is ordered and the terminal event is the final
+    one, so a transcript carrying two (a resumed or restarted turn) is read as
+    ending in its last.
+    """
     for event in reversed(events):
         if event.get("type") == "result":
             return event
@@ -87,34 +116,94 @@ def _content_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:
     return [block for block in content if isinstance(block, dict)]
 
 
-def _skill_state(events: list[dict[str, Any]], raw: str) -> tuple[str, list[str], str]:
-    """Did the `cf` skill actually run? Returns ``(state, names, detail)``.
+def _invoked_names(payload: Any) -> list[str]:
+    """The skill identifiers a `Skill` tool input names.
 
-    ``state`` is ``"ran"``, ``"failed"`` or ``"absent"``. This is a *positive*
-    check against tool-use events in the transcript, not a substring search over
-    the prose: the fallback answer is well-formed and says nothing about whether
-    the skill was reached, which is exactly why the old heuristic scored it.
+    Which key holds the name is not part of any stable contract, so every string
+    value shaped like an identifier is a candidate — but each is compared
+    *whole*, after dropping any `plugin:` namespace. That is what separates the
+    skill's name from the argument text, which in this suite always quotes a
+    `/cf …` prompt.
+    """
+    if not isinstance(payload, dict):
+        return []
+    names = []
+    for value in payload.values():
+        if not isinstance(value, str) or not _NAME_SHAPE.fullmatch(value.strip()):
+            continue
+        name = value.strip()
+        for separator in _NAME_SEPARATORS:
+            name = name.rsplit(separator, 1)[-1]
+        if name:
+            names.append(name)
+    return names
+
+
+class _SkillTrace(NamedTuple):
+    """What the transcript says about the skill this suite measures."""
+
+    state: str          # "ran" | "failed" | "absent"
+    names: list[str]    # skill identifiers the transcript names
+    inputs: list[str]   # the tool inputs verbatim, serialized, for diagnosis
+    detail: str
+
+
+def _skill_trace(events: list[dict[str, Any]], raw: str) -> _SkillTrace:
+    """Did the `cf` skill actually run?
+
+    A *positive* check against tool-use events, not a substring search over the
+    prose: the fallback answer is well-formed and says nothing about whether the
+    skill was reached, which is exactly why the old heuristic scored it.
+
+    The evidence is bound per call. `ran` needs one `Skill` call that names `cf`
+    *and* a non-error result for that same call — not merely some call naming it
+    and some other call succeeding. A call with no observed result is not a
+    confirmed run either: a truncated or interrupted trace is the case this
+    whole module exists to refuse to score.
     """
     calls: dict[Any, Any] = {}
-    errored: set[Any] = set()
+    results: dict[Any, bool] = {}
     for event in events:
         for block in _content_blocks(event):
             kind = block.get("type")
             if kind == "tool_use" and block.get("name") == _SKILL_TOOL:
+                # Last wins on a repeated id. Either order is safe: the verdict
+                # below needs a success bound to the surviving cf call, and a
+                # collision can only take evidence away, never invent it.
                 calls[block.get("id")] = block.get("input") or {}
-            elif kind == "tool_result" and block.get("is_error"):
-                errored.add(block.get("tool_use_id"))
+            elif kind == "tool_result":
+                results[block.get("tool_use_id")] = bool(block.get("is_error"))
 
-    names = sorted({json.dumps(payload, default=str, sort_keys=True) for payload in calls.values()})
+    named = {call_id: _invoked_names(payload) for call_id, payload in calls.items()}
+    names = sorted({name for found in named.values() for name in found})
+    inputs = sorted({json.dumps(payload, default=str, sort_keys=True) for payload in calls.values()})
+
     if _SKILL_ERROR_MARK in raw:
-        return "failed", names, f"the transcript carries {_SKILL_ERROR_MARK!r}"
+        return _SkillTrace("failed", names, inputs, f"the transcript carries {_SKILL_ERROR_MARK!r}")
     if not calls:
-        return "absent", names, f"no {_SKILL_TOOL} tool call in the transcript"
-    if all(call_id in errored for call_id in calls):
-        return "failed", names, f"every {_SKILL_TOOL} call came back as an error"
-    if not any(_SKILL_NAME in payload for payload in names):
-        return "failed", names, f"a {_SKILL_TOOL} ran but none of them named {_SKILL_NAME!r}"
-    return "ran", names, ""
+        return _SkillTrace("absent", names, inputs, f"no {_SKILL_TOOL} tool call in the transcript")
+
+    targeted = [call_id for call_id, found in named.items() if _SKILL_NAME in found]
+    if not targeted:
+        return _SkillTrace(
+            "failed", names, inputs,
+            f"a {_SKILL_TOOL} ran but none of them named {_SKILL_NAME!r}",
+        )
+    if any(results.get(call_id) is False for call_id in targeted):
+        return _SkillTrace("ran", names, inputs, "")
+    if any(call_id not in results for call_id in targeted):
+        return _SkillTrace(
+            "failed", names, inputs,
+            f"the {_SKILL_NAME!r} call has no result in the transcript",
+        )
+    return _SkillTrace(
+        "failed", names, inputs, f"every {_SKILL_NAME!r} call came back as an error",
+    )
+
+
+def _baseline(cwd: Path, started: float) -> dict[str, Any]:
+    """What every return carries, answer or error: how long it took, and where."""
+    return {"duration_s": round(time.monotonic() - started, 2), "sandbox": str(cwd)}
 
 
 def call_api(prompt: str, options: dict | None = None, context: dict | None = None) -> dict:
@@ -124,8 +213,15 @@ def call_api(prompt: str, options: dict | None = None, context: dict | None = No
             return _invoke(prompt, cwd, started)
     except SandboxError as exc:
         return {"error": f"sandbox setup failed: {exc}"}
-    except subprocess.TimeoutExpired:
-        return {"error": f"claude timed out after {CALL_TIMEOUT_S}s"}
+    except subprocess.TimeoutExpired as exc:
+        # Not the `claude` call — `_invoke` handles its own timeout, where the
+        # sandbox path is still in scope. Reaching here means a setup command
+        # (`git`, the in-tree `cfs init`) hit its own deadline, and saying
+        # "claude timed out" would have sent triage to the wrong process.
+        return {
+            "error": f"sandbox setup timed out after {exc.timeout}s: {exc.cmd[0] if exc.cmd else '?'}",
+            "metadata": {"duration_s": round(time.monotonic() - started, 2)},
+        }
     except Exception as exc:  # noqa: BLE001 — surface unexpected errors to promptfoo
         return {"error": f"unexpected: {type(exc).__name__}: {exc}"}
 
@@ -144,44 +240,75 @@ def _invoke(prompt: str, cwd: Path, started: float) -> dict:
         # `-p` emit the intermediate events rather than the result alone.
         "--output-format", "stream-json",
         "--verbose",
-        "--max-budget-usd", "0.30",
+        "--max-budget-usd", MAX_BUDGET_USD,
         invoked,
     ]
-    proc = subprocess.run(
-        cmd, cwd=cwd, capture_output=True, text=True, timeout=CALL_TIMEOUT_S, check=False,
-        stdin=subprocess.DEVNULL,
-    )
-    duration = time.monotonic() - started
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=CALL_TIMEOUT_S, check=False,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        # Handled here rather than in `call_api` so it carries the same baseline
+        # as every other error: an operator triaging a wave of them can tell a
+        # run that burned 850s from one that failed at once, and can say where.
+        return {
+            "error": f"claude timed out after {CALL_TIMEOUT_S}s",
+            "metadata": _baseline(cwd, started),
+        }
+    base = _baseline(cwd, started)
 
     if proc.returncode != 0:
         return {
             "error": f"claude exited {proc.returncode}: {proc.stderr.strip()[:500]}",
-            "metadata": {"duration_s": round(duration, 2)},
+            "metadata": base,
         }
 
-    events = _stream_events(proc.stdout)
+    events, unparsed = _stream_events(proc.stdout)
     payload = _result_event(events)
-    base = {"duration_s": round(duration, 2), "sandbox": str(cwd)}
+    base["unparsed_lines"] = unparsed
     if payload is None:
         # Fail closed. Without the terminal event there is no answer to grade and
         # no transcript to trust, so returning the raw text would hand the rubric
         # something to score with no idea what produced it.
+        #
+        # Both causes are named because they look identical here and lead to
+        # opposite fixes: a budget ceiling reached mid-turn ends the stream just
+        # as an unhonoured `--output-format` does, and only one of them is a bug.
         return {
-            "error": "claude emitted no result event; stream-json may not have been honoured",
+            "error": (
+                "claude emitted no result event: the turn may have stopped at the "
+                f"--max-budget-usd {MAX_BUDGET_USD} ceiling, or stream-json was not honoured"
+            ),
             "metadata": {**base, "stdout_tail": proc.stdout.strip()[-500:]},
         }
 
     output_text = payload.get("result") or ""
-    state, skills, detail = _skill_state(events, proc.stdout)
+    trace = _skill_trace(events, proc.stdout)
+    state, detail = trace.state, trace.detail
     metadata = {
         **base,
         "session_id": payload.get("session_id"),
         "num_turns": payload.get("num_turns"),
         "total_cost_usd": payload.get("total_cost_usd"),
         "skill_state": state,
-        "skills_invoked": skills,
+        "skills_invoked": trace.names,
+        "skill_call_inputs": trace.inputs,
     }
     cost = payload.get("total_cost_usd")
+
+    # A turn that stopped short is not an answer, even when the skill did load:
+    # `result` then holds whatever had been written when the limit hit, and
+    # grading a fragment reports on Studio for a run that never finished. Only a
+    # subtype that is *present and not success* counts as that — an unfamiliar
+    # shape should not be able to manufacture failures.
+    subtype = payload.get("subtype")
+    if payload.get("is_error") or (subtype is not None and subtype != _RESULT_OK):
+        return {
+            "error": f"claude did not finish the turn (result subtype {subtype!r})",
+            "metadata": {**metadata, "unscored_output": output_text[:500]},
+        }
+
     if state != "ran":
         # A hard error, not a metadata flag. The fallback answer is plausible and
         # well-formed, so left to the grader it scores as a pass and the suite

--- a/tests/prompts/cf-ux/providers/claude_provider.py
+++ b/tests/prompts/cf-ux/providers/claude_provider.py
@@ -24,16 +24,97 @@ CALL_TIMEOUT_S = 850  # under promptfoo worker timeout (900s)
 DEFAULT_MODEL = os.environ.get("CF_UX_CLAUDE_MODEL", "claude-haiku-4-5")
 DEFAULT_EFFORT = os.environ.get("CF_UX_CLAUDE_EFFORT", "low")
 
+# Skill *execution* asks for permission, and `-p` has nobody to ask, so the
+# request is denied, the `cf` skill never runs, and the agent answers directly
+# instead — returning something plausible that the shared rubric then scores as
+# though Studio had behaved well. The codex provider has always passed the
+# equivalent pair (`--sandbox workspace-write`, `approval_policy="never"`); this
+# is the same decision for this CLI, and the asymmetry was the bug.
+#
+# Scoped to a throwaway tree: `_sandbox.sandbox()` builds a fresh directory
+# under the system temp dir and wipes it in `finally`, on `atexit`, and on
+# SIGTERM/SIGINT/SIGHUP. The one exception is `CF_UX_SHARED_SANDBOX`, which
+# points a run at a directory the caller chose — noted in the README, because
+# there the agent writes where it is told to.
+PERMISSION_MODE = "bypassPermissions"
 
-def _parse_json_output(raw: str) -> dict[str, Any]:
-    """`claude -p --output-format json` returns one JSON object on stdout."""
-    raw = raw.strip()
-    if not raw:
-        return {}
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        return {"_raw": raw}
+#: The tool Claude Code reports when it executes a skill.
+_SKILL_TOOL = "Skill"
+#: The skill this suite exists to measure. Matched loosely against the tool
+#: input, since only `cf-*` skills are installed in the sandbox and the input's
+#: key for the skill name is not part of any stable contract.
+_SKILL_NAME = "cf"
+#: What a *failed* execution looks like in the transcript: `<error>Execute
+#: skill: cf</error>`. The previous guard searched for "skills failed to load",
+#: which the CLI never emits, so it could not fire.
+_SKILL_ERROR_MARK = "Execute skill:"
+
+
+def _stream_events(raw: str) -> list[dict[str, Any]]:
+    """Parse `--output-format stream-json`: one JSON object per line.
+
+    A line that will not parse is skipped rather than fatal — the stream is a
+    transcript, and one malformed entry says nothing about the rest. Whether the
+    run is usable at all is decided by :func:`_result_event`, which fails closed.
+    """
+    events: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def _result_event(events: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """The terminal `result` event, which carries the answer and the totals."""
+    for event in reversed(events):
+        if event.get("type") == "result":
+            return event
+    return None
+
+
+def _content_blocks(event: dict[str, Any]) -> list[dict[str, Any]]:
+    message = event.get("message")
+    content = message.get("content") if isinstance(message, dict) else None
+    if not isinstance(content, list):
+        return []
+    return [block for block in content if isinstance(block, dict)]
+
+
+def _skill_state(events: list[dict[str, Any]], raw: str) -> tuple[str, list[str], str]:
+    """Did the `cf` skill actually run? Returns ``(state, names, detail)``.
+
+    ``state`` is ``"ran"``, ``"failed"`` or ``"absent"``. This is a *positive*
+    check against tool-use events in the transcript, not a substring search over
+    the prose: the fallback answer is well-formed and says nothing about whether
+    the skill was reached, which is exactly why the old heuristic scored it.
+    """
+    calls: dict[Any, Any] = {}
+    errored: set[Any] = set()
+    for event in events:
+        for block in _content_blocks(event):
+            kind = block.get("type")
+            if kind == "tool_use" and block.get("name") == _SKILL_TOOL:
+                calls[block.get("id")] = block.get("input") or {}
+            elif kind == "tool_result" and block.get("is_error"):
+                errored.add(block.get("tool_use_id"))
+
+    names = sorted({json.dumps(payload, default=str, sort_keys=True) for payload in calls.values()})
+    if _SKILL_ERROR_MARK in raw:
+        return "failed", names, f"the transcript carries {_SKILL_ERROR_MARK!r}"
+    if not calls:
+        return "absent", names, f"no {_SKILL_TOOL} tool call in the transcript"
+    if all(call_id in errored for call_id in calls):
+        return "failed", names, f"every {_SKILL_TOOL} call came back as an error"
+    if not any(_SKILL_NAME in payload for payload in names):
+        return "failed", names, f"a {_SKILL_TOOL} ran but none of them named {_SKILL_NAME!r}"
+    return "ran", names, ""
 
 
 def call_api(prompt: str, options: dict | None = None, context: dict | None = None) -> dict:
@@ -56,7 +137,13 @@ def _invoke(prompt: str, cwd: Path, started: float) -> dict:
         CLAUDE_BIN, "-p",
         "--model", DEFAULT_MODEL,
         "--effort", DEFAULT_EFFORT,
-        "--output-format", "json",
+        # Without this the skill is denied and the run scores the fallback path.
+        "--permission-mode", PERMISSION_MODE,
+        # The transcript, not just the answer: tool-use events are the only place
+        # the run says whether the skill was reached. `--verbose` is what makes
+        # `-p` emit the intermediate events rather than the result alone.
+        "--output-format", "stream-json",
+        "--verbose",
         "--max-budget-usd", "0.30",
         invoked,
     ]
@@ -72,25 +159,42 @@ def _invoke(prompt: str, cwd: Path, started: float) -> dict:
             "metadata": {"duration_s": round(duration, 2)},
         }
 
-    payload = _parse_json_output(proc.stdout)
-    output_text = (
-        payload.get("result")
-        or payload.get("text")
-        or payload.get("_raw")
-        or proc.stdout.strip()
-    )
+    events = _stream_events(proc.stdout)
+    payload = _result_event(events)
+    base = {"duration_s": round(duration, 2), "sandbox": str(cwd)}
+    if payload is None:
+        # Fail closed. Without the terminal event there is no answer to grade and
+        # no transcript to trust, so returning the raw text would hand the rubric
+        # something to score with no idea what produced it.
+        return {
+            "error": "claude emitted no result event; stream-json may not have been honoured",
+            "metadata": {**base, "stdout_tail": proc.stdout.strip()[-500:]},
+        }
 
+    output_text = payload.get("result") or ""
+    state, skills, detail = _skill_state(events, proc.stdout)
     metadata = {
-        "duration_s": round(duration, 2),
-        "sandbox": str(cwd),
+        **base,
         "session_id": payload.get("session_id"),
         "num_turns": payload.get("num_turns"),
         "total_cost_usd": payload.get("total_cost_usd"),
-        # Heuristic — actual skill-loading detection refined later via stream-json.
-        "skill_load_warning": "skills failed to load" in output_text.lower(),
+        "skill_state": state,
+        "skills_invoked": skills,
     }
     cost = payload.get("total_cost_usd")
-    result: dict[str, Any] = {"output": output_text, "metadata": metadata}
+    if state != "ran":
+        # A hard error, not a metadata flag. The fallback answer is plausible and
+        # well-formed, so left to the grader it scores as a pass and the suite
+        # reports on an agent that never loaded Studio. A run that did not engage
+        # the skill is not a measurement of the skill, and must not be graded as
+        # one — this is the part of the fix that keeps the defect from returning
+        # the next time an invocation detail changes.
+        result: dict[str, Any] = {
+            "error": f"cf skill did not run ({state}): {detail}",
+            "metadata": {**metadata, "unscored_output": output_text[:500]},
+        }
+    else:
+        result = {"output": output_text, "metadata": metadata}
     if isinstance(cost, (int, float)):
         result["cost"] = float(cost)
     return result

--- a/tests/prompts/cf-ux/providers/claude_provider.py
+++ b/tests/prompts/cf-ux/providers/claude_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import subprocess
@@ -11,6 +12,8 @@ from pathlib import Path
 from typing import Any, NamedTuple
 
 from _sandbox import SandboxError, sandbox
+
+logger = logging.getLogger(__name__)
 
 CLAUDE_BIN = "claude"
 CALL_TIMEOUT_S = 850  # under promptfoo worker timeout (900s)
@@ -60,13 +63,22 @@ _NAME_SEPARATORS = (":", "/")
 #: and not prose.
 _NAME_SHAPE = re.compile(r"[A-Za-z0-9_.:/-]{1,64}")
 #: What a *failed* execution looks like in the transcript: `<error>Execute
-#: skill: cf</error>`. The previous guard searched for "skills failed to load",
-#: which the CLI never emits, so it could not fire.
-_SKILL_ERROR_MARK = "Execute skill:"
+#: skill: cf</error>`. Bound to the name, with a boundary, for the same reason
+#: the positive check is: an unrelated skill failing (`Execute skill:
+#: superpowers`) must not fail this one, and neither must answer prose that
+#: quotes the phrase. The previous guard searched for "skills failed to load",
+#: which the CLI never emits, so it could not fire at all.
+_SKILL_ERROR_TEXT = "Execute skill:"
+_SKILL_ERROR_MARK = re.compile(rf"{_SKILL_ERROR_TEXT}\s*{_SKILL_NAME}(?![\w.:/-])")
 #: The terminal event's subtype when the turn ran to completion. Anything else
 #: (`error_max_turns`, `error_during_execution`) leaves `result` holding a
 #: fragment rather than an answer.
 _RESULT_OK = "success"
+
+#: Counting a dropped line into the metadata is not the same as saying so where
+#: a person will see it, and the house rule is that a swallowed exception warns
+#: on stderr rather than only in a return value (`architecture/DESIGN.md`).
+_LOG_UNPARSED_LINE = "cf-ux claude provider: stream line %d would not parse; skipped"
 
 
 def _stream_events(raw: str) -> tuple[list[dict[str, Any]], int]:
@@ -81,7 +93,7 @@ def _stream_events(raw: str) -> tuple[list[dict[str, Any]], int]:
     """
     events: list[dict[str, Any]] = []
     unparsed = 0
-    for line in raw.splitlines():
+    for number, line in enumerate(raw.splitlines(), start=1):
         line = line.strip()
         if not line:
             continue
@@ -89,6 +101,7 @@ def _stream_events(raw: str) -> tuple[list[dict[str, Any]], int]:
             event = json.loads(line)
         except json.JSONDecodeError:
             unparsed += 1
+            logger.warning(_LOG_UNPARSED_LINE, number)
             continue
         if isinstance(event, dict):
             events.append(event)
@@ -178,8 +191,11 @@ def _skill_trace(events: list[dict[str, Any]], raw: str) -> _SkillTrace:
     names = sorted({name for found in named.values() for name in found})
     inputs = sorted({json.dumps(payload, default=str, sort_keys=True) for payload in calls.values()})
 
-    if _SKILL_ERROR_MARK in raw:
-        return _SkillTrace("failed", names, inputs, f"the transcript carries {_SKILL_ERROR_MARK!r}")
+    if _SKILL_ERROR_MARK.search(raw):
+        return _SkillTrace(
+            "failed", names, inputs,
+            f"the transcript reports {_SKILL_ERROR_TEXT} {_SKILL_NAME}",
+        )
     if not calls:
         return _SkillTrace("absent", names, inputs, f"no {_SKILL_TOOL} tool call in the transcript")
 
@@ -275,15 +291,32 @@ def _invoke(prompt: str, cwd: Path, started: float) -> dict:
         # Both causes are named because they look identical here and lead to
         # opposite fixes: a budget ceiling reached mid-turn ends the stream just
         # as an unhonoured `--output-format` does, and only one of them is a bug.
+        #
+        # `events_seen` and `last_event_type` are what tell the two apart without
+        # reading the tail by hand: a stream that was never JSON lines parses to
+        # nothing, while a turn cut off at the ceiling leaves a run of events
+        # ending somewhere mid-turn. `unparsed_lines` distinguishes truncation
+        # mid-line from a stream that simply stopped between lines.
         return {
             "error": (
                 "claude emitted no result event: the turn may have stopped at the "
                 f"--max-budget-usd {MAX_BUDGET_USD} ceiling, or stream-json was not honoured"
             ),
-            "metadata": {**base, "stdout_tail": proc.stdout.strip()[-500:]},
+            "metadata": {
+                **base,
+                "events_seen": len(events),
+                "last_event_type": events[-1].get("type") if events else None,
+                "stdout_tail": proc.stdout.strip()[-500:],
+            },
         }
 
-    output_text = payload.get("result") or ""
+    answer = payload.get("result")
+    is_text = isinstance(answer, str)
+    output_text = answer if is_text else ""
+    # What to show when the answer is withheld from the grader: the text itself,
+    # or a repr of whatever non-text thing arrived instead of one. Kept as a
+    # string so no branch below can slice a dict.
+    withheld = (output_text if is_text else "" if answer is None else repr(answer))[:500]
     trace = _skill_trace(events, proc.stdout)
     state, detail = trace.state, trace.detail
     metadata = {
@@ -304,21 +337,29 @@ def _invoke(prompt: str, cwd: Path, started: float) -> dict:
     # shape should not be able to manufacture failures.
     subtype = payload.get("subtype")
     if payload.get("is_error") or (subtype is not None and subtype != _RESULT_OK):
-        return {
+        result: dict[str, Any] = {
             "error": f"claude did not finish the turn (result subtype {subtype!r})",
-            "metadata": {**metadata, "unscored_output": output_text[:500]},
+            "metadata": {**metadata, "unscored_output": withheld},
         }
-
-    if state != "ran":
+    elif answer is not None and not is_text:
+        # Nothing downstream would notice: promptfoo would hand the rubric a
+        # dict and the rubric would score whatever it made of it. Text is what
+        # this suite grades, so a non-text answer is a shape change to report,
+        # not to render.
+        result = {
+            "error": f"claude returned a non-text result ({type(answer).__name__})",
+            "metadata": {**metadata, "unscored_output": withheld},
+        }
+    elif state != "ran":
         # A hard error, not a metadata flag. The fallback answer is plausible and
         # well-formed, so left to the grader it scores as a pass and the suite
         # reports on an agent that never loaded Studio. A run that did not engage
         # the skill is not a measurement of the skill, and must not be graded as
         # one — this is the part of the fix that keeps the defect from returning
         # the next time an invocation detail changes.
-        result: dict[str, Any] = {
+        result = {
             "error": f"cf skill did not run ({state}): {detail}",
-            "metadata": {**metadata, "unscored_output": output_text[:500]},
+            "metadata": {**metadata, "unscored_output": withheld},
         }
     else:
         result = {"output": output_text, "metadata": metadata}

--- a/tests/test_cf_ux_claude_provider.py
+++ b/tests/test_cf_ux_claude_provider.py
@@ -44,9 +44,9 @@ def _skill_result(call_id: str = "t1", *, is_error: bool = False) -> dict:
     ]}}
 
 
-def _result(text: str = "the answer", cost: float = 0.01) -> dict:
+def _result(text: str = "the answer", cost: float = 0.01, **overrides) -> dict:
     return {"type": "result", "subtype": "success", "result": text,
-            "session_id": "s1", "num_turns": 3, "total_cost_usd": cost}
+            "session_id": "s1", "num_turns": 3, "total_cost_usd": cost, **overrides}
 
 
 def _stream(*events: dict) -> str:
@@ -62,9 +62,11 @@ def run_provider(tmp_path, monkeypatch):
     def _fake_sandbox():
         yield tmp_path
 
-    def _make(stdout: str, returncode: int = 0, stderr: str = ""):
+    def _make(stdout: str, returncode: int = 0, stderr: str = "", raises: Exception | None = None):
         def _fake_run(cmd, **_kwargs):
             seen["cmd"] = list(cmd)
+            if raises is not None:
+                raise raises
             return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
 
         monkeypatch.setattr(claude_provider, "sandbox", _fake_sandbox)
@@ -112,6 +114,59 @@ class TestARunThatLoadedTheSkillIsScored:
         assert out["cost"] == 0.02
         assert out["metadata"]["skill_state"] == "ran"
         assert out["metadata"]["num_turns"] == 3
+        assert out["metadata"]["unparsed_lines"] == 0, "a clean transcript dropped nothing"
+
+    def test_a_namespaced_cf_skill_is_still_the_cf_skill(self, run_provider):
+        """`plugin:skill` is how a skill from a marketplace is named, so the
+        trailing segment is the identifier to compare."""
+        out, _seen = run_provider(
+            _stream(_skill_call(skill="studio:cf"), _skill_result(), _result()),
+        )
+
+        assert out["output"] == "the answer"
+        assert out["metadata"]["skill_state"] == "ran"
+
+    def test_the_metadata_names_the_skill_and_keeps_the_input_beside_it(self, run_provider):
+        """`skills_invoked` used to hold `'{"command": "cf"}'` — a serialized
+        payload under a key promising a name. The raw input is still worth having
+        for diagnosis, so it keeps its own key instead of borrowing this one."""
+        out, _seen = run_provider(
+            _stream(_skill_call(skill="studio:cf"), _skill_result(), _result()),
+        )
+
+        assert out["metadata"]["skills_invoked"] == ["cf"]
+        assert out["metadata"]["skill_call_inputs"] == ['{"command": "studio:cf"}']
+
+    def test_the_request_text_is_not_listed_as_a_skill_name(self, run_provider):
+        """Which key holds the name is not contractual, so every string value is
+        a candidate — but only the ones shaped like an identifier. Otherwise a
+        field promising names reports the user's sentence as one of them."""
+        call = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "command": "cf", "args": "write a PRD for the billing service",
+            }},
+        ]}}
+
+        out, _seen = run_provider(_stream(call, _skill_result(), _result()))
+
+        assert out["metadata"]["skill_state"] == "ran"
+        assert out["metadata"]["skills_invoked"] == ["cf"]
+
+    def test_a_result_event_with_no_subtype_is_still_an_answer(self, run_provider):
+        """Only a subtype that is present and says otherwise means a short turn.
+        An unfamiliar event shape must not be able to manufacture failures."""
+        bare = {"type": "result", "result": "the answer", "session_id": "s1"}
+
+        out, _seen = run_provider(_stream(_skill_call(), _skill_result(), bare))
+
+        assert out["output"] == "the answer"
+
+    def test_two_result_events_are_read_as_ending_in_the_last(self, run_provider):
+        out, _seen = run_provider(
+            _stream(_skill_call(), _skill_result(), _result("first"), _result("second")),
+        )
+
+        assert out["output"] == "second"
 
     def test_a_skill_that_ran_alongside_a_failed_unrelated_tool_still_counts(self, run_provider):
         """Only the `Skill` call's own result decides this. An unrelated tool
@@ -168,7 +223,72 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "none of them named 'cf'" in out["error"]
-        assert out["metadata"]["skills_invoked"], "and it says which did run"
+        assert out["metadata"]["skills_invoked"] == ["superpowers"], "and it says which did run"
+
+    def test_a_skill_whose_name_merely_begins_with_cf_is_not_the_cf_skill(self, run_provider):
+        out, _seen = run_provider(
+            _stream(_skill_call(skill="cf-generate"), _skill_result(), _result()),
+        )
+
+        assert "output" not in out
+        assert "none of them named 'cf'" in out["error"]
+
+    def test_argument_text_naming_cf_is_not_the_skill_naming_cf(self, run_provider):
+        """The prompt this suite sends is `/cf <request>`, so every scenario's
+        argument text carries "cf". Under substring containment a competing skill
+        that quoted the user message back was scored as the cf skill running —
+        the false positive the whole PR exists to remove, reintroduced by the
+        matcher itself."""
+        rival = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "command": "superpowers:brainstorming",
+                "args": "the user asked: /cf write a PRD for cf-studio",
+            }},
+        ]}}
+
+        out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
+
+        assert "output" not in out
+        assert "none of them named 'cf'" in out["error"]
+
+    def test_a_failed_cf_call_beside_a_successful_other_skill_is_not_a_run(self, run_provider):
+        """Evidence has to be bound per call. "Some Skill call succeeded" and
+        "some payload names cf" were both true here while the cf call itself
+        errored."""
+        out, _seen = run_provider(_stream(
+            _skill_call("A", skill="cf"),
+            _skill_call("B", skill="superpowers:brainstorming"),
+            _skill_result("A", is_error=True),
+            _skill_result("B"),
+            _result("drafted directly"),
+        ))
+
+        assert "output" not in out
+        assert "came back as an error" in out["error"]
+
+    def test_a_cf_call_with_no_result_at_all_is_not_a_confirmed_run(self, run_provider):
+        """Absence of a result is not a non-error result. A trace cut off after
+        the call — a killed CLI, a truncated stream — is the case this module
+        exists to refuse, so it cannot be the case it waves through."""
+        out, _seen = run_provider(_stream(_skill_call(), _result("answered anyway")))
+
+        assert "output" not in out
+        assert "no result in the transcript" in out["error"]
+
+    def test_a_repeated_call_id_collapses_to_the_last_one(self, run_provider):
+        """The id is the only binding between a call and its result, so a
+        collision has to resolve one way. Last wins, and it can only take
+        evidence away: here the cf call is overwritten by a later rival sharing
+        its id, and the verdict is refusal rather than an unexamined pass."""
+        out, _seen = run_provider(_stream(
+            _skill_call("dup", skill="cf"),
+            _skill_call("dup", skill="superpowers"),
+            _skill_result("dup"),
+            _result(),
+        ))
+
+        assert "output" not in out
+        assert "none of them named 'cf'" in out["error"]
 
 
 # ------------------------------------------------------------------ fail-closed
@@ -179,11 +299,85 @@ class TestAnUnreadableRunIsNeverScored:
         """Without the terminal event there is no answer to grade and no transcript
         to trust. Returning the raw text would hand the rubric something to score
         with no idea what produced it."""
-        out, _seen = run_provider(_stream(_skill_call(), _skill_result()))
+        transcript = _stream(_skill_call(), _skill_result())
+
+        out, _seen = run_provider(transcript)
 
         assert "output" not in out
         assert "no result event" in out["error"]
-        assert out["metadata"]["stdout_tail"]
+        assert out["metadata"]["stdout_tail"].endswith(json.dumps(_skill_result()))
+
+    def test_the_missing_result_error_names_both_causes(self, run_provider):
+        """A budget ceiling reached mid-turn ends the stream exactly as an
+        unhonoured `--output-format` does, and the two lead to opposite fixes:
+        raise the budget, or chase a CLI contract change. Naming only the second
+        sent triage after a bug that was not there."""
+        out, seen = run_provider(_stream(_skill_call(), _skill_result()))
+
+        budget = seen["cmd"][seen["cmd"].index("--max-budget-usd") + 1]
+        assert f"--max-budget-usd {budget}" in out["error"], "the ceiling it may have hit"
+        assert "stream-json" in out["error"], "or the regression it may be instead"
+
+    @pytest.mark.parametrize("ending", [
+        {"subtype": "error_max_turns"},
+        {"subtype": "error_during_execution"},
+        {"is_error": True},
+    ])
+    def test_a_turn_that_stopped_short_is_not_graded(self, run_provider, ending):
+        """The skill can load and the turn still fail — hit max turns, hit the
+        budget, error out. `result` then holds whatever had been written when the
+        limit landed, and grading that fragment reports on Studio for a run that
+        never finished."""
+        out, _seen = run_provider(
+            _stream(_skill_call(), _skill_result(), _result("half a gate", **ending)),
+        )
+
+        assert "output" not in out
+        assert "did not finish the turn" in out["error"]
+        assert out["metadata"]["skill_state"] == "ran", "the skill loaded; the turn is what failed"
+        assert out["metadata"]["unscored_output"] == "half a gate"
+
+    def test_a_dropped_line_is_counted_where_the_verdict_is_read(self, run_provider):
+        """A line that will not parse can be a dropped `tool_result`, and the
+        verdict is read off exactly those. Skipping one silently let the evidence
+        shrink without the answer admitting it."""
+        transcript = (
+            json.dumps(_skill_call()) + "\n"
+            + "{ truncated mid-line\n"
+            + json.dumps(_skill_result()) + "\n"
+            + json.dumps(_result()) + "\n"
+        )
+
+        out, _seen = run_provider(transcript)
+
+        assert out["metadata"]["unparsed_lines"] == 1
+
+    def test_a_timeout_reports_how_long_it_ran_and_where(self, run_provider, tmp_path):
+        """850s under the 900s worker deadline is a documented failure mode. It
+        used to come back as a bare error string, so a wave of them could not be
+        told apart from runs that failed instantly."""
+        out, _seen = run_provider(
+            "", raises=subprocess.TimeoutExpired(cmd=["claude"], timeout=850),
+        )
+
+        assert f"timed out after {claude_provider.CALL_TIMEOUT_S}s" in out["error"]
+        assert set(out["metadata"]) == {"duration_s", "sandbox"}
+        assert out["metadata"]["sandbox"] == str(tmp_path)
+
+    def test_a_setup_timeout_is_not_blamed_on_the_cli(self, monkeypatch):
+        """`git` and the in-tree `cfs init` carry their own deadlines. Reported as
+        "claude timed out after 850s", they pointed triage at a process that had
+        not started yet."""
+        def _fake_sandbox():
+            raise subprocess.TimeoutExpired(cmd=["git", "init"], timeout=180)
+
+        monkeypatch.setattr(claude_provider, "sandbox", _fake_sandbox)
+
+        out = claude_provider.call_api("write a PRD")
+
+        assert "sandbox setup timed out after 180s" in out["error"]
+        assert "git" in out["error"]
+        assert "claude" not in out["error"], "the CLI was never reached"
 
     def test_a_non_json_stream_is_an_error(self, run_provider):
         out, _seen = run_provider("not json at all\nnor this\n")
@@ -206,7 +400,40 @@ class TestAnUnreadableRunIsNeverScored:
         assert out["output"] == "survived"
         assert out["metadata"]["skill_state"] == "ran"
 
-    def test_a_non_zero_exit_still_reports_the_exit(self, run_provider):
+    def test_a_non_zero_exit_still_reports_the_exit(self, run_provider, tmp_path):
         out, _seen = run_provider("", returncode=2, stderr="unknown flag")
 
         assert "claude exited 2" in out["error"]
+        assert out["metadata"]["sandbox"] == str(tmp_path), "which tree, as elsewhere"
+
+
+# --------------------------------------------------- what bypassPermissions rests on
+
+class TestTheSandboxIsWipedEvenWhenTheRunDies:
+    """`bypassPermissions` is defensible because the tree it writes into is
+    temporary and always removed. That is a claim about `_sandbox.sandbox()`, so
+    these drive the real one — the rest of the suite fakes it away."""
+
+    def test_the_directory_is_gone_after_the_invocation_raises(self, tmp_path, monkeypatch):
+        sandbox_module = pytest.importorskip("_sandbox")
+        monkeypatch.delenv("CF_UX_SHARED_SANDBOX", raising=False)
+        monkeypatch.delenv("CF_UX_KEEP_SANDBOX", raising=False)
+        monkeypatch.setattr(sandbox_module, "_SANDBOX_PARENT", tmp_path / "cf-ux-sandboxes")
+        # `cfs init` in a fresh tree is minutes of work and is not what is under
+        # test here; the process-wide signal handlers would outlive the test.
+        monkeypatch.setattr(sandbox_module, "_init_sandbox", lambda root: None)
+        monkeypatch.setattr(sandbox_module, "_install_handlers_once", lambda: None)
+        seen: dict = {}
+
+        def _dies(cmd, **kwargs):
+            seen["cwd"] = Path(kwargs["cwd"])
+            assert seen["cwd"].is_dir(), "the CLI is handed a real directory to write in"
+            raise RuntimeError("the CLI died mid-run")
+
+        monkeypatch.setattr(claude_provider.subprocess, "run", _dies)
+
+        out = claude_provider.call_api("write a PRD")
+
+        assert "unexpected: RuntimeError" in out["error"]
+        assert not seen["cwd"].exists(), "and the directory does not outlive the run"
+        assert seen["cwd"] not in sandbox_module._LIVE_SANDBOXES

--- a/tests/test_cf_ux_claude_provider.py
+++ b/tests/test_cf_ux_claude_provider.py
@@ -1,0 +1,212 @@
+"""Tests for the cf-ux Claude provider — that a run which never loaded the skill
+is not scored as one that did.
+
+The suite these back cannot run here: `claude` is a CLI this repository does not
+vendor, and a real invocation costs money and needs credentials. So the provider
+is driven with a faked `subprocess.run` and a faked sandbox, which is enough to
+pin the three things that went wrong — the missing permission flag, a guard that
+searched for a string the CLI never emits, and a skill failure recorded as
+metadata where the grader would never see it.
+
+What these tests deliberately do *not* claim: that `--permission-mode
+bypassPermissions` makes the skill execute. That is a fact about the CLI, and it
+belongs to whoever can run one.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_PROVIDERS = Path(__file__).resolve().parents[1] / "tests" / "prompts" / "cf-ux" / "providers"
+if str(_PROVIDERS) not in sys.path:
+    sys.path.insert(0, str(_PROVIDERS))
+
+claude_provider = pytest.importorskip("claude_provider")
+
+
+# --------------------------------------------------------------------------- helpers
+
+def _skill_call(call_id: str = "t1", name: str = "Skill", skill: str = "cf") -> dict:
+    return {"type": "assistant", "message": {"content": [
+        {"type": "tool_use", "id": call_id, "name": name, "input": {"command": skill}},
+    ]}}
+
+
+def _skill_result(call_id: str = "t1", *, is_error: bool = False) -> dict:
+    return {"type": "user", "message": {"content": [
+        {"type": "tool_result", "tool_use_id": call_id, "is_error": is_error, "content": "..."},
+    ]}}
+
+
+def _result(text: str = "the answer", cost: float = 0.01) -> dict:
+    return {"type": "result", "subtype": "success", "result": text,
+            "session_id": "s1", "num_turns": 3, "total_cost_usd": cost}
+
+
+def _stream(*events: dict) -> str:
+    return "".join(json.dumps(event) + "\n" for event in events)
+
+
+@pytest.fixture
+def run_provider(tmp_path, monkeypatch):
+    """Drive `call_api` against a canned transcript; hand back the call's argv."""
+    seen: dict = {}
+
+    @contextmanager
+    def _fake_sandbox():
+        yield tmp_path
+
+    def _make(stdout: str, returncode: int = 0, stderr: str = ""):
+        def _fake_run(cmd, **_kwargs):
+            seen["cmd"] = list(cmd)
+            return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
+
+        monkeypatch.setattr(claude_provider, "sandbox", _fake_sandbox)
+        monkeypatch.setattr(claude_provider.subprocess, "run", _fake_run)
+        return claude_provider.call_api("write a PRD"), seen
+
+    return _make
+
+
+# ------------------------------------------------------- the permission flag
+
+class TestTheSkillIsAllowedToExecute:
+
+    def test_the_invocation_carries_a_permission_mode(self, run_provider):
+        """The defect itself: with no permission flag, skill execution is denied in
+        print mode because there is nobody to ask, so the agent answers directly
+        and the run scores the fallback path."""
+        _out, seen = run_provider(_stream(_skill_call(), _skill_result(), _result()))
+
+        cmd = seen["cmd"]
+        assert "--permission-mode" in cmd, "print mode has nobody to grant permission"
+        assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions"
+
+    def test_the_transcript_is_requested_not_only_the_answer(self, run_provider):
+        """Tool-use events are the only place the run says whether the skill was
+        reached, and `-p` emits them only in the streaming format."""
+        _out, seen = run_provider(_stream(_skill_call(), _skill_result(), _result()))
+
+        cmd = seen["cmd"]
+        assert cmd[cmd.index("--output-format") + 1] == "stream-json"
+        assert "--verbose" in cmd, "without it `-p` returns the result alone"
+
+
+# ------------------------------------------------- a run that loaded the skill
+
+class TestARunThatLoadedTheSkillIsScored:
+
+    def test_the_answer_and_the_totals_come_back(self, run_provider):
+        out, _seen = run_provider(
+            _stream(_skill_call(), _skill_result(), _result("gate rendered", cost=0.02)),
+        )
+
+        assert "error" not in out
+        assert out["output"] == "gate rendered"
+        assert out["cost"] == 0.02
+        assert out["metadata"]["skill_state"] == "ran"
+        assert out["metadata"]["num_turns"] == 3
+
+    def test_a_skill_that_ran_alongside_a_failed_unrelated_tool_still_counts(self, run_provider):
+        """Only the `Skill` call's own result decides this. An unrelated tool
+        erroring mid-workflow is ordinary, and must not read as the skill failing."""
+        other = {"type": "user", "message": {"content": [
+            {"type": "tool_result", "tool_use_id": "other", "is_error": True, "content": "nope"},
+        ]}}
+        out, _seen = run_provider(
+            _stream(_skill_call(), _skill_result(), other, _result()),
+        )
+
+        assert "error" not in out
+        assert out["metadata"]["skill_state"] == "ran"
+
+
+# --------------------------------------------- a run that did not, is not scored
+
+class TestARunThatNeverLoadedTheSkillIsNotScored:
+    """The heart of the report: the fallback answer is plausible and well-formed,
+    so left to the grader it scores as a pass and the suite reports confidently on
+    an agent that never loaded Studio."""
+
+    def test_no_skill_call_at_all_is_an_error_not_an_output(self, run_provider):
+        out, _seen = run_provider(_stream(_result("here is a PRD I wrote myself")))
+
+        assert "output" not in out, "a fallback answer must never reach the grader"
+        assert "did not run (absent)" in out["error"]
+        assert out["metadata"]["skill_state"] == "absent"
+        assert out["metadata"]["unscored_output"].startswith("here is a PRD")
+
+    def test_a_skill_call_that_errored_is_an_error(self, run_provider):
+        out, _seen = run_provider(
+            _stream(_skill_call(), _skill_result(is_error=True), _result("drafted directly")),
+        )
+
+        assert "output" not in out
+        assert "did not run (failed)" in out["error"]
+
+    def test_the_real_failure_signature_is_recognised(self, run_provider):
+        """The observed failure is `<error>Execute skill: cf</error>`. The previous
+        guard looked for "skills failed to load", which the CLI never emits, so the
+        one check meant to catch this could not fire."""
+        transcript = _stream(_result("<error>Execute skill: cf</error> so I answered"))
+
+        out, _seen = run_provider(transcript)
+
+        assert "output" not in out
+        assert "Execute skill:" in out["error"]
+
+    def test_a_different_skill_running_is_not_the_cf_skill_running(self, run_provider):
+        out, _seen = run_provider(
+            _stream(_skill_call(skill="superpowers"), _skill_result(), _result()),
+        )
+
+        assert "output" not in out
+        assert "none of them named 'cf'" in out["error"]
+        assert out["metadata"]["skills_invoked"], "and it says which did run"
+
+
+# ------------------------------------------------------------------ fail-closed
+
+class TestAnUnreadableRunIsNeverScored:
+
+    def test_a_missing_result_event_is_an_error(self, run_provider):
+        """Without the terminal event there is no answer to grade and no transcript
+        to trust. Returning the raw text would hand the rubric something to score
+        with no idea what produced it."""
+        out, _seen = run_provider(_stream(_skill_call(), _skill_result()))
+
+        assert "output" not in out
+        assert "no result event" in out["error"]
+        assert out["metadata"]["stdout_tail"]
+
+    def test_a_non_json_stream_is_an_error(self, run_provider):
+        out, _seen = run_provider("not json at all\nnor this\n")
+
+        assert "output" not in out
+        assert "no result event" in out["error"]
+
+    def test_one_malformed_line_does_not_discard_the_rest(self, run_provider):
+        """A transcript is a stream; one bad entry says nothing about the others.
+        The run is judged by what it contains, not by whether every line parsed."""
+        transcript = (
+            json.dumps(_skill_call()) + "\n"
+            + "{ this line is broken\n"
+            + json.dumps(_skill_result()) + "\n"
+            + json.dumps(_result("survived")) + "\n"
+        )
+
+        out, _seen = run_provider(transcript)
+
+        assert out["output"] == "survived"
+        assert out["metadata"]["skill_state"] == "ran"
+
+    def test_a_non_zero_exit_still_reports_the_exit(self, run_provider):
+        out, _seen = run_provider("", returncode=2, stderr="unknown flag")
+
+        assert "claude exited 2" in out["error"]

--- a/tests/test_cf_ux_claude_provider.py
+++ b/tests/test_cf_ux_claude_provider.py
@@ -216,6 +216,19 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
         assert "output" not in out
         assert "Execute skill:" in out["error"]
 
+    @pytest.mark.parametrize("rival", ["superpowers", "cf-generate"])
+    def test_another_skill_failing_does_not_fail_the_cf_run(self, run_provider, rival):
+        """`Execute skill:` with no name attached meant one skill's failure
+        condemned another's success — the mirror of the substring problem on the
+        positive side, and it fired before any positive evidence was weighed."""
+        out, _seen = run_provider(_stream(
+            _skill_call(), _skill_result(),
+            _result(f"<error>Execute skill: {rival}</error> but cf answered"),
+        ))
+
+        assert "error" not in out
+        assert out["metadata"]["skill_state"] == "ran"
+
     def test_a_different_skill_running_is_not_the_cf_skill_running(self, run_provider):
         out, _seen = run_provider(
             _stream(_skill_call(skill="superpowers"), _skill_result(), _result()),
@@ -336,6 +349,43 @@ class TestAnUnreadableRunIsNeverScored:
         assert "did not finish the turn" in out["error"]
         assert out["metadata"]["skill_state"] == "ran", "the skill loaded; the turn is what failed"
         assert out["metadata"]["unscored_output"] == "half a gate"
+        assert out["cost"] == 0.01, "a run that hit a limit is the expensive kind; report it"
+
+    def test_a_non_text_result_is_not_handed_to_the_grader(self, run_provider):
+        """Nothing downstream would notice: promptfoo would pass the rubric a
+        dict and the rubric would score whatever it made of it."""
+        out, _seen = run_provider(
+            _stream(_skill_call(), _skill_result(), _result({"answer": "structured"})),
+        )
+
+        assert "output" not in out
+        assert "non-text result (dict)" in out["error"]
+        assert "structured" in out["metadata"]["unscored_output"], "kept for diagnosis"
+
+    def test_a_non_text_result_on_a_short_turn_reports_the_turn(self, run_provider):
+        """Both faults at once. The turn is the outer fact, so it is what the
+        error names — and nothing slices the dict on the way out."""
+        out, _seen = run_provider(_stream(
+            _skill_call(), _skill_result(),
+            _result({"answer": "structured"}, subtype="error_max_turns"),
+        ))
+
+        assert "did not finish the turn" in out["error"]
+        assert "structured" in out["metadata"]["unscored_output"]
+
+    def test_the_missing_result_metadata_tells_the_two_causes_apart(self, run_provider):
+        """Naming both causes in prose still leaves triage reading the tail by
+        hand. A stream that was never JSON lines parses to nothing; a turn cut
+        off at the ceiling leaves events that stop mid-turn."""
+        broken, _seen = run_provider("not json at all\nnor this\n")
+        truncated, _seen2 = run_provider(_stream(_skill_call(), _skill_result()))
+
+        assert broken["metadata"]["events_seen"] == 0
+        assert broken["metadata"]["last_event_type"] is None
+        assert broken["metadata"]["unparsed_lines"] == 2
+        assert truncated["metadata"]["events_seen"] == 2
+        assert truncated["metadata"]["last_event_type"] == "user"
+        assert truncated["metadata"]["unparsed_lines"] == 0
 
     def test_a_dropped_line_is_counted_where_the_verdict_is_read(self, run_provider):
         """A line that will not parse can be a dropped `tool_result`, and the
@@ -351,6 +401,23 @@ class TestAnUnreadableRunIsNeverScored:
         out, _seen = run_provider(transcript)
 
         assert out["metadata"]["unparsed_lines"] == 1
+
+    def test_a_dropped_line_also_warns_where_a_person_will_see_it(self, run_provider, caplog):
+        """A count riding along in a metadata dict is not the same as saying so.
+        The house rule is that a swallowed exception warns rather than only
+        returning a number."""
+        transcript = (
+            json.dumps(_skill_call()) + "\n"
+            + "{ truncated mid-line\n"
+            + json.dumps(_skill_result()) + "\n"
+            + json.dumps(_result()) + "\n"
+        )
+
+        with caplog.at_level("WARNING", logger=claude_provider.logger.name):
+            run_provider(transcript)
+
+        assert [r for r in caplog.records if "would not parse" in r.getMessage()]
+        assert "line 2" in caplog.text, "and says which line it was"
 
     def test_a_timeout_reports_how_long_it_ran_and_where(self, run_provider, tmp_path):
         """850s under the 900s worker deadline is a documented failure mode. It


### PR DESCRIPTION
Fixes #146.

The Claude provider invoked `claude -p "/cf <prompt>"` with no permission flag. Skill *execution* asks for permission and print mode has nobody to ask, so the skill was denied, the agent answered the request directly, and the answer was plausible enough for the shared rubric to pass it. The suite then reported confidently on an agent that never loaded Studio.

The codex provider never had this problem — it has always passed the equivalent pair, `--sandbox workspace-write` and `approval_policy="never"`. The asymmetry was the bug.

## Three changes

**1. `--permission-mode bypassPermissions`.** Safe in this context: every invocation runs in a fresh directory under the system temp dir which `_sandbox` wipes in `finally`, on `atexit`, and on SIGTERM/SIGINT/SIGHUP. `CF_UX_SHARED_SANDBOX` is the exception — it writes where the caller points it — and the README now warns about that explicitly, since it is the one path where this flag has real blast radius.

**2. Positive skill detection from the tool-call trace.** `--output-format stream-json --verbose`, then a `Skill` tool-use event whose input names `cf`, with a non-error `tool_result` bound to *that call's* id. Review round 2 tightened every clause of that sentence — see below.

The guard this replaces was:

```python
"skill_load_warning": "skills failed to load" in output_text.lower(),
```

The CLI never emits that string, so the one check meant to catch this could not fire. The real signature is `<error>Execute skill: cf</error>`, which is now recognised as a failure too. The file's own comment already conceded the point — *"Heuristic — actual skill-loading detection refined later via stream-json"* — and the README listed this parsing under "Next steps"; #146 is the argument for why it was not optional.

**3. A run that did not load the skill returns a promptfoo error, not a metadata flag.** This is the one that keeps the defect from returning. A fallback answer never reaches the grader — it is kept under `unscored_output` for diagnosis instead. A transcript with no terminal `result` event is an error as well: there is then no answer to grade and no trace to trust.

`skill_state` is `ran` / `failed` / `absent`, and `skills_invoked` records what actually ran, so a failure says which.

## Review round 2 (`4067cacf`)

Thirteen findings on `422deade`. Twelve fixed, one declined with reasoning. Three were `Major`, and all three were the same shape: the positive check could still say `ran` for a run that did not run the cf skill.

| # | Finding | Fix |
|---|---|---|
| 1 | **Name matched by substring** over the serialized tool input. The prompt is `/cf <request>`, so the *argument* text carries "cf" on every scenario here — a rival skill quoting the user message back counted as this one. | Names compared whole, after dropping a `plugin:`/`path/` namespace; only identifier-shaped values are candidates. |
| 2 | **Evidence not bound per call**: "some `Skill` call succeeded" + "some call named cf" was enough, even when those were different calls and the cf one errored. | `ran` requires a non-error result for the cf call itself. |
| 3 | **A cf call with no `tool_result` at all** read as success — absence of a result is not a non-error result. | A truncated trace is refused, with a distinguishing detail. |
| 4 | A `result` event whose `subtype` says the turn **stopped short** (`error_max_turns`, `error_during_execution`) was graded on the fragment it left behind. | Refused, with `skill_state` and the fragment kept in metadata so both facts are visible. An *absent* subtype is deliberately still graded. |
| 5 | Unparseable lines dropped in silence — and a lost line can be a lost `tool_result`, which is what the verdict is read from. | Counted into `metadata["unparsed_lines"]`. |
| 6 | `skills_invoked` held serialized inputs under a key promising names. | Names, with the raw inputs beside it under `skill_call_inputs`. |
| 7 | Error branches carried inconsistent metadata; the timeout branch carried none. | One `_baseline` (`duration_s`, `sandbox`) behind every return. The `claude` timeout moved into `_invoke` where `cwd` is in scope. |
| 8 | A setup-command deadline reported as "claude timed out after 850s". | Says which command and which deadline. |
| 9 | The missing-`result` error named only a `stream-json` regression, not the budget ceiling — identical shapes, opposite fixes. | Names both, pinned to the same constant the argv passes. |
| 10 | Duplicate call ids and multiple `result` events had unexamined selection policies. | Both stated (last wins) and tested; both fail closed under the per-call bind. |
| 11 | Truthy-only assertions on diagnostic fields. | Value-exact. This is what surfaced #6 as a test failure rather than a review comment. |
| 12 | Nothing exercised the real `sandbox()` wipe — the claim `bypassPermissions` rests on. | A test drives the real one and asserts the tree is gone after a run dies. |

**Declined:** an explicit cap on transcript size. `capture_output=True` has already materialized stdout before parsing, so a cap there cannot lower the peak; and capping retained *events* would make `skill_state` a function of transcript length — silent mis-measurement, this PR's own defect class. The honest fix is a `Popen` streaming rewrite, which I'd rather not fold into a permission-flag fix. Offered separately. Full reasoning in the thread.

## Review round 3 (`caa43a20`)

Seven more findings, including one bug in round 2's own fix. Nine of round 2's twelve were independently re-verified as resolved by the reviewer.

| Finding | Fix |
|---|---|
| **`Execute skill:` matched with no name attached**, so `<error>Execute skill: superpowers</error>` condemned a successful `cf` run — and that branch is checked *first*, before any positive evidence. The mirror of the substring problem, on the failure side, missed while fixing the positive half in the same commit. | Bound to the name with a right boundary, so a hypothetical `cf-generate` failing does not implicate `cf` either. |
| **A non-string `result` was graded as-is** — promptfoo would hand the rubric a dict and the rubric would score whatever it made of it. | Reported, not rendered, with a `repr` kept for diagnosis. (First version of this fix could slice a dict on the both-faults-at-once path; caught before commit, and it has its own test.) |
| **Cost dropped on the stopped-short branch** — an early return skipped the cost attachment, losing `total_cost_usd` from exactly the runs that spent the most. | All four returns after the terminal event carry it. |
| Naming both causes of a missing `result` in prose still left triage reading `stdout_tail` by hand. | `events_seen` + `last_event_type`, which separate a format regression (nothing parsed at all) from a budget ceiling (events that stop mid-turn) programmatically. |
| A dropped stream line was counted into metadata but never said out loud. | Warns on stderr with its line number, per `architecture/DESIGN.md:277` and the pattern every sibling module uses. |
| The README's "every return carries `duration_s` and `sandbox`" was false for three branches that fail before a sandbox exists. | Corrected rather than made true — naming a path that does not exist would be worse. |

**Still declined:** the transcript size cap, with the arithmetic in the thread. `capture_output=True` materializes stdout before parsing, so a cap cannot lower the peak; and capping retained *events* would make `skill_state` a function of transcript length. A `Popen` streaming rewrite is the honest bound and is offered as its own PR.

**One strictness increase I cannot verify** (round 2, finding 3): requiring a paired `tool_result` assumes the transcript pairs skill results by `tool_use_id` inside `message.content`. If that shape is wrong, runs become loud errors naming the missing result, rather than silently scoring the fallback. The previous code leaned on the same shape for its `is_error` detection — the difference is that a wrong assumption there failed silently and here it fails visibly.

## What reviewers should expect to change

Errors, not just failures, if the CLI's invocation contract shifts again. That is intended: an error says *the suite could not measure*, which is a different claim from *Studio behaved badly*, and those two were previously indistinguishable. It is also possible some scenarios move from green to red once the skill genuinely loads — that would be real signal arriving for the first time, not a regression from this PR.

## Tests

Thirty-six, in `tests/test_cf_ux_claude_provider.py`, driving the provider with a faked `subprocess.run` and a faked sandbox — except the last, which drives the real one.

| group | pins |
|---|---|
| `TestTheSkillIsAllowedToExecute` | the permission flag and its value; `stream-json` + `--verbose` |
| `TestARunThatLoadedTheSkillIsScored` | answer, cost and totals returned; an unrelated tool erroring is not the skill failing |
| `TestARunThatNeverLoadedTheSkillIsNotScored` | no `Skill` call; a `Skill` call that errored; the `Execute skill:` signature; a *different* skill running |
| `TestAnUnreadableRunIsNeverScored` | missing `result` event and both its named causes; a turn that stopped short (3 subtypes); non-JSON stream; one malformed line does not discard the rest, and is counted; both timeout paths; a non-zero exit reports the exit and the sandbox |
| `TestTheSandboxIsWipedEvenWhenTheRunDies` | the real `sandbox()` — the directory is gone after the invocation raises |

Every behaviour above fails its own test when reverted. **26 mutations, 26 caught**, all re-run against `caa43a20`:

| mutation | fails |
|---|---|
| drop `--permission-mode` | 1 |
| skill failure back to a metadata flag | 9 |
| drop the fail-closed `result`-event guard | 3 |
| name match back to substring over the payload | 2 |
| namespace segment not stripped | 2 |
| identifier-shape filter dropped | 1 |
| per-call binding relaxed to any success | 1 |
| no-result branch removed | 1 |
| turn-completion check removed | 3 |
| a missing subtype treated as failure | 1 |
| dropped lines not counted | 1 |
| `skills_invoked` back to serialized inputs | 2 |
| non-zero exit loses the sandbox path | 1 |
| claude timeout loses its metadata | 1 |
| setup timeout blamed on the CLI | 1 |
| missing-result message names one cause | 1 |
| terminal `result`: first wins | 1 |
| duplicate call id: first wins | 1 |
| `_sandbox._wipe` becomes a no-op | 1 |
| error mark unbound from the skill name | 2 |
| error mark loses its right boundary | 1 |
| non-text result graded anyway | 1 |
| cost dropped on the stopped-short branch | 3 |
| no stderr warning for a dropped line | 1 |
| missing-result metadata loses the discriminators | 1 |
| withheld answer stops keeping a non-text repr | 2 |

## What I could not verify, and who can

**`claude` is not installed in my environment**, so I could not re-run the reproduction from the issue. The behavioural claim — that `bypassPermissions` is what makes the skill execute — rests on the measurements in #146, not on anything I ran, and a fake cannot establish it.

What a maintainer with the CLI should run to confirm end to end:

```bash
cd tests/prompts/cf-ux
CF_UX_KEEP_SANDBOX=1 python3 -c "
import sys; sys.path.insert(0, 'providers')
from _sandbox import sandbox
with sandbox() as p: print(p)
"
cd <printed sandbox path>
claude -p "/cf write a PRD for a markdown-to-PDF CLI" \
  --output-format stream-json --verbose --permission-mode bypassPermissions \
  | grep -o '"name":"Skill"'
```

A `Skill` event present is the state this PR requires; absent is what it now refuses to score.

## Gates

| Gate | Result |
|---|---|
| `make test` | **5,599 passed**, 4 skipped, 15 xfailed (36 in this file) |
| `cfs validate` | 0 errors |
| `spec-coverage --system studio` | **0.4603**, unchanged — `tests/prompts/` is outside the traced population, so this adds no `@cpt` obligations |
| `make pylint` | clean; the changed files are under `tests/`, outside the lint target |

Scoped to the harness: no `skills/` or `src/` file is touched, and the codex provider is left alone since it was already correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that shared sandbox paths must point to throwaway directories.
  - Documented how skill execution is verified and when runs are treated as errors.

- **Bug Fixes**
  - Improved handling of streamed provider output, malformed events, incomplete runs, timeouts, and failed executions.
  - Runs now fail safely when the required skill does not execute successfully.

- **Tests**
  - Added comprehensive coverage for skill invocation, streamed output, error conditions, timeouts, and sandbox cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
