### PR TITLE
fix(pdsl): carve out declared mode/gate-type resolution from anti-reinterpretation rules

### DIFF
--- a/skills/studio/modules/gates/simple-mode.md
+++ b/skills/studio/modules/gates/simple-mode.md
@@ -32,3 +32,17 @@ OPTIONS:
   3 debug — debugger overlay in run mode, for workflow development only -> SET SIMPLE_MODE = debug; LOAD {cf-studio-path}/.core/skills/studio/modules/gates/simple-mode-debug.md; CONTINUE SimpleModeDebug
   INVALID -> EMIT_MENU SimpleModeChoice
 ```
+
+```pdsl
+UNIT SimpleModeChangeTrigger
+PURPOSE: Recognize the one declared mode-change trigger and re-open mode selection without resetting any other session state.
+WHEN:
+  REQUIRE SIMPLE_MODE != unset
+  REQUIRE the user's message is exactly the phrase "change mode" (case-insensitive; not a paraphrase, synonym, or superset phrase)
+DO:
+  EMIT_MENU SimpleModeChoice
+  WAIT user.reply
+  STOP_TURN
+RULES:
+  ALWAYS treat "change mode" as the sole mode-change trigger; NEVER treat semantically similar phrases, synonyms, or partial matches as satisfying it.
+```

--- a/skills/studio/modules/gates/simple-mode.md
+++ b/skills/studio/modules/gates/simple-mode.md
@@ -38,7 +38,7 @@ UNIT SimpleModeChangeTrigger
 PURPOSE: Recognize the one declared mode-change trigger and re-open mode selection without resetting any other session state.
 WHEN:
   REQUIRE SIMPLE_MODE != unset
-  REQUIRE the user's message is exactly the phrase "change mode" (case-insensitive; not a paraphrase, synonym, or superset phrase)
+  REQUIRE the user's message, after trimming leading/trailing whitespace and folding ASCII case, equals exactly the phrase "change mode" with no other leading, trailing, or embedded characters (not a paraphrase, synonym, punctuation-padded variant, or superset phrase)
 DO:
   EMIT_MENU SimpleModeChoice
   WAIT user.reply

--- a/skills/studio/modules/runtime/active-workflow-state-law.md
+++ b/skills/studio/modules/runtime/active-workflow-state-law.md
@@ -5,8 +5,8 @@ UNIT ActiveWorkflowStateLaw
 PURPOSE: Keep an active cf/cf-* workflow inside explicit workflow states unless control is visibly handed off.
 RULES:
   ALWAYS while a cf/cf-* workflow is active, treat every new user message as candidate input to the current workflow state first; user messages are workflow input, not permission for generic autonomous behavior.
-  ALWAYS map each new user message to exactly one of these outcomes, in order: a valid current-state transition or loaded session gate, a visible companion-skill handoff, or an explicit exit from the active workflow to free mode.
-  ALWAYS prefer workflow-owned WAIT/STOP_TURN continuations, menus, gates, approvals, dispatch gates, and completion paths over ad-hoc interpretation; resolving a gate by its declared type is workflow-owned behaviour, not ad-hoc interpretation.
+  ALWAYS map each new user message to exactly one of these outcomes, in order: a match against the declared mode-change trigger (RUN SimpleModeChangeTrigger from `gates/simple-mode.md` when its WHEN is satisfied), a valid current-state transition or loaded session gate, a visible companion-skill handoff, or an explicit exit from the active workflow to free mode.
+  ALWAYS prefer workflow-owned WAIT/STOP_TURN continuations, menus, gates, approvals, dispatch gates, and completion paths over ad-hoc interpretation; resolving a gate by its declared type is workflow-owned behaviour, not ad-hoc interpretation -- the canonical definition of that carve-out lives in `runtime/pdsl-execution-card.md`.
   ALWAYS use visible companion-skill routing and return a launch list for current user messages that no longer fit the active workflow's reachable states but clearly span another cf-* domain; NEVER switch workflows silently.
   ALWAYS say that the current workflow is being exited and that control is returning to free mode before handling any request outside the workflow; requests outside the workflow are allowed only after no valid current-state transition or companion workflow remains.
   NEVER treat an off-protocol follow-up as authority to skip the active
@@ -20,5 +20,5 @@ RULES:
   NEVER treat a reply as a mode reset; mode and typed-gate semantics persist
     across cancels, re-plans, and workflow transitions and change only on
     an explicit request matched against the declared trigger set in
-    SimpleModeChoice.
+    SimpleModeChangeTrigger.
 ```

