### PR TITLE
refactor(traceability): extract the shared cpt-id def↔ref scan into a util

### DIFF
--- a/architecture/features/traceability-validation.md
+++ b/architecture/features/traceability-validation.md
@@ -13,6 +13,7 @@
   - [Query Traceability](#query-traceability)
 - [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
   - [Scan Artifact IDs](#scan-artifact-ids)
+  - [CPT Reference Scan](#cpt-reference-scan)
   - [Scan CDSL Instructions](#scan-cdsl-instructions)
   - [Validate Artifact Structure](#validate-artifact-structure)
   - [Cross-Validate Artifacts](#cross-validate-artifacts)
@@ -227,6 +228,25 @@ Catches structural and traceability issues that AI agents miss or hallucinate �
 - [x] - `p1` - Content scoped extraction: hash-fence blocks, heading scopes, ID-definition scopes - `inst-scan-ids-get-content`
 - [x] - `p1` - File I/O utilities: safe text reader, text file iterator, relative path converter - `inst-scan-ids-file-utils`
 - [x] - `p1` - Wrapper function for `parse_cpt` identifier parser - `inst-parse-cpt-fn`
+
+### CPT Reference Scan
+
+- [x] `p1` - **ID**: `cpt-studio-algo-cpt-reference-scan`
+
+**Input**: Artifacts to scan `[(path, artifact_type)]`, a target `cpt-id`, and a path→source map
+
+**Output**: Reference records `{artifact, artifact_type, line, kind, type, checked, source?}` (definition records omit `type`; `kind` is always `null` here — callers infer and fill it), or a def↔ref graph `{defined_in, referenced_in}`
+
+**Scope**: `cpt-*` identifiers only — `PRD-NNN` requirement references are out of scope (a documented v1 limit), the same scope as `where-used` / `where-defined`. The def↔ref graph is assembled from two independent scans (one per side), so `defined_in` and `referenced_in` carry no cross-list atomicity guarantee; a caller that needs many ids should build a single scan pass and partition it locally rather than call the graph per id.
+
+**Steps**:
+1. [x] - `p1` - Iterate every `scan_cpt_ids` hit across the artifacts, yielding it with its artifact context — the shared scan the query commands reuse - `inst-scan-records`
+2. [x] - `p1` - Project the scan into references to a target id, optionally including its definitions - `inst-references`
+3. [x] - `p1` - Project the scan into a target id's definitions only - `inst-definitions`
+4. [x] - `p1` - Assemble a cpt-id's def↔ref graph view (`defined_in` / `referenced_in`) for the artifact-quality detectors - `inst-graph-for`
+
+**Supporting**:
+- [x] - `p1` - The shared locus record both projections build — reference records carry `type`, definitions omit it - `inst-record`
 
 ### Scan CDSL Instructions
 
@@ -831,6 +851,7 @@ The system **MUST** provide CLI commands for navigating the ID graph: `list-ids 
 **Implements**:
 - `cpt-studio-flow-traceability-validation-query`
 - `cpt-studio-algo-traceability-validation-scan-ids`
+- `cpt-studio-algo-cpt-reference-scan`
 
 **Covers (PRD)**:
 - `cpt-studio-fr-core-traceability`
@@ -867,6 +888,7 @@ The system **MUST** scan CDSL instruction markers (`inst-{slug}` suffixes in num
 | Where Defined | `skills/.../commands/where_defined.py` | Find where an ID is defined |
 | Where Used | `skills/.../commands/where_used.py` | Find all references to an ID |
 | Document Utils | `skills/.../utils/document.py` | ID scanning, CDSL instruction scanning |
+| CPT Reference Scan | `skills/.../utils/cpt_reference_scan.py` | Shared cpt-id def↔ref scan for the query commands; def↔ref graph view for the artifact-quality detectors |
 | Constraints Utils | `skills/.../utils/constraints.py` | Constraint loading, heading validation, cross-validation |
 | Codebase Utils | `skills/.../utils/codebase.py` | Code file scanning, `@cpt-*` marker validation |
 | Error Codes | `skills/.../utils/error_codes.py` | Stable error codes for validation issues |

--- a/skills/studio/scripts/studio/commands/list_id_kinds.py
+++ b/skills/studio/scripts/studio/commands/list_id_kinds.py
@@ -10,7 +10,7 @@ import argparse
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
-from ..utils.document import scan_cpt_ids
+from ..utils import cpt_reference_scan
 from ..utils.ui import ui
 from .list_ids import (
     _collect_known_kinds,
@@ -62,19 +62,18 @@ def _collect_kind_maps(
     kind_to_templates: Dict[str, Set[str]] = {}
     kind_counts: Dict[str, int] = {}
 
-    for artifact_path, artifact_type in artifacts_to_scan:
-        for hit in scan_cpt_ids(artifact_path):
-            if hit.get("type") != "definition":
-                continue
-            cpt_id = str(hit.get("id") or "").strip()
-            if not cpt_id:
-                continue
-            # @cpt-begin:cpt-studio-algo-traceability-validation-list-id-kinds:p1:inst-kinds-aggregate
-            for kind_name in _infer_kinds(cpt_id, registered_systems, known_kinds):
-                kind_to_templates.setdefault(kind_name, set()).add(artifact_type)
-                template_to_kinds.setdefault(artifact_type, set()).add(kind_name)
-                kind_counts[kind_name] = kind_counts.get(kind_name, 0) + 1
-            # @cpt-end:cpt-studio-algo-traceability-validation-list-id-kinds:p1:inst-kinds-aggregate
+    for _artifact_path, artifact_type, hit in cpt_reference_scan.scan_records(artifacts_to_scan):
+        if hit.get("type") != "definition":
+            continue
+        cpt_id = str(hit.get("id") or "").strip()
+        if not cpt_id:
+            continue
+        # @cpt-begin:cpt-studio-algo-traceability-validation-list-id-kinds:p1:inst-kinds-aggregate
+        for kind_name in _infer_kinds(cpt_id, registered_systems, known_kinds):
+            kind_to_templates.setdefault(kind_name, set()).add(artifact_type)
+            template_to_kinds.setdefault(artifact_type, set()).add(kind_name)
+            kind_counts[kind_name] = kind_counts.get(kind_name, 0) + 1
+        # @cpt-end:cpt-studio-algo-traceability-validation-list-id-kinds:p1:inst-kinds-aggregate
     return template_to_kinds, kind_to_templates, kind_counts
 # @cpt-end:cpt-studio-algo-traceability-validation-list-id-kinds:p1:inst-kinds-scan-ids
 

--- a/skills/studio/scripts/studio/commands/list_ids.py
+++ b/skills/studio/scripts/studio/commands/list_ids.py
@@ -7,8 +7,8 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 
+from ..utils import cpt_reference_scan
 from ..utils.codebase import scan_registered_codebase_references
-from ..utils.document import scan_cpt_ids
 from ..utils.ui import ui
 # @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-query-imports
 
@@ -211,23 +211,22 @@ def _collect_artifact_hits(
     """Scan artifact IDs and annotate each hit with inferred kind metadata."""
     # @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-scan-all
     hits: List[Dict[str, object]] = []
-    for artifact_path, artifact_type in artifacts_to_scan:
-        for fh in scan_cpt_ids(artifact_path):
-            cid = str(fh.get("id") or "").strip()
-            if not cid:
-                continue
-            hit: Dict[str, object] = {
-                "id": cid,
-                "kind": _infer_primary_kind(cid, registered_systems, known_kinds),
-                "type": fh.get("type"),
-                "artifact_type": artifact_type,
-                "line": fh.get("line"),
-                "artifact": str(artifact_path),
-                "checked": bool(fh.get("checked", False)),
-            }
-            if fh.get("priority") is not None:
-                hit["priority"] = fh.get("priority")
-            hits.append(hit)
+    for artifact_path, artifact_type, fh in cpt_reference_scan.scan_records(artifacts_to_scan):
+        cid = str(fh.get("id") or "").strip()
+        if not cid:
+            continue
+        hit: Dict[str, object] = {
+            "id": cid,
+            "kind": _infer_primary_kind(cid, registered_systems, known_kinds),
+            "type": fh.get("type"),
+            "artifact_type": artifact_type,
+            "line": fh.get("line"),
+            "artifact": str(artifact_path),
+            "checked": bool(fh.get("checked", False)),
+        }
+        if fh.get("priority") is not None:
+            hit["priority"] = fh.get("priority")
+        hits.append(hit)
     return hits
     # @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-scan-all
 

--- a/skills/studio/scripts/studio/commands/where_defined.py
+++ b/skills/studio/scripts/studio/commands/where_defined.py
@@ -2,10 +2,10 @@
 
 # @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-query-imports
 import argparse
-from typing import Dict, List
+from typing import List
 
+from ..utils import cpt_reference_scan
 from ..utils.context import resolve_target_and_artifacts
-from ..utils.document import scan_cpt_ids
 from ..utils.ui import ui
 # @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-query-imports
 
@@ -35,25 +35,7 @@ def cmd_where_defined(argv: List[str]) -> int:
     # @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-if-where-def
 
     # Search for definitions
-    definitions: List[Dict[str, object]] = []
-
-    for artifact_path, artifact_type in artifacts_to_scan:
-        for h in scan_cpt_ids(artifact_path):
-            if h.get("type") != "definition":
-                continue
-            if str(h.get("id") or "") != target_id:
-                continue
-            d: Dict[str, object] = {
-                "artifact": str(artifact_path),
-                "artifact_type": artifact_type,
-                "line": int(h.get("line", 1) or 1),
-                "kind": None,
-                "checked": bool(h.get("checked", False)),
-            }
-            src = path_to_source.get(str(artifact_path))
-            if src:
-                d["source"] = src
-            definitions.append(d)
+    definitions = cpt_reference_scan.definitions(target_id, artifacts_to_scan, path_to_source)
 
     if not definitions:
         ui.result(

--- a/skills/studio/scripts/studio/commands/where_used.py
+++ b/skills/studio/scripts/studio/commands/where_used.py
@@ -4,42 +4,13 @@
 import argparse
 from typing import Dict, List, Tuple
 
+from ..utils import cpt_reference_scan
 from ..utils.codebase import scan_registered_codebase_references
 from ..utils.context import resolve_target_and_artifacts
-from ..utils.document import scan_cpt_ids
 from ..utils.ui import ui
 # @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-query-imports
 
 # @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-if-where-used
-def _collect_artifact_references(
-    artifacts_to_scan,
-    target_id: str,
-    include_definitions: bool,
-    path_to_source: Dict[str, str],
-) -> List[Dict[str, object]]:
-    """Scan artifacts for references to *target_id*."""
-    references: List[Dict[str, object]] = []
-    for artifact_path, artifact_type in artifacts_to_scan:
-        for h in scan_cpt_ids(artifact_path):
-            if str(h.get("id") or "") != target_id:
-                continue
-            if h.get("type") == "definition" and not include_definitions:
-                continue
-            r: Dict[str, object] = {
-                "artifact": str(artifact_path),
-                "artifact_type": artifact_type,
-                "line": int(h.get("line", 1) or 1),
-                "kind": None,
-                "type": str(h.get("type")),
-                "checked": bool(h.get("checked", False)),
-            }
-            src = path_to_source.get(str(artifact_path))
-            if src:
-                r["source"] = src
-            references.append(r)
-    return references
-
-
 def _collect_code_references(ctx, target_id: str) -> Tuple[List[Dict[str, object]], int, int]:
     """Scan registered codebase entries for references to *target_id*."""
     code_hits, code_files_scanned, code_files_skipped = scan_registered_codebase_references(ctx)
@@ -88,8 +59,9 @@ def cmd_where_used(argv: List[str]) -> int:
     # @cpt-end:cpt-studio-flow-traceability-validation-query:p1:inst-query-resolve
 
     # @cpt-begin:cpt-studio-flow-traceability-validation-query:p1:inst-if-where-used
-    references = _collect_artifact_references(
-        artifacts_to_scan, target_id, bool(args.include_definitions), path_to_source
+    references = cpt_reference_scan.references(
+        target_id, artifacts_to_scan, path_to_source,
+        include_definitions=bool(args.include_definitions),
     )
 
     code_files_scanned = 0

--- a/skills/studio/scripts/studio/utils/cpt_reference_scan.py
+++ b/skills/studio/scripts/studio/utils/cpt_reference_scan.py
@@ -1,0 +1,145 @@
+"""Shared cpt-id reference scan.
+
+The one ``scan_cpt_ids`` traversal that ``where_used``, ``where_defined``,
+``list_ids`` and ``list_id_kinds`` each re-implemented, plus the def↔ref view the
+artifact-quality gap / traceability / contradiction detectors build on. cpt-id
+scoped — prose / ``PRD-NNN`` requirements are out of scope (a documented v1 limit).
+
+Read-only, stdlib-only. Behaviour is identical to the loops it replaces; the
+callers keep their own projections.
+
+@cpt-algo:cpt-studio-algo-cpt-reference-scan:p1
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+from .document import scan_cpt_ids
+
+
+# @cpt-begin:cpt-studio-algo-cpt-reference-scan:p1:inst-scan-records
+def scan_records(
+    artifacts_to_scan: List[Tuple[Path, str]],
+) -> Iterator[Tuple[Path, str, Dict[str, object]]]:
+    """Yield ``(artifact_path, artifact_type, hit)`` for every ``scan_cpt_ids``
+    hit across *artifacts_to_scan* — the doubled loop the callers shared.
+
+    The raw hit is passed through untouched so each caller keeps its exact
+    projection (id-strip, line coercion, kind inference, def/ref filtering).
+    """
+    for artifact_path, artifact_type in artifacts_to_scan:
+        for hit in scan_cpt_ids(artifact_path):
+            yield artifact_path, artifact_type, hit
+# @cpt-end:cpt-studio-algo-cpt-reference-scan:p1:inst-scan-records
+
+
+# @cpt-begin:cpt-studio-algo-cpt-reference-scan:p1:inst-record
+def _record(
+    artifact_path: Path,
+    artifact_type: str,
+    hit: Dict[str, object],
+    path_to_source: Dict[str, str],
+    *,
+    include_type: bool,
+) -> Dict[str, object]:
+    """One locus record, shared by the reference and definition projections.
+
+    ``include_type`` adds the ``type`` key (references carry it; definitions omit
+    it) in its historical position — between ``kind`` and ``checked`` — so the
+    emitted dict is byte-for-byte what the commands produced before this util.
+    """
+    rec: Dict[str, object] = {
+        "artifact": str(artifact_path),
+        "artifact_type": artifact_type,
+        "line": int(hit.get("line", 1) or 1),
+        "kind": None,
+    }
+    if include_type:
+        rec["type"] = str(hit.get("type"))
+    rec["checked"] = bool(hit.get("checked", False))
+    src = path_to_source.get(str(artifact_path))
+    if src:
+        rec["source"] = src
+    return rec
+# @cpt-end:cpt-studio-algo-cpt-reference-scan:p1:inst-record
+
+
+# @cpt-begin:cpt-studio-algo-cpt-reference-scan:p1:inst-references
+def references(
+    target_id: str,
+    artifacts_to_scan: List[Tuple[Path, str]],
+    path_to_source: Dict[str, str],
+    *,
+    include_definitions: bool,
+) -> List[Dict[str, object]]:
+    """References to *target_id* (optionally including its definitions).
+
+    The ``where_used`` projection, verbatim: a reference hit whose id matches,
+    with its type; definition hits included only when *include_definitions*.
+    """
+    out: List[Dict[str, object]] = []
+    for artifact_path, artifact_type, h in scan_records(artifacts_to_scan):
+        if str(h.get("id") or "") != target_id:
+            continue
+        if h.get("type") == "definition" and not include_definitions:
+            continue
+        out.append(_record(artifact_path, artifact_type, h, path_to_source, include_type=True))
+    return out
+# @cpt-end:cpt-studio-algo-cpt-reference-scan:p1:inst-references
+
+
+# @cpt-begin:cpt-studio-algo-cpt-reference-scan:p1:inst-definitions
+def definitions(
+    target_id: str,
+    artifacts_to_scan: List[Tuple[Path, str]],
+    path_to_source: Dict[str, str],
+) -> List[Dict[str, object]]:
+    """Definitions of *target_id* — the ``where_defined`` projection, verbatim
+    (no ``type`` key; ``kind`` left ``None`` for the caller to annotate)."""
+    out: List[Dict[str, object]] = []
+    for artifact_path, artifact_type, h in scan_records(artifacts_to_scan):
+        if h.get("type") != "definition":
+            continue
+        if str(h.get("id") or "") != target_id:
+            continue
+        out.append(_record(artifact_path, artifact_type, h, path_to_source, include_type=False))
+    return out
+# @cpt-end:cpt-studio-algo-cpt-reference-scan:p1:inst-definitions
+
+
+# @cpt-begin:cpt-studio-algo-cpt-reference-scan:p1:inst-graph-for
+def graph_for(
+    target_id: str,
+    artifacts_to_scan: List[Tuple[Path, str]],
+    path_to_source: Optional[Dict[str, str]] = None,
+) -> Dict[str, List[Dict[str, object]]]:
+    """The def↔ref view a detector wants for one cpt-id: where it is defined and
+    where it is referenced.
+
+    ``defined_in`` is the definition loci (no ``type`` key); ``referenced_in`` is the
+    non-definition reference loci (each with its ``type``). Built with the same
+    ``references`` / ``definitions`` logic the query commands use, so it classifies
+    definitions and references identically to them.
+
+    Two-pass by construction: ``defined_in`` and ``referenced_in`` come from two
+    independent ``scan_records`` passes, so they are computed separately — do not rely
+    on cross-list atomicity between them. That is fine for one id while the view is
+    unused, but a caller that needs many ids must NOT call ``graph_for`` per id in a
+    loop — that is ``O(n_ids × n_artifacts)`` rescans of the whole tree. Build a single
+    ``scan_records`` pass and partition it locally instead.
+
+    ``path_to_source`` is optional here — a detector usually wants only the def/ref
+    loci, not source text — whereas ``references`` / ``definitions`` require it, since
+    every command call site has the map. Requiring it there is deliberate: a missing
+    map at those call sites is a bug we want surfaced, not silently defaulted. Passing
+    ``None`` is equivalent to an empty map (no ``source`` keys emitted).
+    """
+    src = path_to_source or {}
+    return {
+        "defined_in": definitions(target_id, artifacts_to_scan, src),
+        "referenced_in": references(
+            target_id, artifacts_to_scan, src, include_definitions=False
+        ),
+    }
+# @cpt-end:cpt-studio-algo-cpt-reference-scan:p1:inst-graph-for

--- a/tests/test_cli_py_coverage.py
+++ b/tests/test_cli_py_coverage.py
@@ -2648,7 +2648,7 @@ class TestCLIPyCoverageListIdsBranches(unittest.TestCase):
                         {"id": "cpt-test-req-1", "type": "definition", "line": 2},
                     ]
                 buf = io.StringIO()
-                with patch("studio.commands.list_ids.scan_cpt_ids", side_effect=fake_scan):
+                with patch("studio.utils.cpt_reference_scan.scan_cpt_ids", side_effect=fake_scan):
                     with redirect_stdout(buf):
                         rc = main(["list-ids"])
                 self.assertEqual(rc, 0)

--- a/tests/test_cpt_reference_scan.py
+++ b/tests/test_cpt_reference_scan.py
@@ -1,0 +1,200 @@
+"""Tests for utils/cpt_reference_scan — the shared cpt-id def↔ref scan.
+
+The four commands' golden tests already prove behaviour-identity; these pin the
+util's own contract: the projections, the def↔ref graph view, and that it adds no
+new error-swallowing over scan_cpt_ids.
+"""
+import random
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from studio.utils import cpt_reference_scan as scan
+
+
+def _arts(*names):
+    return [(Path(n), "REQUIREMENTS") for n in names]
+
+
+def _hits(*specs):  # spec: (id, type, line, checked)
+    return [{"id": i, "type": t, "line": ln, "checked": c} for (i, t, ln, c) in specs]
+
+
+# ---------------------------------------------------------------- scan_records
+def test_scan_records_yields_every_hit_with_artifact_context():
+    per = {Path("a.md"): _hits(("cpt-x-req-1", "reference", 3, False)),
+           Path("b.md"): _hits(("cpt-x-req-1", "definition", 1, False),
+                                ("cpt-x-req-2", "reference", 5, False))}
+    with patch.object(scan, "scan_cpt_ids", side_effect=lambda p: per[p]):
+        recs = list(scan.scan_records(_arts("a.md", "b.md")))
+    assert [(str(p), t, h["id"]) for p, t, h in recs] == [
+        ("a.md", "REQUIREMENTS", "cpt-x-req-1"),
+        ("b.md", "REQUIREMENTS", "cpt-x-req-1"),
+        ("b.md", "REQUIREMENTS", "cpt-x-req-2"),
+    ]
+
+
+# ------------------------------------------------------------------ references
+def test_references_filter_target_exclude_definitions_by_default():
+    hits = _hits(("cpt-x-req-1", "definition", 1, False),
+                 ("cpt-x-req-1", "reference", 4, True),
+                 ("cpt-x-req-2", "reference", 7, False))
+    with patch.object(scan, "scan_cpt_ids", return_value=hits):
+        refs = scan.references("cpt-x-req-1", _arts("a.md"), {}, include_definitions=False)
+    assert refs == [{"artifact": "a.md", "artifact_type": "REQUIREMENTS", "line": 4,
+                     "kind": None, "type": "reference", "checked": True}]
+
+
+def test_references_include_definitions_and_attach_source():
+    hits = _hits(("cpt-x-req-1", "definition", 1, False), ("cpt-x-req-1", "reference", 4, False))
+    with patch.object(scan, "scan_cpt_ids", return_value=hits):
+        refs = scan.references("cpt-x-req-1", _arts("a.md"), {"a.md": "SRC"},
+                               include_definitions=True)
+    assert [r["type"] for r in refs] == ["definition", "reference"]
+    assert all(r["source"] == "SRC" for r in refs)
+
+
+# ----------------------------------------------------------------- definitions
+def test_definitions_are_definition_only_and_omit_the_type_key():
+    hits = _hits(("cpt-x-req-1", "definition", 1, False),
+                 ("cpt-x-req-1", "reference", 4, False),
+                 ("cpt-x-req-2", "definition", 9, False))
+    with patch.object(scan, "scan_cpt_ids", return_value=hits):
+        defs = scan.definitions("cpt-x-req-1", _arts("a.md"), {})
+    assert defs == [{"artifact": "a.md", "artifact_type": "REQUIREMENTS", "line": 1,
+                     "kind": None, "checked": False}]
+    assert "type" not in defs[0]
+
+
+def test_definitions_attach_source_when_present():
+    hits = _hits(("cpt-x-req-1", "definition", 2, False))
+    with patch.object(scan, "scan_cpt_ids", return_value=hits):
+        defs = scan.definitions("cpt-x-req-1", _arts("a.md"), {"a.md": "SRC"})
+    assert defs[0]["source"] == "SRC"
+
+
+def test_empty_artifacts_yield_empty_everywhere():
+    # §3a edge / empty state: no artifacts → empty across every view; scan_cpt_ids never called.
+    assert list(scan.scan_records([])) == []
+    assert scan.references("cpt-x-req-1", [], {}, include_definitions=True) == []
+    assert scan.definitions("cpt-x-req-1", [], {}) == []
+    assert scan.graph_for("cpt-x-req-1", []) == {"defined_in": [], "referenced_in": []}
+
+
+def test_non_ascii_artifact_path_passes_through_unchanged():
+    # A4: paths are stringified, not normalised — a non-ASCII path must survive verbatim.
+    hits = _hits(("cpt-x-req-1", "reference", 2, False))
+    with patch.object(scan, "scan_cpt_ids", return_value=hits):
+        refs = scan.references("cpt-x-req-1", [(Path("café/交/x.md"), "REQUIREMENTS")], {},
+                               include_definitions=True)
+    assert refs[0]["artifact"] == "café/交/x.md"
+
+
+def test_unknown_id_yields_empty_for_both_views():
+    with patch.object(scan, "scan_cpt_ids",
+                      return_value=_hits(("cpt-x-req-1", "reference", 1, False))):
+        assert scan.references("cpt-x-nope", _arts("a.md"), {}, include_definitions=True) == []
+        assert scan.definitions("cpt-x-nope", _arts("a.md"), {}) == []
+
+
+# ------------------------------------------------------- graph_for (B4 parity)
+def test_graph_for_partitions_into_defs_and_refs_matching_the_views():
+    hits = _hits(("cpt-x-req-1", "definition", 1, False),
+                 ("cpt-x-req-1", "reference", 4, False),
+                 ("cpt-x-req-1", "reference", 9, False))
+    with patch.object(scan, "scan_cpt_ids", return_value=hits):
+        g = scan.graph_for("cpt-x-req-1", _arts("a.md"))
+        defs = scan.definitions("cpt-x-req-1", _arts("a.md"), {})
+        refs = scan.references("cpt-x-req-1", _arts("a.md"), {}, include_definitions=False)
+    assert g["defined_in"] == defs
+    assert g["referenced_in"] == refs
+    assert len(g["defined_in"]) == 1
+    assert len(g["referenced_in"]) == 2
+
+
+def test_graph_for_attaches_source_through_both_partitions():
+    hits = _hits(("cpt-x-req-1", "definition", 1, False), ("cpt-x-req-1", "reference", 4, False))
+    with patch.object(scan, "scan_cpt_ids", return_value=hits):
+        g = scan.graph_for("cpt-x-req-1", _arts("a.md"), {"a.md": "SRC"})
+    assert g["defined_in"][0]["source"] == "SRC"
+    assert g["referenced_in"][0]["source"] == "SRC"
+
+
+# ------------------------------------------- A1: adds no new error-swallowing
+def test_util_does_not_swallow_scan_errors():
+    with patch.object(scan, "scan_cpt_ids", side_effect=OSError("boom")):
+        records = scan.scan_records(_arts("a.md"))  # lazy — does not raise until iterated
+        with pytest.raises(OSError):
+            list(records)
+
+
+# --------------------------------------------------------- property (§3a)
+def test_property_references_typed_and_count_matches_target_hits():
+    rng = random.Random(1234)
+    ids = ["cpt-x-req-1", "cpt-x-req-2", "cpt-x-flow-a"]
+    for _ in range(400):
+        hits = [{"id": rng.choice(ids), "type": rng.choice(["definition", "reference"]),
+                 "line": rng.randint(1, 50), "checked": rng.choice([True, False])}
+                for _ in range(rng.randint(0, 6))]
+        target = rng.choice(ids)
+        with patch.object(scan, "scan_cpt_ids", return_value=hits):
+            refs = scan.references(target, _arts("a.md"), {}, include_definitions=True)
+            recs = list(scan.scan_records(_arts("a.md")))
+        assert all(r["type"] in ("definition", "reference") for r in refs)
+        assert len(refs) == sum(1 for h in hits if h["id"] == target)
+        assert len(recs) == len(hits)
+
+
+def test_property_definitions_and_graph_partition_the_target_scan():
+    rng = random.Random(99)
+    ids = ["cpt-x-req-1", "cpt-x-req-2", "cpt-x-flow-a"]
+    for _ in range(400):
+        hits = [{"id": rng.choice(ids), "type": rng.choice(["definition", "reference"]),
+                 "line": rng.randint(1, 50), "checked": rng.choice([True, False])}
+                for _ in range(rng.randint(0, 6))]
+        target = rng.choice(ids)
+        with patch.object(scan, "scan_cpt_ids", return_value=hits):
+            defs = scan.definitions(target, _arts("a.md"), {})
+            g = scan.graph_for(target, _arts("a.md"))
+        n_defs = sum(1 for h in hits if h["id"] == target and h["type"] == "definition")
+        n_refs = sum(1 for h in hits if h["id"] == target and h["type"] == "reference")
+        assert len(defs) == n_defs
+        assert all("type" not in d for d in defs)
+        assert len(g["defined_in"]) == n_defs
+        assert len(g["referenced_in"]) == n_refs
+
+
+@pytest.mark.parametrize("call", [
+    lambda: scan.references("cpt-x-req-1", _arts("a.md"), {}, include_definitions=True),
+    lambda: scan.definitions("cpt-x-req-1", _arts("a.md"), {}),
+    lambda: scan.graph_for("cpt-x-req-1", _arts("a.md")),
+])
+def test_no_projection_swallows_scan_errors(call):
+    # A1: every projection iterates scan_records eagerly, so a scan_cpt_ids error propagates.
+    with patch.object(scan, "scan_cpt_ids", side_effect=OSError("boom")):
+        with pytest.raises(OSError):
+            call()
+
+
+def test_source_attached_per_artifact_across_multiple_artifacts():
+    per = {Path("a.md"): _hits(("cpt-x-req-1", "reference", 1, False)),
+           Path("b.md"): _hits(("cpt-x-req-1", "reference", 2, False))}
+    arts = [(Path("a.md"), "REQUIREMENTS"), (Path("b.md"), "REQUIREMENTS")]
+    with patch.object(scan, "scan_cpt_ids", side_effect=lambda p: per[p]):
+        refs = scan.references("cpt-x-req-1", arts, {"a.md": "SRC_A", "b.md": "SRC_B"},
+                               include_definitions=True)
+    assert refs[0]["source"] == "SRC_A"
+    assert refs[1]["source"] == "SRC_B"
+
+
+def test_definitions_source_attached_per_artifact_across_multiple_artifacts():
+    # #5 mirror: definitions() shares _record with references(), but pin its per-artifact
+    # source mapping directly on the where_defined path too — not only via references().
+    per = {Path("a.md"): _hits(("cpt-x-req-1", "definition", 1, False)),
+           Path("b.md"): _hits(("cpt-x-req-1", "definition", 2, False))}
+    arts = [(Path("a.md"), "REQUIREMENTS"), (Path("b.md"), "REQUIREMENTS")]
+    with patch.object(scan, "scan_cpt_ids", side_effect=lambda p: per[p]):
+        defs = scan.definitions("cpt-x-req-1", arts, {"a.md": "SRC_A", "b.md": "SRC_B"})
+    assert defs[0]["source"] == "SRC_A"
+    assert defs[1]["source"] == "SRC_B"

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -186,3 +186,13 @@ RUN_UNATTRIBUTED  # noqa: B018
 # If a later refactor leaves one genuinely unused, delete its line rather than keep suppressing it.
 ArtifactFinding  # noqa: B018
 finding_json_schema  # noqa: B018
+
+# cpt_reference_scan.graph_for — the def↔ref graph view for the artifact-quality
+# gap / traceability / contradiction detectors (later tasks). The four query commands
+# consume references / definitions / scan_records now; graph_for is unreferenced until
+# the first detector imports it. REMOVAL TRIGGER — delete this entry once a detector
+# imports graph_for (i.e. once `cpt-studio-flow-artifact-quality-assess` is implemented
+# — grep that id in architecture/features/artifact-quality.md and check its `[ ]`→`[x]`).
+# The algo itself is declared in architecture/features/traceability-validation.md (### CPT Reference Scan).
+from studio.utils.cpt_reference_scan import graph_for  # noqa: E402
+graph_for  # noqa: B018


### PR DESCRIPTION
## What

Four query commands — `where-used`, `where-defined`, `list-ids`, `list-id-kinds` — each hand-rolled the same loop over `scan_cpt_ids`. This lifts that loop into a shared `utils/cpt_reference_scan.py` (`scan_records` + the target-filtered `references` / `definitions`, plus a `graph_for` def↔ref view) and routes all four through it.

**Behaviour is identical** — each command's output and its existing tests are unchanged.

## Why

`graph_for` is the def↔ref view a later gap / traceability / contradiction analysis will consume. It is unused today (whitelisted with a removal trigger), so this is a **genuine dedup of the four commands plus prep for that later work** — it does not dedupe or touch the semantic-quality feature, which has no traversal yet.

## Notes

- New `@cpt-algo:cpt-studio-algo-cpt-reference-scan` declared in `traceability-validation.md` (its current consumers, the query commands, live there); `cfs validate` resolves **0 errors**.
- Full suite green; the util is unit + property tested at 100% line coverage.
- Pre-commit adversarial review was scoped to three finders (behaviour-parity, util edge-cases, CPT/doc) for a behaviour-identical refactor, and converged to doc/test polish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CPT reference scanning for artifact IDs, including definitions, references, and relationship graph views.
  * Improved ID listing and kind discovery with more consistent scan results.
  * Enhanced “where defined” and “where used” queries with shared reference and definition data.
  * Preserved source locations, checked status, priorities, and optional definition inclusion.

* **Documentation**
  * Added the CPT Reference Scan process specification and updated related implementation references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->