### PR TITLE
cf-ux: pin the skill-name matcher's false-positive trade (follow-up to #161)

### DIFF
--- a/tests/prompts/cf-ux/README.md
+++ b/tests/prompts/cf-ux/README.md
@@ -71,6 +71,40 @@ bound to *that* call's id. Each half of that matters.
 - No result at all is not a non-error result. A trace cut off after the call is
   refused, not read as a success.
 
+### One false positive is accepted on purpose
+
+Which key holds the skill name is not part of any stable contract, so **every
+identifier-shaped value in the tool input is a candidate, at any depth**. That
+means a rival skill invoked with some unrelated field whose value happens to be
+`cf` — `{"command": "superpowers:brainstorming", "mode": "cf"}` — reads as this
+skill running. `plugin:cf` in that position does too, since the comparison
+happens after the namespace is dropped.
+
+This is a deliberate trade, not an oversight. Narrowing the scan to a fixed set
+of name keys would close it and open a worse hole:
+
+| | every value (today) | narrowed to name keys |
+|---|---|---|
+| rival skill with a bare `cf` field | rare false **pass** | correct |
+| the real key is not in the list | correct | certain false **failure**, on every run |
+
+Nobody here has run the CLI, so the input's real shape is unknown — the fixtures
+use `{"command": …}` because someone chose it, not because it was measured. Under
+that uncertainty the scan errs toward recall, which is also why it descends into
+nested values: a name one level down that went unfound would produce the certain
+failure rather than the rare pass.
+
+Two things keep the accepted case from being silent:
+
+- **`skill_match_ambiguous`**, and a matching stderr warning naming the other
+  candidate, whenever a `ran` verdict rests on one of several identifiers in the
+  matched call. That is the shape a false pass takes, so it is reported per run
+  rather than left for whoever thinks to look.
+- **`skill_call_inputs`**, the raw inputs verbatim, so the verdict can be checked.
+
+`test_a_bare_cf_in_an_unrelated_field_still_counts` pins the trade. If the real
+key is ever established, that test is where it gets renegotiated.
+
 Three more shapes are errors for the same reason — there is no answer to grade,
 or no trace to trust:
 
@@ -82,7 +116,8 @@ or no trace to trust:
 
 Metadata: `skill_state` (`ran` / `failed` / `absent`), `skills_invoked` (the
 names), `skill_call_inputs` (those inputs verbatim, for when a name did not
-resolve), `unparsed_lines`, and `unscored_output` — the answer that was withheld
+resolve), `skill_match_ambiguous` (above), `unparsed_lines`, and
+`unscored_output` — the answer that was withheld
 from the grader, kept for diagnosis. Every return *that reached the CLI*, answer
 or error, carries `duration_s` and `sandbox`; a failure before the sandbox
 exists — setup error, setup timeout — has no sandbox path to name. The

--- a/tests/prompts/cf-ux/README.md
+++ b/tests/prompts/cf-ux/README.md
@@ -74,11 +74,12 @@ bound to *that* call's id. Each half of that matters.
 ### One false positive is accepted on purpose
 
 Which key holds the skill name is not part of any stable contract, so **every
-identifier-shaped value in the tool input is a candidate, at any depth**. That
-means a rival skill invoked with some unrelated field whose value happens to be
-`cf` — `{"command": "superpowers:brainstorming", "mode": "cf"}` — reads as this
-skill running. `plugin:cf` in that position does too, since the comparison
-happens after the namespace is dropped.
+identifier-shaped value in the tool input is a candidate, at any depth** — and
+an input that is not a dict at all is scanned rather than refused, for the same
+reason. That means a rival skill invoked with some unrelated field whose value
+happens to be `cf` — `{"command": "superpowers:brainstorming", "mode": "cf"}` —
+reads as this skill running. `plugin:cf` in that position does too, since the
+comparison happens after the namespace is dropped.
 
 This is a deliberate trade, not an oversight. Narrowing the scan to a fixed set
 of name keys would close it and open a worse hole:
@@ -96,10 +97,15 @@ failure rather than the rare pass.
 
 Two things keep the accepted case from being silent:
 
-- **`skill_match_ambiguous`**, and a matching stderr warning naming the other
-  candidate, whenever a `ran` verdict rests on one of several identifiers in the
-  matched call. That is the shape a false pass takes, so it is reported per run
-  rather than left for whoever thinks to look.
+- **`skill_match_other_candidates`**, and a matching stderr warning, listing the
+  other identifiers whenever the matched call's input named more than one. That
+  is the shape a false pass takes, so it is reported per run rather than left
+  for whoever thinks to look. It is an **over-approximation, named for what it
+  observes rather than what it suspects**: it cannot tell a wrong-field match
+  from a correct call that merely carries a second identifier, so a genuine
+  `{"command": "cf", "mode": "auto"}` is listed too. Narrowing it would need the
+  very knowledge whose absence created the trade. It is a flag, not a verdict —
+  the run is still scored.
 - **`skill_call_inputs`**, the raw inputs verbatim, so the verdict can be checked.
 
 `test_a_bare_cf_in_an_unrelated_field_still_counts` pins the trade. If the real