--- a/skills/studio/modules/runtime/active-workflow-state-law.md
+++ b/skills/studio/modules/runtime/active-workflow-state-law.md
@@ -6,9 +6,19 @@ PURPOSE: Keep an active cf/cf-* workflow inside explicit workflow states unless 
 RULES:
   ALWAYS while a cf/cf-* workflow is active, treat every new user message as candidate input to the current workflow state first; user messages are workflow input, not permission for generic autonomous behavior.
   ALWAYS map each new user message to exactly one of these outcomes, in order: a valid current-state transition or loaded session gate, a visible companion-skill handoff, or an explicit exit from the active workflow to free mode.
-  ALWAYS prefer workflow-owned WAIT/STOP_TURN continuations, menus, gates, approvals, dispatch gates, and completion paths over ad-hoc interpretation.
+  ALWAYS prefer workflow-owned WAIT/STOP_TURN continuations, menus, gates, approvals, dispatch gates, and completion paths over ad-hoc interpretation; resolving a gate by its declared type is workflow-owned behaviour, not ad-hoc interpretation.
   ALWAYS use visible companion-skill routing and return a launch list for current user messages that no longer fit the active workflow's reachable states but clearly span another cf-* domain; NEVER switch workflows silently.
   ALWAYS say that the current workflow is being exited and that control is returning to free mode before handling any request outside the workflow; requests outside the workflow are allowed only after no valid current-state transition or companion workflow remains.
-  NEVER treat an off-protocol follow-up as authority to skip the active workflow's states, menus, approvals, validation, dispatch gates, or completion criteria.
+  NEVER treat an off-protocol follow-up as authority to skip the active
+    workflow's states, menus, approvals, validation, dispatch gates, or
+    completion criteria. A skip is bypassing a gate without a resolution
+    permitted by its statically declared type and the deterministic gate
+    semantics that apply to it; a gate resolved within those is not a skip.
+  ALWAYS produce the required audit record for every permitted autonomous
+    resolution.
   NEVER continue the active workflow and free mode in the same turn.
+  NEVER treat a reply as a mode reset; mode and typed-gate semantics persist
+    across cancels, re-plans, and workflow transitions and change only on
+    an explicit request matched against the declared trigger set in
+    SimpleModeChoice.
 ```

--- a/skills/studio/modules/runtime/pdsl-execution-card.md
+++ b/skills/studio/modules/runtime/pdsl-execution-card.md
@@ -28,6 +28,14 @@ RULES:
   ALWAYS after any `WAIT`/`STOP_TURN` resume at the exact active PDSL
     continuation target; REQUIRED: do not reinterpret the user's reply as
     broad permission for generic autonomous execution.
+  ALWAYS treat a session's declared mode and a gate's declared risk type —
+    the literal type named in that gate's own MENU block — as workflow-owned
+    behaviour, not an interpretation of the user's reply; resolving a gate by
+    that declared type is outside the prohibition above.
+  NEVER treat a runtime-derived eligibility or risk classification, such as
+    an autonomy overlay's per-menu eligibility check, as a declaration; only
+    a literal type named in the gate's own MENU block qualifies for the
+    carve-out above.
   ALWAYS while a workflow, gate, or menu remains active, treat each new user
     message as input to that active continuation, not as permission for
     unrelated execution.

--- a/skills/studio/modules/runtime/pdsl-execution-card.md
+++ b/skills/studio/modules/runtime/pdsl-execution-card.md
@@ -53,4 +53,13 @@ RULES:
     obligations unless an active rule references them.
   NEVER weaken `ALWAYS`, `NEVER`, `REQUIRE`, `WAIT`, `STOP_TURN`, or
     `INVARIANTS` because nearby prose sounds softer.
+NOTES:
+  No core module declares a gate `TYPE` or resolves a gate from one today —
+  see `architecture/specs/PDSL.md` and `cpt-studio-adr-autonomous-default-and-gate-risk`
+  (ADR-0023). This carve-out only removes the prohibition against such
+  resolution once it exists; it does not itself define or implement how a
+  gate is resolved from its declared type.
+  The identical carve-out is restated for workflow-state law in
+  `runtime/active-workflow-state-law.md`; keep both definitions in sync if
+  this one changes.
 ```

