### PR TITLE
docs(pdsl): state declaration-region precedence and deferred continue

### DIFF
--- a/architecture/specs/PDSL.md
+++ b/architecture/specs/PDSL.md
@@ -115,6 +115,7 @@ Use this small keyword set before inventing new words.
 | `WAIT` | Stop for user input |
 | `STOP_TURN` | End assistant turn immediately |
 | `CONTINUE` | Move to named unit or phase |
+| `CONTINUE … after user.reply` | Deferred move, taken when the turn resumes |
 | `DISPATCH` | Invoke a named sub-agent or worker contract |
 | `RETURN` | Return a manifest, report, checkpoint, or handoff |
 | `REQUIRE` | Required precondition |
@@ -186,6 +187,17 @@ controller or sub-agent interpreting PDSL applies these rules:
 - `WAIT` plus `STOP_TURN` is a hard assistant-turn boundary.
 - `CONTINUE <unit-or-phase>` transfers control to that target; it is not
   optional advice.
+- `CONTINUE <unit-or-phase> after user.reply` defers that transfer to the turn
+  which resumes after the boundary, and **must be written before the `WAIT` it
+  defers past** — a `CONTINUE` placed after `WAIT`/`STOP_TURN` is unreachable,
+  because the boundary has already transferred control. Use it where a branch
+  must collect a reply and then continue somewhere other than where it stopped.
+  **Defined here only for a clause carrying a single boundary.** Four cases are
+  deliberately left open: a block holding more than one `WAIT`, two deferred
+  continuations before one boundary, control leaving the branch before the
+  boundary is reached, and a boundary never reached at all. Both present uses
+  carry exactly one boundary, so the corpus does not settle any of the four, and
+  binding them would need an enforced check rather than a sentence.
 - `DISPATCH` invokes a named sub-agent or worker contract. Concurrency,
   isolation, and join behavior belong in explicit dispatch options or
   surrounding rules, not in separate dispatch keywords.
@@ -380,8 +392,8 @@ Rules:
   undeclared menu is treated as `blocking` — the conservative direction, in
   which a gate asks rather than proceeds.
 - **Nothing resolves a gate from a declared type today**, so this lint changes
-  no runtime behaviour. Two shipped paths *do* auto-resolve gates, and neither
-  reads a declaration: assistant mode's own auto-selection rule
+  no runtime behaviour. Three shipped paths *do* auto-resolve gates, and none of
+  them reads a declaration: assistant mode's own auto-selection rule
   (`skills/studio/modules/gates/simple-mode-rules.md:19`), the autonomy overlay
   (`workflows/brave-new-world.md`), and sub-agent dispatch's pre-set rule
   (`skills/studio/modules/subagents/dispatch.md:43`), all of which decide by
@@ -392,7 +404,7 @@ Rules:
   that introduces declaration-driven resolution, which is where the obligation
   and a test asserting that an omitted `TYPE` produces blocking behaviour
   belong. Until then, omission is *unvalidated*, and the safety of the
-  grandfathered set rests on those two paths being narrow and reviewed — not on
+  grandfathered set rests on those three paths being narrow and reviewed — not on
   a default that has been demonstrated.
 - **`TYPE` is read only in the menu's declaration region:** from the menu
   header up to the first section that is not `TITLE` or `TYPE`. A declaration
@@ -403,7 +415,17 @@ Rules:
   onto a second line is read as title text. A `TYPE:` written there is not read
   as the declaration, and a near-miss written there is not reported. The level
   is taken from the menu's first sub-header, whichever that is, and measured per
-  menu rather than per block.
+  menu rather than per block — **that first sub-header's own indentation sets the
+  level even where it is itself over-indented**, and the exemption below changes
+  whether a header is a section, never whether it sets the level. **`TITLE:`, `OPTIONS:` and `INVALID:` are exempt
+  from this rule** and keep their section status at any indentation, so an
+  over-indented `OPTIONS:` still ends the region and a `TYPE:` after it is
+  inert — reported as a declaration nothing reads. Every other recognized
+  header is subject to it: an over-indented `NOTES:` is continuation text, so the
+  region has *not* ended — and a `TYPE:` after it is read **only if that `TYPE:`
+  itself sits at the level**, since a `TYPE:` indented deeper is continuation
+  text by this same rule. Resolve the two rules in that order — the exemption
+  first, then the region-ending rule below.
 - **Any recognized section other than `TITLE` or `TYPE` ends the region** — `OPTIONS:`,
   `INVALID:`, and also `NOTES:`, `RULES:`, `ON_ERROR:`, `PURPOSE:` and the
   rest. Unrecognized prose headers such as `NOTE:` and `ELSE:` do not. So put