@@ -116,7 +122,7 @@ or no trace to trust:
 
 Metadata: `skill_state` (`ran` / `failed` / `absent`), `skills_invoked` (the
 names), `skill_call_inputs` (those inputs verbatim, for when a name did not
-resolve), `skill_match_ambiguous` (above), `unparsed_lines`, and
+resolve), `skill_match_other_candidates` (above), `unparsed_lines`, and
 `unscored_output` — the answer that was withheld
 from the grader, kept for diagnosis. Every return *that reached the CLI*, answer
 or error, carries `duration_s` and `sandbox`; a failure before the sandbox

--- a/tests/prompts/cf-ux/providers/claude_provider.py
+++ b/tests/prompts/cf-ux/providers/claude_provider.py
@@ -79,6 +79,13 @@ _RESULT_OK = "success"
 #: a person will see it, and the house rule is that a swallowed exception warns
 #: on stderr rather than only in a return value (`architecture/DESIGN.md`).
 _LOG_UNPARSED_LINE = "cf-ux claude provider: stream line %d would not parse; skipped"
+#: A `ran` verdict that rests on one of several candidate identifiers is the
+#: shape a false pass takes, so it is reported per run rather than left to
+#: whoever thinks to inspect `skill_call_inputs` afterwards.
+_LOG_AMBIGUOUS_MATCH = (
+    "cf-ux claude provider: matched %r in a Skill input that also names %s; "
+    "the verdict may rest on a field that is not the skill name"
+)
 
 
 def _stream_events(raw: str) -> tuple[list[dict[str, Any]], int]:
@@ -133,18 +140,31 @@ def _invoked_names(payload: Any) -> list[str]:
     """The skill identifiers a `Skill` tool input names.
 
     Which key holds the name is not part of any stable contract, so every string
-    value shaped like an identifier is a candidate — but each is compared
-    *whole*, after dropping any `plugin:` namespace. That is what separates the
-    skill's name from the argument text, which in this suite always quotes a
-    `/cf …` prompt.
+    value shaped like an identifier is a candidate — *at any depth*, because a
+    tool input that nests its identifier one level down (`{"options": {"skill":
+    "cf"}}`) is a shape this cannot rule out either. Stopping at the top level
+    would mean a nested name is never found, and then every run errors: the
+    certain false failure this trade exists to avoid, rather than the rare false
+    pass it accepts.
+
+    Each candidate is compared *whole* — but only after any `plugin:` or `path/`
+    namespace is dropped, so `plugin:cf` counts and `cf-generate` does not. What
+    the shape filter excludes is the argument text, which in this suite always
+    quotes a `/cf …` prompt.
     """
-    if not isinstance(payload, dict):
-        return []
     names = []
-    for value in payload.values():
-        if not isinstance(value, str) or not _NAME_SHAPE.fullmatch(value.strip()):
+    pending = [payload]
+    while pending:
+        current = pending.pop()
+        if isinstance(current, dict):
+            pending.extend(current.values())
             continue
-        name = value.strip()
+        if isinstance(current, list):
+            pending.extend(current)
+            continue
+        if not isinstance(current, str) or not _NAME_SHAPE.fullmatch(current.strip()):
+            continue
+        name = current.strip()
         for separator in _NAME_SEPARATORS:
             name = name.rsplit(separator, 1)[-1]
         if name:
@@ -159,6 +179,7 @@ class _SkillTrace(NamedTuple):
     names: list[str]    # skill identifiers the transcript names
     inputs: list[str]   # the tool inputs verbatim, serialized, for diagnosis
     detail: str
+    ambiguous: bool = False   # the verdict rests on one of several candidates
 
 
 def _skill_trace(events: list[dict[str, Any]], raw: str) -> _SkillTrace:
@@ -205,8 +226,19 @@ def _skill_trace(events: list[dict[str, Any]], raw: str) -> _SkillTrace:
             "failed", names, inputs,
             f"a {_SKILL_TOOL} ran but none of them named {_SKILL_NAME!r}",
         )
-    if any(results.get(call_id) is False for call_id in targeted):
-        return _SkillTrace("ran", names, inputs, "")
+    for call_id in targeted:
+        if results.get(call_id) is not False:
+            continue
+        # Because the name's key is unknown, `cf` may have been matched against a
+        # field that is not the name at all — a rival skill invoked with some
+        # unrelated value of `cf` reads as this one running. That trade is
+        # accepted (a rare false pass beats a certain false failure), but a
+        # verdict resting on one of several candidates is said out loud rather
+        # than left for whoever thinks to diff the metadata afterwards.
+        others = [name for name in named[call_id] if name != _SKILL_NAME]
+        if others:
+            logger.warning(_LOG_AMBIGUOUS_MATCH, _SKILL_NAME, others)
+        return _SkillTrace("ran", names, inputs, "", bool(others))
     if any(call_id not in results for call_id in targeted):
         return _SkillTrace(
             "failed", names, inputs,
@@ -327,6 +359,7 @@ def _invoke(prompt: str, cwd: Path, started: float) -> dict:
         "skill_state": state,
         "skills_invoked": trace.names,
         "skill_call_inputs": trace.inputs,
+        "skill_match_ambiguous": trace.ambiguous,
     }
     cost = payload.get("total_cost_usd")
 