--- a/tests/test_pdsl_keywords.py
+++ b/tests/test_pdsl_keywords.py
@@ -564,6 +564,37 @@ def test_pdsl_workflows_load_execution_card_during_bootstrap() -> None:
     assert not failures, "\n".join(failures)
 
 
+def test_mode_change_trigger_is_disjoint_from_brave_new_world_phrases() -> None:
+    """ADR-0023 prerequisite 1: the declared mode-change trigger set must
+    never overlap the Brave New World overlay's open-ended activation
+    phrases, or a user saying one could be silently read as the other.
+    """
+    simple_mode_text = (REPO_ROOT / "skills/studio/modules/gates/simple-mode.md").read_text()
+    bnw_text = (REPO_ROOT / "workflows/brave-new-world.md").read_text()
+
+    trigger = "change mode"
+    assert f'"{trigger}"' in simple_mode_text, (
+        "Expected the literal mode-change trigger phrase to still be declared "
+        "in gates/simple-mode.md; update this test if the wording changed."
+    )
+
+    activation_line = next(
+        (line for line in bnw_text.splitlines() if "ALWAYS resolve semantically equivalent phrases" in line),
+        None,
+    )
+    assert activation_line is not None, (
+        "Expected to find BraveNewWorldActivate's activation-phrase rule in "
+        "workflows/brave-new-world.md; update this test if the wording moved."
+    )
+    bnw_phrases = re.findall(r"'([^']+)'", activation_line)
+    assert bnw_phrases, "Expected quoted activation phrases on that rule line"
+
+    assert trigger not in bnw_phrases, (
+        f"Mode-change trigger {trigger!r} collides with a Brave New World "
+        "activation phrase; ADR-0023 requires these trigger sets to be disjoint."
+    )
+
+
 def test_named_pdsl_units_and_menus_are_not_exact_duplicates() -> None:
     """Exact duplicate named PDSL blocks should be defined once and loaded."""
     blocks_by_body: dict[str, list[str]] = defaultdict(list)

--- a/tests/test_pdsl_keywords.py
+++ b/tests/test_pdsl_keywords.py
@@ -568,9 +568,17 @@ def test_mode_change_trigger_is_disjoint_from_brave_new_world_phrases() -> None:
     """ADR-0023 prerequisite 1: the declared mode-change trigger set must
     never overlap the Brave New World overlay's open-ended activation
     phrases, or a user saying one could be silently read as the other.
+
+    Checked case-insensitively and for substring/superset overlap in either
+    direction, not just exact list membership -- SimpleModeChangeTrigger's own
+    contract rejects "a paraphrase, synonym, punctuation-padded variant, or
+    superset phrase", so this test rejects the same shapes of collision. The
+    activation-phrase and exclusion lines are both read only from inside
+    BraveNewWorldActivate's own PDSL block, not a flat file-wide scan.
     """
