### PR TITLE
feat(ui): make skill-invocation ASCII art default-off (#145)

### DIFF
--- a/schemas/core-config.schema.json
+++ b/schemas/core-config.schema.json
@@ -57,7 +57,7 @@
     },
     "ui": {
       "$ref": "#/$defs/ui",
-      "description": "Optional UI/output preferences for interactive skill and workflow runs."
+      "description": "Optional UI/output preferences for skill and workflow runs."
     }
   },
   "$defs": {

--- a/schemas/core-config.schema.json
+++ b/schemas/core-config.schema.json
@@ -54,6 +54,10 @@
     "paths": {
       "$ref": "#/$defs/paths",
       "description": "Optional path overrides for non-standard layouts."
+    },
+    "ui": {
+      "$ref": "#/$defs/ui",
+      "description": "Optional UI/output preferences for interactive skill and workflow runs."
     }
   },
   "$defs": {
@@ -197,6 +201,17 @@
           "type": "string",
           "minLength": 1,
           "description": "Relative path to the studio core directory. Used when the core is not at the default location."
+        }
+      }
+    },
+    "ui": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "skill_invocation_art_enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether to draw the decorative ASCII-art picture (plus label) at cf/cf-* skill and workflow entry. Default-off: the picture costs nothing unless explicitly enabled."
         }
       }
     }

--- a/skills/studio/modules/ui/skill-invocation-art.md
+++ b/skills/studio/modules/ui/skill-invocation-art.md
@@ -9,7 +9,7 @@ purpose: Defines SkillInvocationArt — the ASCII-art entry picture rendered at 
 
 ```pdsl
 UNIT SkillInvocationArt
-PURPOSE: When enabled via `[ui].skill_invocation_art_enabled` in `{cf-studio-path}/config/core.toml`, prefix each cf, cf-studio, or cf-* skill entry with one small ASCII-art picture relevant to the skill name, with a plain-text label below, without changing the workflow's control flow.
+PURPOSE: When enabled via `[ui].skill_invocation_art_enabled` in `{cf-studio-path}/config/core.toml`, prefix each cf, cf-studio, or cf-* skill or workflow entry with one small ASCII-art picture relevant to the entry name, with a plain-text label below, without changing the workflow's control flow.
 STATE:
   SET SKILL_INVOCATION_ART_ENABLED: true | false | unset (default unset, scope session)
 WHEN:

--- a/skills/studio/modules/ui/skill-invocation-art.md
+++ b/skills/studio/modules/ui/skill-invocation-art.md
@@ -9,7 +9,7 @@ purpose: Defines SkillInvocationArt — the ASCII-art entry picture rendered at 
 
 ```pdsl
 UNIT SkillInvocationArt
-PURPOSE: Prefix each cf, cf-studio, or cf-* skill entry with one small ASCII-art picture relevant to the skill name, with a plain-text label below, without changing the workflow's control flow.
+PURPOSE: When enabled via `[ui].skill_invocation_art_enabled` in `{cf-studio-path}/config/core.toml`, prefix each cf, cf-studio, or cf-* skill entry with one small ASCII-art picture relevant to the skill name, with a plain-text label below, without changing the workflow's control flow.
 STATE:
   SET SKILL_INVOCATION_ART_ENABLED: true | false | unset (default unset, scope session)
 WHEN:

--- a/skills/studio/modules/ui/skill-invocation-art.md
+++ b/skills/studio/modules/ui/skill-invocation-art.md
@@ -10,13 +10,17 @@ purpose: Defines SkillInvocationArt — the ASCII-art entry picture rendered at 
 ```pdsl
 UNIT SkillInvocationArt
 PURPOSE: Prefix each cf, cf-studio, or cf-* skill entry with one small ASCII-art picture relevant to the skill name, with a plain-text label below, without changing the workflow's control flow.
+STATE:
+  SET SKILL_INVOCATION_ART_ENABLED: true | false | unset (default unset, scope session)
 WHEN:
   REQUIRE a cf, cf-studio, or cf-* skill or workflow entry is beginning execution
   SKIP silently (no picture, no output) WHEN this unit is loaded in a context that does not satisfy the above REQUIRE
 DO:
-  RUN SkillInvocationArtGuard
+  RUN resolve SKILL_INVOCATION_ART_ENABLED from `[ui].skill_invocation_art_enabled` in `{cf-studio-path}/config/core.toml` (false when the key or file is absent) WHEN SKILL_INVOCATION_ART_ENABLED == unset
+  RUN SkillInvocationArtGuard WHEN SKILL_INVOCATION_ART_ENABLED == true
   RUN SkillInvocationArtGenerate WHEN SkillInvocationArtGuard passes
 RULES:
+  ALWAYS default to disabled and resolve the config flag at most once per session: skip the picture with no further state read unless `[ui].skill_invocation_art_enabled` is explicitly `true` in `{cf-studio-path}/config/core.toml`
   ALWAYS run this unit once at the start of every cf, cf-studio, or cf-* workflow bootstrap or alias entry, before the workflow's first normal EMIT, EMIT_MENU, WAIT, CONTINUE, INVOKE, DISPATCH, RETURN, or STOP_TURN
   NEVER alter, delay, or suppress any existing output directive; the picture precedes but does not replace or reorder normal output
   NEVER replace, delay, reorder, suppress, or alter any load report


### PR DESCRIPTION
## Summary
- Gates `SkillInvocationArt` behind a new `[ui].skill_invocation_art_enabled` flag in `core.toml`, default `false` — the decorative ASCII picture at cf/cf-* skill entry now costs nothing unless a project explicitly opts in.
- Adds the corresponding `ui.skill_invocation_art_enabled` boolean to `schemas/core-config.schema.json`.
- Resolves the flag once per session using the existing `unset`-sentinel `STATE` idiom (mirrors `SimpleModeGate`'s `SIMPLE_MODE`), avoiding a bug where "not yet resolved" and "resolved false" would otherwise collapse into the same value and permanently disable the config read.

Addresses #145. #142 (native blocking-question dialog) is tracked separately and not part of this PR.

## Test plan
- [x] `cfs pdsl validate skills/studio/modules/ui/skill-invocation-art.md` — confirmed 0 new findings vs. the pre-change baseline (6 pre-existing findings in untouched units remain, unrelated to this diff)
- [x] `schemas/core-config.schema.json` re-validated as well-formed JSON
- [x] Confirmed `core.toml` is loaded as a generic untyped dict throughout the Python codebase, so the new schema key won't be silently dropped by any existing loader
- [ ] Manual harness check: flip `[ui].skill_invocation_art_enabled = true` in a project's `core.toml` and confirm the picture appears; confirm it's absent by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional UI setting to control decorative ASCII art when entering `cf`, `cf-studio`, and other `cf-*` skills or workflows.
  - When enabled, relevant ASCII art and a label are displayed at entry.
  - The setting is disabled by default and can be configured under the UI preferences section of the core configuration.
  - Configuration now supports UI preferences for both skill and workflow runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->