--- a/tests/prompts/cf-ux/providers/claude_provider.py
+++ b/tests/prompts/cf-ux/providers/claude_provider.py
@@ -79,9 +79,16 @@ _RESULT_OK = "success"
 #: a person will see it, and the house rule is that a swallowed exception warns
 #: on stderr rather than only in a return value (`architecture/DESIGN.md`).
 _LOG_UNPARSED_LINE = "cf-ux claude provider: stream line %d would not parse; skipped"
-#: A `ran` verdict that rests on one of several candidate identifiers is the
-#: shape a false pass takes, so it is reported per run rather than left to
+#: A `ran` verdict reached from an input that names more than one identifier is
+#: the shape a false pass takes, so it is reported per run rather than left to
 #: whoever thinks to inspect `skill_call_inputs` afterwards.
+#:
+#: Deliberately an over-approximation, and named for what it observes rather
+#: than what it suspects. Since the name's key is unknown, this cannot tell a
+#: wrong-field match from a correct call that merely carries a second
+#: identifier: every false positive of this class is reported, and so are some
+#: perfectly good runs. Narrowing it would need the very knowledge whose absence
+#: created the trade.
 _LOG_AMBIGUOUS_MATCH = (
     "cf-ux claude provider: matched %r in a Skill input that also names %s; "
     "the verdict may rest on a field that is not the skill name"
@@ -151,8 +158,16 @@ def _invoked_names(payload: Any) -> list[str]:
     namespace is dropped, so `plugin:cf` counts and `cf-generate` does not. What
     the shape filter excludes is the argument text, which in this suite always
     quotes a `/cf …` prompt.
+
+    A top-level input that is not a dict is scanned rather than refused, for the
+    same reason: a bare string or a list is a shape this cannot rule out either,
+    and refusing it would mean the name is never found and every run errors.
+
+    Returned sorted and deduplicated. The traversal is a stack, so its own order
+    is an implementation detail, and nothing downstream should vary with it —
+    this list reaches a warning message a person reads.
     """
-    names = []
+    names = set()
     pending = [payload]
     while pending:
         current = pending.pop()
@@ -168,8 +183,8 @@ def _invoked_names(payload: Any) -> list[str]:
         for separator in _NAME_SEPARATORS:
             name = name.rsplit(separator, 1)[-1]
         if name:
-            names.append(name)
-    return names
+            names.add(name)
+    return sorted(names)
 
 
 class _SkillTrace(NamedTuple):
@@ -179,7 +194,9 @@ class _SkillTrace(NamedTuple):
     names: list[str]    # skill identifiers the transcript names
     inputs: list[str]   # the tool inputs verbatim, serialized, for diagnosis
     detail: str
-    ambiguous: bool = False   # the verdict rests on one of several candidates
+    #: The other identifiers in the matched call, when there were any. Reported
+    #: rather than judged: see `_LOG_AMBIGUOUS_MATCH`.
+    other_candidates: tuple[str, ...] = ()
 
 
 def _skill_trace(events: list[dict[str, Any]], raw: str) -> _SkillTrace:
@@ -235,10 +252,10 @@ def _skill_trace(events: list[dict[str, Any]], raw: str) -> _SkillTrace:
         # accepted (a rare false pass beats a certain false failure), but a
         # verdict resting on one of several candidates is said out loud rather
         # than left for whoever thinks to diff the metadata afterwards.
-        others = [name for name in named[call_id] if name != _SKILL_NAME]
+        others = tuple(name for name in named[call_id] if name != _SKILL_NAME)
         if others:
-            logger.warning(_LOG_AMBIGUOUS_MATCH, _SKILL_NAME, others)
-        return _SkillTrace("ran", names, inputs, "", bool(others))
+            logger.warning(_LOG_AMBIGUOUS_MATCH, _SKILL_NAME, list(others))
+        return _SkillTrace("ran", names, inputs, "", others)
     if any(call_id not in results for call_id in targeted):
         return _SkillTrace(
             "failed", names, inputs,
@@ -359,7 +376,7 @@ def _invoke(prompt: str, cwd: Path, started: float) -> dict:
         "skill_state": state,
         "skills_invoked": trace.names,
         "skill_call_inputs": trace.inputs,
-        "skill_match_ambiguous": trace.ambiguous,
+        "skill_match_other_candidates": list(trace.other_candidates),
     }
     cost = payload.get("total_cost_usd")
 

--- a/tests/test_cf_ux_claude_provider.py
+++ b/tests/test_cf_ux_claude_provider.py
@@ -202,14 +202,24 @@ class TestARunThatLoadedTheSkillIsScored:
         assert out["metadata"]["skill_state"] == "ran"
         assert out["metadata"]["skills_invoked"] == ["brainstorming", "cf"]
 
-    def test_a_nested_identifier_is_found_too(self, run_provider):
+    @pytest.mark.parametrize("shape", [
+        pytest.param({"options": {"skill": "cf"}}, id="one-level"),
+        pytest.param({"o": {"p": {"skill": "cf"}}}, id="two-levels"),
+        pytest.param({"args": [{"skill": "cf"}]}, id="list-of-dicts"),
+        pytest.param({"a": [{"b": {"skill": "cf"}}]}, id="dict-in-list-in-dict"),
+        pytest.param({"a": [["cf"]]}, id="nested-lists"),
+    ])
+    def test_a_nested_identifier_is_found_at_any_depth(self, run_provider, shape):
         """Stopping at the top level would contradict the trade above rather than
-        implement it: a tool input that nests its identifier one level down is a
-        shape this cannot rule out, and missing it means *every* run errors —
-        the certain false failure, not the rare false pass."""
+        implement it: a tool input that nests its identifier is a shape this
+        cannot rule out, and missing it means *every* run errors — the certain
+        false failure, not the rare false pass.
+
+        Parametrized past depth one because "any depth" is the claim; a single
+        level would leave a regression below it uncaught.
+        """
         nested = {"type": "assistant", "message": {"content": [
-            {"type": "tool_use", "id": "t1", "name": "Skill",
-             "input": {"options": {"skill": "cf"}}},
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": shape},
         ]}}
 
         out, _seen = run_provider(_stream(nested, _skill_result(), _result()))
@@ -217,13 +227,31 @@ class TestARunThatLoadedTheSkillIsScored:
         assert out["metadata"]["skill_state"] == "ran"
         assert out["metadata"]["skills_invoked"] == ["cf"]
 
-    def test_an_unambiguous_match_is_not_flagged(self, run_provider):
-        """The flag has to distinguish, or it says nothing."""
+    @pytest.mark.parametrize("payload", ["cf", ["cf"], ["other", {"skill": "cf"}]])
+    def test_an_input_that_is_not_a_dict_is_scanned_rather_than_refused(
+        self, run_provider, payload,
+    ):
+        """A boundary the earlier version refused outright (`if not
+        isinstance(payload, dict): return []`). Scanning it follows from the same
+        reasoning as the depth walk: a bare string or list input is a shape that
+        cannot be ruled out, and refusing it means the name is never found and
+        every run errors. Called out because it is a behaviour change, not a
+        side effect."""
+        odd = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": payload},
+        ]}}
+
+        out, _seen = run_provider(_stream(odd, _skill_result(), _result()))
+
+        assert out["metadata"]["skill_state"] == "ran"
+
+    def test_a_sole_candidate_leaves_the_other_candidates_empty(self, run_provider):
+        """The field has to distinguish, or it says nothing."""
         out, _seen = run_provider(
             _stream(_skill_call(skill="studio:cf"), _skill_result(), _result()),
         )
 