-    simple_mode_text = (REPO_ROOT / "skills/studio/modules/gates/simple-mode.md").read_text()
-    bnw_text = (REPO_ROOT / "workflows/brave-new-world.md").read_text()
+    simple_mode_path = REPO_ROOT / "skills/studio/modules/gates/simple-mode.md"
+    bnw_path = REPO_ROOT / "workflows/brave-new-world.md"
+    simple_mode_text = simple_mode_path.read_text()
 
     trigger = "change mode"
     assert f'"{trigger}"' in simple_mode_text, (
@@ -578,20 +586,124 @@ def test_mode_change_trigger_is_disjoint_from_brave_new_world_phrases() -> None:
         "in gates/simple-mode.md; update this test if the wording changed."
     )
 
+    bnw_activate_block = next(
+        (
+            block for _, block in _iter_pdsl_blocks(bnw_path)
+            if block and block[0].strip() == "UNIT BraveNewWorldActivate"
+        ),
+        None,
+    )
+    assert bnw_activate_block is not None, (
+        "Expected a UNIT BraveNewWorldActivate PDSL block in "
+        "workflows/brave-new-world.md; update this test if it moved or was renamed."
+    )
+
     activation_line = next(
-        (line for line in bnw_text.splitlines() if "ALWAYS resolve semantically equivalent phrases" in line),
+        (line for line in bnw_activate_block if "ALWAYS resolve semantically equivalent phrases" in line),
         None,
     )
     assert activation_line is not None, (
-        "Expected to find BraveNewWorldActivate's activation-phrase rule in "
-        "workflows/brave-new-world.md; update this test if the wording moved."
+        "Expected BraveNewWorldActivate's activation-phrase rule inside its own "
+        "block; update this test if the wording moved."
     )
-    bnw_phrases = re.findall(r"'([^']+)'", activation_line)
+    bnw_phrases = [phrase.lower() for phrase in re.findall(r"'([^']+)'", activation_line)]
     assert bnw_phrases, "Expected quoted activation phrases on that rule line"
 