--- a/skills/studio/modules/runtime/pdsl-execution-card.md
+++ b/skills/studio/modules/runtime/pdsl-execution-card.md
@@ -25,6 +25,9 @@ RULES:
   ALWAYS treat `WAIT` plus `STOP_TURN` as a hard assistant-turn boundary.
   ALWAYS treat `CONTINUE <unit-or-phase>` as transfer of control to that target,
     not optional advice.
+  ALWAYS treat `CONTINUE <unit-or-phase> after user.reply` as a transfer deferred
+    to the turn that resumes after the boundary, and write it BEFORE the `WAIT`
+    it defers past; a `CONTINUE` placed after `WAIT`/`STOP_TURN` is unreachable.
   ALWAYS after any `WAIT`/`STOP_TURN` resume at the exact active PDSL
     continuation target; REQUIRED: do not reinterpret the user's reply as
     broad permission for generic autonomous execution.
@@ -54,8 +57,9 @@ RULES:
   NEVER weaken `ALWAYS`, `NEVER`, `REQUIRE`, `WAIT`, `STOP_TURN`, or
     `INVARIANTS` because nearby prose sounds softer.
 NOTES:
-  No core module declares a gate `TYPE` or resolves a gate from one today —
-  see `architecture/specs/PDSL.md` and `cpt-studio-adr-autonomous-default-and-gate-risk`
+  A core module now declares a gate `TYPE` — `plan-compile.md`'s production
+  choice — but nothing resolves a gate from one yet. See
+  `architecture/specs/PDSL.md` and `cpt-studio-adr-autonomous-default-and-gate-risk`
   (ADR-0023). This carve-out only removes the prohibition against such
   resolution once it exists; it does not itself define or implement how a
   gate is resolved from its declared type.

--- a/tests/test_pdsl_validate_cli.py
+++ b/tests/test_pdsl_validate_cli.py
@@ -1285,6 +1285,79 @@ def test_an_indented_sub_header_still_opens_its_section() -> None:
     assert _rule_ids(options_deeper_than_title) == ["PDSL400"]
 
 