-        assert out["metadata"]["skill_match_ambiguous"] is False
+        assert out["metadata"]["skill_match_other_candidates"] == []
 
     def test_a_result_event_with_no_subtype_is_still_an_answer(self, run_provider):
         """Only a subtype that is present and says otherwise means a short turn.
@@ -511,11 +539,11 @@ class TestAnUnreadableRunIsNeverScored:
 
         assert out["metadata"]["unparsed_lines"] == 1
 
-    def test_an_ambiguous_match_is_surfaced_not_merely_inspectable(self, run_provider, caplog):
+    def test_the_other_candidates_are_surfaced_not_merely_inspectable(self, run_provider, caplog):
         """"Inspectable" only mitigates the false positive if someone inspects.
-        A verdict resting on one of several candidate identifiers is the shape a
-        false pass takes, so it is reported per run — on stderr and in the
-        metadata — rather than left for whoever thinks to diff
+        A verdict reached from an input naming more than one identifier is the
+        shape a false pass takes, so it is reported per run — on stderr and in
+        the metadata — rather than left for whoever thinks to diff
         `skill_call_inputs` afterwards."""
         rival = {"type": "assistant", "message": {"content": [
             {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
@@ -526,9 +554,44 @@ class TestAnUnreadableRunIsNeverScored:
         with caplog.at_level("WARNING", logger=claude_provider.logger.name):
             out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
 
-        assert out["metadata"]["skill_match_ambiguous"] is True
+        assert out["metadata"]["skill_match_other_candidates"] == ["brainstorming"]
         assert "may rest on a field that is not the skill name" in caplog.text
         assert "brainstorming" in caplog.text, "and names the other candidate"
+
+    def test_the_other_candidates_are_deduplicated_and_ordered(self, run_provider, caplog):
+        """This list reaches a message a person reads, and the traversal is a
+        stack — so left raw it repeats a value that appears twice and orders the
+        rest by an implementation detail. Two runs of the same transcript would
+        then produce different prose for the same finding."""
+        rival = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "a": "zebra", "b": "alpha", "c": "cf",
+                "d": {"e": "zebra"}, "f": ["alpha", "middle"],
+            }},
+        ]}}
+
+        with caplog.at_level("WARNING", logger=claude_provider.logger.name):
+            out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
+
+        assert out["metadata"]["skill_match_other_candidates"] == [
+            "alpha", "middle", "zebra",
+        ], "each named once, in an order that does not depend on the walk"
+        assert "['alpha', 'middle', 'zebra']" in caplog.text
+
+    def test_a_second_identifier_beside_a_genuine_call_is_reported_too(self, run_provider):
+        """The field is an over-approximation and says so: it cannot tell a
+        wrong-field match from a correct call that merely carries a second
+        identifier, because telling them apart needs the very knowledge whose
+        absence created the trade. Reported, not judged — `ran` still stands."""
+        genuine = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill",
+             "input": {"command": "cf", "mode": "auto"}},
+        ]}}
+
+        out, _seen = run_provider(_stream(genuine, _skill_result(), _result()))
+
+        assert out["output"] == "the answer", "a flag, not a verdict"
+        assert out["metadata"]["skill_match_other_candidates"] == ["auto"]
 
     def test_a_dropped_line_also_warns_where_a_person_will_see_it(self, run_provider, caplog):
         """A count riding along in a metadata dict is not the same as saying so.