-    assert trigger not in bnw_phrases, (
-        f"Mode-change trigger {trigger!r} collides with a Brave New World "
-        "activation phrase; ADR-0023 requires these trigger sets to be disjoint."
+    exclusion_line = next(
+        (
+            line for line in bnw_activate_block
+            if "NEVER treat the exact phrase" in line and trigger in line.lower()
+        ),
+        None,
+    )
+    assert exclusion_line is not None, (
+        "Expected an explicit NEVER rule in BraveNewWorldActivate excluding the "
+        "literal mode-change trigger phrase from BNW activation; update this "
+        "test if that exclusion moved or was reworded."
+    )
+
+    for phrase in bnw_phrases:
+        assert trigger != phrase, (
+            f"Mode-change trigger {trigger!r} exactly matches a BNW activation phrase {phrase!r}."
+        )
+        assert trigger not in phrase, (
+            f"Mode-change trigger {trigger!r} is a substring of BNW phrase {phrase!r}; "
+            "ADR-0023 requires these trigger sets to be disjoint, including supersets."
+        )
+        assert phrase not in trigger, (
+            f"BNW phrase {phrase!r} is a substring of the mode-change trigger {trigger!r}."
+        )
+
+
+def test_declared_gate_type_carveout_is_defined_once_and_cross_referenced() -> None:
+    """The declared mode/gate-type carve-out is defined canonically in
+    pdsl-execution-card.md; active-workflow-state-law.md must reference that
+    definition rather than silently restate it, so the two wordings can't
+    drift apart unnoticed (PR #162 review finding).
+    """
+    card_text = (REPO_ROOT / "skills/studio/modules/runtime/pdsl-execution-card.md").read_text()
+    law_text = (REPO_ROOT / "skills/studio/modules/runtime/active-workflow-state-law.md").read_text()
+
+    assert "a gate's declared risk type" in card_text
+    assert "NEVER treat a runtime-derived eligibility or risk classification" in card_text
+    assert "cpt-studio-adr-autonomous-default-and-gate-risk" in card_text, (
+        "Expected the carve-out's NOTES to cite ADR-0023, so a reader knows "
+        "this rule is a currently-inert prerequisite, not an implemented "
+        "resolution mechanism (PR #162 review finding)."
+    )
+    assert "restated for workflow-state law in\n  `runtime/active-workflow-state-law.md`" in card_text
+
+    assert (
+        "the canonical definition of that carve-out lives in `runtime/pdsl-execution-card.md`"
+        in law_text
+    ), (
+        "Expected active-workflow-state-law.md's declared-type carve-out to "
+        "cross-reference pdsl-execution-card.md rather than restate it with no link."
+    )
+
+
+def test_active_workflow_state_law_skip_audit_and_mode_persistence_rules_present() -> None:
+    """Regression lock for the normative additions to active-workflow-state-law.md
+    that otherwise had zero test coverage: the skip redefinition, the
+    audit-record requirement, and the mode-persistence rule -- which must both
+    name and actually dispatch to SimpleModeChangeTrigger, or the rule points
+    at a unit nothing ever reaches (PR #162 review findings).
+    """
+    law_text = (REPO_ROOT / "skills/studio/modules/runtime/active-workflow-state-law.md").read_text()
+
+    assert "A skip is bypassing a gate without a resolution" in law_text
+    assert "permitted by its statically declared type" in law_text
+    assert "ALWAYS produce the required audit record for every permitted autonomous" in law_text
+    assert "NEVER treat a reply as a mode reset" in law_text
+    assert "SimpleModeChangeTrigger" in law_text, (
+        "Expected the mode-persistence rule to name SimpleModeChangeTrigger "
+        "specifically (not the SimpleModeChoice menu) -- that unit is what "
+        "actually implements the declared trigger set."
+    )
+    assert "RUN SimpleModeChangeTrigger from `gates/simple-mode.md`" in law_text, (
+        "Expected the message-mapping rule to explicitly dispatch to "
+        "SimpleModeChangeTrigger; otherwise it is declared but unreachable "
+        "from any active workflow state (PR #162 review finding)."
+    )
+
+
+def test_simple_mode_change_trigger_contract_is_fully_declared() -> None:
+    """Regression lock for SimpleModeChangeTrigger's full matching contract --
+    exact match, ASCII case-folding, whitespace trimming, and rejection of
+    paraphrases/synonyms/superset phrases -- not just its trigger phrase
+    (PR #162 review finding: the prior test covered only BNW disjointness).
+    """
+    simple_mode_text = (REPO_ROOT / "skills/studio/modules/gates/simple-mode.md").read_text()
+
+    unit_start = simple_mode_text.index("UNIT SimpleModeChangeTrigger")
+    unit_text = simple_mode_text[unit_start:]
+
+    assert "folding ASCII case" in unit_text
+    assert "trimming leading/trailing whitespace" in unit_text
+    assert "not a paraphrase, synonym, punctuation-padded variant, or superset phrase" in unit_text
+    assert (
+        "NEVER treat semantically similar phrases, synonyms, or partial matches as satisfying it"
+        in unit_text
     )
 
 

--- a/workflows/brave-new-world.md
+++ b/workflows/brave-new-world.md
@@ -40,6 +40,7 @@ RULES:
   ALWAYS keep all current and future underlying rules, prerequisites, menus, waits, hard stops, validation gates, and terminal shapes active, while allowing this overlay to answer eligible menus and questions by selecting one valid original option
   ALWAYS keep BRAVE_NEW_WORLD_DECISION_LOG append-only for the session across disable and re-enable cycles
   ALWAYS resolve semantically equivalent phrases such as 'stop asking me', 'auto mode', 'autonomous', 'fewer questions', 'less interruptions' as BNW activation when context is unambiguous
+  NEVER treat the exact phrase 'change mode' as BNW activation, semantically equivalent or otherwise; that phrase is reserved exclusively for `gates/simple-mode.md`'s SimpleModeChangeTrigger, and the semantic-equivalence rule above never claims it
   NEVER start substantive task work merely because this overlay was enabled
   NEVER require `cf` or `CFS_INIT == true` merely to enable or disable this overlay
 ```


### PR DESCRIPTION
Closes #148.

`pdsl-execution-card.md:28-33` and `active-workflow-state-law.md:7,9,12` correctly
restrict Studio from reinterpreting a user's reply as broad permission -- but as
worded they also catch Studio auto-proceeding a gate the workflow itself typed
(the `TYPE` declaration #153 added) under a session mode the user chose. Neither
law was written with a declared gate type in mind, so this was blocking the
typed-gate work from being relied on.

## What this adds

**`runtime/pdsl-execution-card.md`** -- a session's declared mode and a gate's
declared `TYPE` (the literal token in that gate's own `MENU` block) are
workflow-owned behaviour, not an interpretation of the user's reply. Explicitly
excludes runtime-derived classifications -- e.g. Brave New World's
`classification_status`, which is computed per-menu at runtime and by design
carries no declared marking -- from qualifying for this carve-out.

**`runtime/active-workflow-state-law.md`**:
- resolving a gate by its declared type is workflow-owned behaviour, not
  ad-hoc interpretation
- splits the "skip" definition into two independently-tested invariants:
  no unauthorised resolution, and no unrecorded autonomous resolution. Tying
  permission to whether the resolution was logged would let a logging failure
  retroactively reclassify a legitimate resolution as a forbidden skip.
- a reply is never a mode reset -- mode and typed-gate semantics persist
  across cancels, re-plans, and workflow transitions; only an explicit
  request matched against a declared, closed trigger set changes it

**`gates/simple-mode.md`** -- new `SimpleModeChangeTrigger` unit implementing
that trigger set: the literal phrase `"change mode"`, kept as its own unit
(rather than folded into `SimpleModeGate`) so it doesn't tip that gate over
its already-allowlisted `PDSL600`/`PDSL601` caps, and rides on the existing
`WorkflowBootstrapSimpleModeGate` load with no changes to `workflow-bootstrap.md`.

**`tests/test_pdsl_keywords.py`** -- regression test asserting the mode-change
trigger phrase stays disjoint from Brave New World's open-ended activation
phrase list (`stop asking me`, `auto mode`, `autonomous`, ...), so a future
edit to either list can't silently collide.

## Verification

- `pdsl validate` on all three edited runtime/gate files: only the
  pre-existing, already-allowlisted `PDSL601`/`PDSL600` findings tracked in
  #87 -- nothing new.
- `tests/test_pdsl_keywords.py`: 14/14 passed, including the new test.
- `tests/test_workflow_subagents_dispatch.py` + `tests/test_pdsl_validate_cli.py`
  (the other files referencing these symbols): 157 passed, 15 xfailed.
- Full suite: 5,626 passed. Two unrelated pre-existing failures reproduced
  identically on `main` before this change (confirmed via `git stash`):
  a macOS/APFS filename-encoding limitation in
  `test_change_summary_links.py` and a semantic-overlap scoring assertion in
  `test_eval_semantic.py`. Neither touches PDSL/gate code; left out of scope
  here, same as #159 was filed separately from PR #151 rather than bundled in.

## Sequencing

Landed after both dependencies this issue names as blocking merged: #151
(ADR-0023, merged as 81b8183d) and #153/#152 (the `TYPE` validator, merged as
3cb9b18a). This closes ADR-0023's prerequisites 1 and 2; prerequisites 3
(the approved keyed source for `decision` gates) and 4 (the write path to
`record()`) remain open and are untouched by this change -- nothing here
flips runtime behaviour.