+def test_a_deeper_non_exempt_header_is_continuation_so_a_later_type_is_read() -> None:
+    """The other half of the indentation rule: only three headers are exempt.
+
+    `TITLE:`, `OPTIONS:` and `INVALID:` keep section status at any indentation,
+    so a deeper `OPTIONS:` still ends the declaration region (covered above).
+    Every other recognized header is subject to the continuation rule instead,
+    so a deeper `NOTES:` is continuation text, the region has *not* ended, and a
+    `TYPE:` after it *is* the declaration.
+
+    Only the exempt half was pinned. The three fixtures below separate the two
+    conditions that a first draft of this test ran together: whether the deeper
+    header ended the region, and whether the `TYPE:` was itself at the level.
+    A valid `TYPE:` cannot tell those apart, because an omitted declaration is
+    legal and yields no finding either way -- so each fixture uses an invalid
+    value, which is reported only when the declaration is actually read.
+    """
+    # An *invalid* value, because a valid one is indistinguishable: an omitted
+    # declaration is legal, so `TYPE: blocking` yields no finding whether it was
+    # read or ignored as continuation text. `urgent` is reported only if read.
+    deeper_notes_then_type_at_level = (
+        "MENU G:\n  TITLE: t\n    NOTES: prose\n  TYPE: urgent\n  OPTIONS:\n    1 a -> RUN X\n"
+    )
+    assert _rule_ids(deeper_notes_then_type_at_level) == ["PDSL700"]
+
+    # The `TYPE:` must sit at the level to be read. Indented deeper it is
+    # continuation text by the same rule, so its invalid value is never reached.
+    deeper_notes_then_deeper_type = (
+        "MENU G:\n  TITLE: t\n    NOTES: prose\n    TYPE: urgent\n  OPTIONS:\n    1 a -> RUN X\n"
+    )
+    assert _rule_ids(deeper_notes_then_deeper_type) == []
+
+    # At the learned level, `NOTES:` ends the region, so a later `TYPE:` is inert
+    # and reported as a declaration nothing reads.
+    notes_at_level_then_type = (
+        "MENU G:\n  TITLE: t\n  NOTES: prose\n  TYPE: urgent\n  OPTIONS:\n    1 a -> RUN X\n"
+    )
+    assert _rule_ids(notes_at_level_then_type) == ["PDSL702"]
+
+
+def test_the_indentation_rule_is_reported_through_the_real_cli() -> None:
+    """The same three fixtures, driven end-to-end rather than through the validator.
+
+    Every other test for this rule calls `_rule_ids`, which reaches
+    `validate_source` in-process and so never exercises argument parsing, the
+    exit-code mapping or the JSON rendering. A review of #153 raised that gap on
+    this module and it was extended rather than closed, so one fixture per
+    outcome now goes through `main()`: a read declaration, an ignored one, and a
+    declaration nothing reads.
+
+    Exit codes are asserted because they are the part `_rule_ids` cannot see: a
+    finding must map to 2, not 1, and a clean source to 0.
+    """
+    for text, expected_ids, expected_rc in (
+            ("MENU G:\n  TITLE: t\n    NOTES: prose\n  TYPE: urgent\n"
+             "  OPTIONS:\n    1 a -> RUN X\n", ["PDSL700"], 2),
+            ("MENU G:\n  TITLE: t\n    NOTES: prose\n    TYPE: urgent\n"
+             "  OPTIONS:\n    1 a -> RUN X\n", [], 0),
+            ("MENU G:\n  TITLE: t\n  NOTES: prose\n  TYPE: urgent\n"
+             "  OPTIONS:\n    1 a -> RUN X\n", ["PDSL702"], 2),
+    ):
+        set_json_mode(False)
+        rc, stdout, stderr = _run(["pdsl", "validate", "--text", text, "--json"])
+
+        assert rc == expected_rc, (text, stdout, stderr)
+        assert stderr == ""
+        payload = json.loads(stdout)
+        assert payload["command"] == "pdsl validate"
+        assert payload["ok"] is not bool(expected_ids)
+        assert payload["summary"]["finding_count"] == len(expected_ids)
+        found = [f["rule_id"] for f in payload["results"][0]["findings"]]
+        assert found == expected_ids, (text, found)
+
+
 def test_an_unrecognized_first_sub_header_sets_the_level() -> None:
     """`NOTE:` and `ELSE:` are legitimate menu headers, so they set it too.
 


### PR DESCRIPTION
Three wording corrections to `architecture/specs/PDSL.md`. **No behaviour change** — in each
case the implementation is already correct and the spec was the thing that misled a reader.

## 1. The declaration-region rules had no stated precedence

Two bullets both apply to an over-indented `OPTIONS:` and imply opposite outcomes:

- *"A line indented deeper than the menu's other sub-headers is continuation text of the header
  above it"*
- *"Any recognized section other than `TITLE` or `TYPE` ends the region"* — which lists `OPTIONS:`

The implementation resolves this by exempting `TITLE`, `OPTIONS` and `INVALID` from the
continuation rule, so those three keep section status at any indentation while every other
header does not. **Verified against the checker rather than read off the code:**

| menu shape | is the later `TYPE:` read? |
|---|---|
| `TITLE` → over-indented `OPTIONS:` → `TYPE:` | **no** — region already ended |
| `TITLE` → over-indented `INVALID:` → `TYPE:` | **no** |
| `TITLE` → over-indented `NOTES:` → `TYPE:` | **yes** — the header is continuation text, region still open |
| `TITLE` → level `NOTES:` → `TYPE:` | no |

The spec now states the exemption, that asymmetry, and the order to resolve the two rules in.

Worth being explicit about why this matters: a reviewer inferred the opposite from the wording
alone and concluded the guard rejects a validly typed menu. It does not — a `TYPE:` after an
over-indented `OPTIONS:` is genuinely inert, and the validator reports it as a declaration
nothing reads. The behaviour was right; only the prose was ambiguous.

## 2. `CONTINUE <unit> after user.reply` was used but never specified

The form appears in the corpus and has **no** mention in this spec. The vocabulary list gives
`WAIT` plus `STOP_TURN` as a hard assistant-turn boundary, and `CONTINUE` as a transfer that is
"not optional advice", but says nothing about deferring a transfer past that boundary.

The observable consequence: two reviewers read the same clause in opposite ways — one as a dead
`CONTINUE` written after the boundary, the other as a premature transfer written before the
`WAIT`. An unspecified idiom is how that happens.

The spec now defines the form and requires it to appear **before** the `WAIT` it defers past,
because a `CONTINUE` written after the boundary is unreachable.

## 3. One residual number

A sentence still said the grandfathered set rests on *"those two paths"*, where the bullet list
immediately above it names three.

## Deliberately prose-only

No fenced example was added, and that is a constraint rather than a preference: two menus
defined **inside this document** are pinned by block position in the untyped-MENU baseline
(`PDSL.md#7::ApprovalMenu`, `PDSL.md#13::SubAgentApprovalMenu`, at lines 318 and 546). Every fix
site here is above both, so one new fenced block would renumber them and fail that guard.

That coupling is worth a separate conversation: the spec's *illustrative* menus count toward the
untyped-gate inventory, which means a documentation example can fail a test about shipped gate
safety. Not addressed here.

A test pinning the over-indent asymmetry would be worth having, but it belongs in
`tests/test_pdsl_keywords.py`, which another open PR is currently rewriting — so it waits rather
than creating a conflict.

## What this PR does not define, deliberately

Review raised four semantic cases for the deferred form: a block holding more than one `WAIT`,
two deferred continuations before one boundary, control leaving the branch before the boundary,
and a boundary never reached. **None is answered here, and the spec now says so.**

Both present uses carry exactly one boundary, so the corpus settles none of the four. And there
is no interpreter to test a semantic rule against — the checker validates syntax, and execution
is a model reading the text — so any answer here would be a choice with a normative voice rather
than a finding. One of my own drafts cited `At most one TYPE per menu` as precedent for a
conflict rule; that governs a declaration rather than a control transfer, and was borrowed
phrasing rather than evidence.

Binding these belongs with an enforced check, the way declared gate risk became real through a
lint plus a frozen baseline rather than prose alone. That is a task, not a wording fix.

Recording them as open is narrower than answering them, and still better than today's silence:
a reader who hits one of the four learns they are off the specified path instead of guessing.

Rebased onto `main` after the duplicate-gate change merged. That is what makes the
"both present uses" statement above true: the second use of the deferred form arrived with that
change, so on the pre-rebase branch only one was discoverable — an accurate count against the
wrong tree.

The declaration-region rule also had only one of its two halves under test. A deeper `OPTIONS:`
still ending the region was covered; a deeper `NOTES:` becoming continuation text, so a later
`TYPE:` **is** read, was not — the half I had verified by hand while drafting the prose and left
no test for. Both directions are now asserted, and mutation-tested to fail if the continuation
logic regresses either way.

`cfs validate` PASS (0 errors, 0 warnings, 240/240) · `pdsl validate` PASS · `make test` 5771
passed · `spec-coverage` 90.8% coverage / 0.4608 granularity · pylint, ruff, vulture-ci and
test-coverage clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified deferred `CONTINUE` behavior after user replies, including ordering with `WAIT` and unreachable placement after turn boundaries.
  - Documented unresolved multi-boundary cases.
  - Updated gate-risk guidance to reflect three automatically resolving paths.
  - Clarified menu header indentation, section-header exceptions, and rule precedence.
  - Noted that gate types are declared but not yet resolved.

- **Bug Fixes**
  - Improved validation of nested menu headers and reporting of inert declarations, including CLI output and exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->