--- a/tests/test_cf_ux_claude_provider.py
+++ b/tests/test_cf_ux_claude_provider.py
@@ -152,6 +152,38 @@ class TestARunThatLoadedTheSkillIsScored:
         assert out["metadata"]["skill_state"] == "ran"
         assert out["metadata"]["skills_invoked"] == ["cf"]
 
+    def test_a_bare_cf_in_an_unrelated_field_still_counts(self, run_provider):
+        """A known false positive, pinned rather than closed.
+
+        Which key holds the skill name is not contractual, so every
+        identifier-shaped value is a candidate — and a rival skill invoked with
+        some field whose *whole* value is `cf` therefore reads as this skill
+        running. Prose does not do this (the test above), but a single token in
+        an unrelated field does.
+
+        Narrowing to a fixed set of name keys would close this and open a worse
+        hole: guess the key wrong and *every* run errors, because the name would
+        never be found where it actually lives. This way round the failure is a
+        rare false pass; that way round it is a certain false failure. Erring
+        toward recall is what makes the harness work without knowing the key,
+        and `skill_call_inputs` keeps the raw input so the verdict stays
+        inspectable. If the key is ever pinned down, this test is where the
+        trade gets renegotiated.
+        """
+        rival = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "command": "superpowers:brainstorming", "mode": "cf",
+            }},
+        ]}}
+
+        out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
+
+        assert out["metadata"]["skill_state"] == "ran"
+        assert out["metadata"]["skills_invoked"] == ["brainstorming", "cf"]
+        assert out["metadata"]["skill_call_inputs"] == [
+            '{"command": "superpowers:brainstorming", "mode": "cf"}'
+        ], "the raw input shows where the name was found, so a false pass is visible"
+
     def test_a_result_event_with_no_subtype_is_still_an_answer(self, run_provider):
         """Only a subtype that is present and says otherwise means a short turn.
         An unfamiliar event shape must not be able to manufacture failures."""
@@ -242,6 +274,21 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
         out, _seen = run_provider(
             _stream(_skill_call(skill="cf-generate"), _skill_result(), _result()),
         )
+
+        assert "output" not in out
+        assert "none of them named 'cf'" in out["error"]
+
+    def test_a_single_token_that_is_not_cf_does_not_count_either(self, run_provider):
+        """The trade pinned above is not "any short token wins". The comparison
+        stays whole-value in every field, so a sibling name sitting in the same
+        unrelated position does not match."""
+        rival = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "command": "superpowers:brainstorming", "mode": "cf-generate",
+            }},
+        ]}}
+
+        out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
 
         assert "output" not in out
         assert "none of them named 'cf'" in out["error"]

--- a/tests/test_cf_ux_claude_provider.py
+++ b/tests/test_cf_ux_claude_provider.py
@@ -178,11 +178,52 @@ class TestARunThatLoadedTheSkillIsScored:
 
         out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
 
+        assert out["output"] == "the answer", "the point of the false positive: it gets scored"
+        assert "error" not in out
         assert out["metadata"]["skill_state"] == "ran"
         assert out["metadata"]["skills_invoked"] == ["brainstorming", "cf"]
         assert out["metadata"]["skill_call_inputs"] == [
             '{"command": "superpowers:brainstorming", "mode": "cf"}'
         ], "the raw input shows where the name was found, so a false pass is visible"
+
+    def test_a_namespaced_value_in_an_unrelated_field_counts_the_same_way(self, run_provider):
+        """The same false-positive class through a second mechanism: the value is
+        not literally `cf`, it reduces to it once the namespace is dropped. The
+        comparison is whole-value *after* stripping, which is what lets
+        `plugin:cf` count while `cf-generate` does not."""
+        rival = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "command": "superpowers:brainstorming", "mode": "plugin:cf",
+            }},
+        ]}}
+
+        out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
+
+        assert out["metadata"]["skill_state"] == "ran"
+        assert out["metadata"]["skills_invoked"] == ["brainstorming", "cf"]
+
+    def test_a_nested_identifier_is_found_too(self, run_provider):
+        """Stopping at the top level would contradict the trade above rather than
+        implement it: a tool input that nests its identifier one level down is a
+        shape this cannot rule out, and missing it means *every* run errors —
+        the certain false failure, not the rare false pass."""
+        nested = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill",
+             "input": {"options": {"skill": "cf"}}},
+        ]}}
+
+        out, _seen = run_provider(_stream(nested, _skill_result(), _result()))
+
+        assert out["metadata"]["skill_state"] == "ran"
+        assert out["metadata"]["skills_invoked"] == ["cf"]
+
+    def test_an_unambiguous_match_is_not_flagged(self, run_provider):
+        """The flag has to distinguish, or it says nothing."""
+        out, _seen = run_provider(
+            _stream(_skill_call(skill="studio:cf"), _skill_result(), _result()),
+        )
+
+        assert out["metadata"]["skill_match_ambiguous"] is False
 
     def test_a_result_event_with_no_subtype_is_still_an_answer(self, run_provider):
         """Only a subtype that is present and says otherwise means a short turn.
@@ -292,6 +333,27 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "none of them named 'cf'" in out["error"]
+        assert out["metadata"]["skills_invoked"] == ["brainstorming", "cf-generate"], (
+            "both candidates were parsed and neither matched — not one silently dropped"
+        )
+
+    def test_a_false_positive_match_whose_call_errored_is_still_a_failure(self, run_provider):
+        """The accepted false positive buys a *name* match, not a verdict. The
+        matched call still has to have come back clean, so the interaction of
+        the loose match with the error branch is the one worth pinning."""
+        rival = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "command": "superpowers:brainstorming", "mode": "cf",
+            }},
+        ]}}
+
+        out, _seen = run_provider(
+            _stream(rival, _skill_result(is_error=True), _result("answered directly")),
+        )
+
+        assert "output" not in out
+        assert "came back as an error" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
 
     def test_argument_text_naming_cf_is_not_the_skill_naming_cf(self, run_provider):
         """The prompt this suite sends is `/cf <request>`, so every scenario's
@@ -448,6 +510,25 @@ class TestAnUnreadableRunIsNeverScored:
         out, _seen = run_provider(transcript)
 
         assert out["metadata"]["unparsed_lines"] == 1
+
+    def test_an_ambiguous_match_is_surfaced_not_merely_inspectable(self, run_provider, caplog):
+        """"Inspectable" only mitigates the false positive if someone inspects.
+        A verdict resting on one of several candidate identifiers is the shape a
+        false pass takes, so it is reported per run — on stderr and in the
+        metadata — rather than left for whoever thinks to diff
+        `skill_call_inputs` afterwards."""
+        rival = {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "id": "t1", "name": "Skill", "input": {
+                "command": "superpowers:brainstorming", "mode": "cf",
+            }},
+        ]}}
+
+        with caplog.at_level("WARNING", logger=claude_provider.logger.name):
+            out, _seen = run_provider(_stream(rival, _skill_result(), _result()))
+
+        assert out["metadata"]["skill_match_ambiguous"] is True
+        assert "may rest on a field that is not the skill name" in caplog.text
+        assert "brainstorming" in caplog.text, "and names the other candidate"
 
     def test_a_dropped_line_also_warns_where_a_person_will_see_it(self, run_provider, caplog):
         """A count riding along in a metadata dict is not the same as saying so.

--- a/tests/test_cf_ux_claude_provider.py
+++ b/tests/test_cf_ux_claude_provider.py
@@ -305,6 +305,7 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "did not run (failed)" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
 
     def test_the_real_failure_signature_is_recognised(self, run_provider):
         """The observed failure is `<error>Execute skill: cf</error>`. The previous
@@ -316,6 +317,7 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "Execute skill:" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
 
     @pytest.mark.parametrize("rival", ["superpowers", "cf-generate"])
     def test_another_skill_failing_does_not_fail_the_cf_run(self, run_provider, rival):
@@ -337,6 +339,7 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "none of them named 'cf'" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
         assert out["metadata"]["skills_invoked"] == ["superpowers"], "and it says which did run"
 
     def test_a_skill_whose_name_merely_begins_with_cf_is_not_the_cf_skill(self, run_provider):
@@ -346,6 +349,7 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "none of them named 'cf'" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
 
     def test_a_single_token_that_is_not_cf_does_not_count_either(self, run_provider):
         """The trade pinned above is not "any short token wins". The comparison
@@ -361,6 +365,7 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "none of them named 'cf'" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
         assert out["metadata"]["skills_invoked"] == ["brainstorming", "cf-generate"], (
             "both candidates were parsed and neither matched — not one silently dropped"
         )
@@ -415,6 +420,7 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "came back as an error" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
 
     def test_a_cf_call_with_no_result_at_all_is_not_a_confirmed_run(self, run_provider):
         """Absence of a result is not a non-error result. A trace cut off after
@@ -424,6 +430,7 @@ class TestARunThatNeverLoadedTheSkillIsNotScored:
 
         assert "output" not in out
         assert "no result in the transcript" in out["error"]
+        assert out["metadata"]["skill_state"] == "failed"
 
     def test_a_repeated_call_id_collapses_to_the_last_one(self, run_provider):
         """The id is the only binding between a call and its result, so a


### PR DESCRIPTION
Review follow-up to #161, which merged before this could land on it.

One of the two findings on that PR was a genuine test gap. This is the test.

## The gap

`_invoked_names` compares every identifier-shaped string value in a `Skill` tool input, because which key holds the skill name is not part of any stable contract. Multi-word prose is excluded by shape (`_NAME_SHAPE`), and that case had a test. **A single bare token in an unrelated field is not excluded**, so:

```json
{"command": "superpowers:brainstorming", "mode": "cf"}
```

reads as the `cf` skill running. Reproduced before writing anything:

```
ran      names=['cf']                       <- prose beside the name (already tested)
ran      names=['brainstorming', 'cf']      <- bare 'cf' in an unrelated field  <- the gap
ran      names=['brainstorming', 'cf']      <- 'cf' as a target
ran      names=['brainstorming', 'cf']      <- a path ending in /cf
failed   names=['brainstorming']            <- rival only, no bare cf anywhere
```

## Pinned, not closed — and why

Narrowing the match to a fixed set of name keys (`command`, `skill`, `name`, …) would close this and open a worse hole. Guess the key wrong and **every** run errors, because the name would never be found where it actually lives. I do not know the real key: the fixtures in this suite use `{"command": …}`, which I chose, not something I measured — `claude` is not installed in my environment, as stated on #161.

So the trade is deliberate, and it errs the way that keeps the harness working without that knowledge:

| | this way (all values) | narrowed to name keys |
|---|---|---|
| rival skill with a bare `cf` field | rare false **pass** | correct |
| real key not in the list | correct | certain false **failure**, every run |

`skill_call_inputs` carries the raw input verbatim, so a `ran` verdict reached this way is inspectable — a maintainer sees `{"command": "superpowers:brainstorming", "mode": "cf"}` and spots it. That field exists for exactly this.

If the real key is ever pinned down by someone who can run the CLI, **the new test is where the trade gets renegotiated** — narrowing the matcher fails it, loudly, with the reasoning in the docstring.

## Tests

| test | pins |
|---|---|
| `test_a_bare_cf_in_an_unrelated_field_still_counts` | the accepted false positive, with the trade argued in the docstring |
| `test_a_single_token_that_is_not_cf_does_not_count_either` | the other side — the comparison stays whole-value in every field, so `mode: "cf-generate"` does not match |

**Two mutations, two caught:**

| mutation | fails |
|---|---|
| narrow `_invoked_names` to a fixed set of name keys | 1 — **and nothing else**, which is what made this worth a test |
| whole-value compare → substring containment | 5 |

That first row is the finding restated as a measurement: before this commit, the matcher's scope could be changed and the suite would not notice.

## Review round 2 (`7303349e`)

Six findings and a README gap. All actioned — and one of them found a contradiction between the argument above and the code implementing it.

**The scan stopped at the top level.** The trade is recall over precision, accepting a rare false pass to avoid a certain false failure. But `{"options": {"skill": "cf"}}` found nothing, so an input that nests its identifier one level down would make *every* run error while reporting `absent` — the exact failure the trade exists to avoid, inside its own implementation. The docstring was not overstating the policy; the code was under-delivering it. `_invoked_names` now walks dicts and lists to any depth, iteratively so transcript nesting cannot reach a recursion limit.

**"Inspectable" was doing work it had not earned.** Asked whether anything actually surfaces these false passes, the honest answer was no — the mitigation was "someone diffs the metadata afterwards," which is a hope, not a mitigation. A `ran` verdict resting on one of several candidate identifiers *in the matched call* is the shape a false pass takes, so it now reports itself: `metadata["skill_match_ambiguous"]` plus a stderr warning naming the other candidate. A flag, not a verdict change — it knows it could not tell which value was the name, not that the match is wrong — but a false pass is now countable by whatever consumes `skill_state`, which was the risk raised.

Four test gaps, all real:

| gap | now |
|---|---|
| the false-positive match combined with an errored `tool_result` | pinned — the loose match buys a *name*, not a verdict |
| a namespaced value in an unrelated field (`plugin:cf`), the same false positive through the separator-stripping path | pinned, and the docstring's "whole-value" framing corrected to say *after stripping* |
| the positive test never asserted an answer was delivered — the whole point of the false positive | `assert out["output"] == "the answer"` |
| the negative test never pinned `skills_invoked`, so silently dropping a candidate would pass | exact list asserted |

**README** documented the false positives that were closed and was silent on the one left open. Now carries the trade, both mitigations, the unverified-CLI caveat, and which test pins it.

**7 mutations, 7 caught.** Reverting to the top-level-only scan fails the new nested test and nothing else.

## Review round 3 (`f75c71dc`)

Four findings. Five of round 2's six were independently re-verified as resolved; the sixth was accepted as answered.

| Finding | Fix |
|---|---|
| **The ambiguity flag overclaimed.** `skill_match_ambiguous` fired whenever a matched call named a second identifier, which cannot distinguish a wrong-field match from a correct call that merely carries one. I had conceded exactly that on a thread and then shipped the assertion anyway. | Renamed to **`skill_match_other_candidates`** — a list of what was observed, not a boolean asserting a suspicion. Narrowing it is impossible by construction: it would need the key whose absence created the trade. Documented as an over-approximation; the run is still scored. |
| **The candidate list was neither deduplicated nor ordered**, and it reaches a warning a person reads. The stack pops LIFO, so a repeated value was repeated and the rest came out in an unpredictable order — two runs over one transcript could word the same finding differently. | `_invoked_names` returns `sorted(set(...))`, so traversal order becomes an implementation detail nothing depends on. Test asserts the rendered warning text, not just the list. |
| **Dropping the `isinstance(payload, dict)` guard was an undeclared boundary change** — a bare string or list input is now scanned rather than refused. | Kept, because refusing it reinstates at the outermost level the failure the depth walk removed — but now in the docstring, the README, and a parametrized test. |
| **"Any depth" was pinned only at depth one.** | Parametrized over two levels, list-of-dicts, dict-in-list-in-dict, and nested lists. |

**6 mutations, 6 caught.** The precise one for the last row: a traversal depth-limited to one level leaves `one-level` passing and fails the other four — the regression as described, which the previous single test would have missed.

## Review round 4 (`fa829c10`)

One finding: the negative tests asserted the absence of output and a detail substring, never the `skill_state` label itself — the field downstream actually reads.

Checked before fixing, and it was exploitable: mislabelling the none-named branch `"absent"` while leaving its detail text correct **passed all 52 tests**. The error string interpolates whatever state it is handed (`f"cf skill did not run ({state}): {detail}"`), so asserting the detail proves nothing about the label.

`skill_state` is now asserted on every negative case, one per branch of the ladder. **5 mutations, 5 caught** — each label swapped in turn, including the `absent` branch mutated in the opposite direction so it is pinned as `absent` rather than as "not the default".

## Scope

`tests/prompts/` is outside the traced population, so no `@cpt` obligation.

| Gate | Result |
|---|---|
| `make test` | **5,822 passed**, 4 skipped, 15 xfailed (52 in this file) |
| `cfs validate` | 0 errors |
| `spec-coverage --system studio` | 0.4608, unchanged |

## The other finding on #161, and one I found while answering it

The second finding was an architecture challenge — should the skill-run verdict live in the provider or in a promptfoo assertion? Answered on its thread rather than here, since it is a design question and non-blocking.

While answering it I found something worth a maintainer's ruling, in `promptfooconfig.yaml`:

```yaml
- type: not-icontains-any
  value:
    - "skills failed to load"
    - "cf skills failed"
    - "skill could not load"
```

Three scenarios each assert the **absence of strings the CLI does not emit** — the assertion-level twin of the `skill_load_warning` guard #161 removed from the provider, inert for the same reason. Now that the provider returns an error on the real signature before any assertion runs, these are dead weight rather than a second line of defence.

I have not touched them: deleting per-scenario assertions is a behaviour change on a shared config, and the disposition is a maintainer call — delete, or repoint at something that can actually fire. Say which and I will open it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Skill identifiers are detected within deeply nested dictionaries and lists, as well as non-dictionary inputs.
  * Additional candidate skill names are surfaced when multiple possible matches are found.
  * Candidate names are deduplicated and presented in a consistent order.
  * Genuine tool calls continue returning expected results while reporting other candidate identifiers.
  * Failed matches now clearly report a failed skill state.

* **Documentation**
  * Updated guidance covers nested input scanning, candidate reporting, warnings, and diagnostic limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->